### PR TITLE
fix(): add write permission for the labels workflow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -67,7 +67,8 @@
   description: "To be discussed or developed before it's ready"
 
 - name: "hacktoberfest"
-  color: "9393e6"
+  color: "000000"
 
 - name: "preview"
   color: "171f2b"
+  description: "Deploy the app preview"

--- a/.github/workflows/deploy-labels.yml
+++ b/.github/workflows/deploy-labels.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  issues: write
 
 jobs:
   sync-labels:


### PR DESCRIPTION
Write permission on issues is required.

The workflow works: https://github.com/Gudsfile/tracksy/actions/runs/18258480196

