### PR TITLE
feat: allow to run preview manually

### DIFF
--- a/.github/workflows/deploy-app-preview.yml
+++ b/.github/workflows/deploy-app-preview.yml
@@ -5,6 +5,7 @@ on:
         paths:
           - "app/**"
           - ".github/workflows/deploy-app-preview.yml"
+    workflow_dispatch:
 
 permissions:
     checks: write


### PR DESCRIPTION
External contributors' PRs cannot launch the preview because the secrets are missing. Until we have a better process, we would like to be able to launch the preview manually.