### PR TITLE
chore(deps): apply the right labels to bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "monthly"
     labels:
       - "dependencies"
+      - "[ app ]"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -14,6 +15,9 @@ updates:
     directory: "/synthetic-datasets"
     schedule:
       interval: "monthly"
+    labels:
+      - "dependencies"
+      - "[ synthetic-datasets ]"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -22,6 +26,9 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    labels:
+      - "dependencies"
+      - "ci/cd"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
I forgot to configure the labels for `uv` and `github-actions` so dependabot generated new labels (`python:uv`). I was thinking of keeping only the `dependencies` labels, but you can also be more specific and use the existing ones.