### PR TITLE
chore(ci/cd): reduce the number of pipelines for synthetic-datasets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,15 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    # Dependabot don't support pyproject.toml updates: https://github.com/astral-sh/uv/issues/2512
+    # It only updates the uv.lock file, so we've decided to group together all bumps (except major ones).
+    groups:
+      bump-uv-lock:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/generate-synthetic-datasets.yml
+++ b/.github/workflows/generate-synthetic-datasets.yml
@@ -1,14 +1,11 @@
 name: Deploy datasets
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/generate-synthetic-datasets.yml"
   push:
     branches: ["main"]
     paths:
       - "synthetic-datasets/synthetic_datasets/**/*.py"
-      - ".github/workflows/generate-synthetic-datasets.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
- reduce the number of dependabot python bump PRs by grouping them together (except major ones)
- reduce the number of datasets deployments (removing PR deployment but adding the possibility of manual deployment)