### PR TITLE
chore(deps): bump the npm-packages group across 1 directory with 12 updates

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -48,7 +48,7 @@
     "jsdom": "^27.2.0",
     "prettier": "^3.6.2",
     "prettier-plugin-astro": "^0.14.1",
-    "vite-plugin-static-copy": "^3.1.3",
+    "vite-plugin-static-copy": "^3.1.4",
     "vitest": "^3.2.4"
   },
   "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee"

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^0.14.1
         version: 0.14.1
       vite-plugin-static-copy:
-        specifier: ^3.1.3
-        version: 3.1.3(vite@6.4.1(@types/node@24.10.1)(jiti@1.21.7)(yaml@2.8.1))
+        specifier: ^3.1.4
+        version: 3.1.4(vite@6.4.1(@types/node@24.10.1)(jiti@1.21.7)(yaml@2.8.1))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jiti@1.21.7)(jsdom@27.2.0(postcss@8.5.6))(yaml@2.8.1)
@@ -2317,10 +2317,6 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
-  fs-extra@11.3.2:
-    resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
-    engines: {node: '>=14.14'}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2406,9 +2402,6 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-
-  graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -2812,9 +2805,6 @@ packages:
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
-
-  jsonfile@6.2.0:
-    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -3931,10 +3921,6 @@ packages:
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
-  universalify@2.0.1:
-    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
-    engines: {node: '>= 10.0.0'}
-
   unstorage@1.17.2:
     resolution: {integrity: sha512-cKEsD6iBWJgOMJ6vW1ID/SYuqNf8oN4yqRk8OYqaVQ3nnkJXOT1PSpaMh2QfzLs78UN5kSNRD2c/mgjT8tX7+w==}
     peerDependencies:
@@ -4023,8 +4009,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite-plugin-static-copy@3.1.3:
-    resolution: {integrity: sha512-U47jgyoJfrvreF87u2udU6dHIXbHhdgGZ7wSEqn6nVHKDOMdRoB2uVc6iqxbEzENN5JvX6djE5cBhQZ2MMBclA==}
+  vite-plugin-static-copy@3.1.4:
+    resolution: {integrity: sha512-iCmr4GSw4eSnaB+G8zc2f4dxSuDjbkjwpuBLLGvQYR9IW7rnDzftnUjOH5p4RYR+d4GsiBqXRvzuFhs5bnzVyw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -7003,12 +6989,6 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
-  fs-extra@11.3.2:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.0
-      universalify: 2.0.1
-
   fsevents@2.3.3:
     optional: true
 
@@ -7114,8 +7094,6 @@ snapshots:
       slash: 3.0.0
 
   gopd@1.2.0: {}
-
-  graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
 
@@ -7585,12 +7563,6 @@ snapshots:
   jsonc-parser@2.3.1: {}
 
   jsonc-parser@3.3.1: {}
-
-  jsonfile@6.2.0:
-    dependencies:
-      universalify: 2.0.1
-    optionalDependencies:
-      graceful-fs: 4.2.11
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -9084,8 +9056,6 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  universalify@2.0.1: {}
-
   unstorage@1.17.2:
     dependencies:
       anymatch: 3.1.3
@@ -9151,10 +9121,9 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-static-copy@3.1.3(vite@6.4.1(@types/node@24.10.1)(jiti@1.21.7)(yaml@2.8.1)):
+  vite-plugin-static-copy@3.1.4(vite@6.4.1(@types/node@24.10.1)(jiti@1.21.7)(yaml@2.8.1)):
     dependencies:
       chokidar: 3.6.0
-      fs-extra: 11.3.2
       p-map: 7.0.3
       picocolors: 1.1.1
       tinyglobby: 0.2.15


### PR DESCRIPTION
Bumps the npm-packages group with 12 updates in the /app directory:

| Package | From | To |
| --- | --- | --- |
| [@astrojs/check](https://github.com/withastro/language-tools/tree/HEAD/packages/astro-check) | `0.9.4` | `0.9.5` |
| [@astrojs/react](https://github.com/withastro/astro/tree/HEAD/packages/integrations/react) | `4.4.0` | `4.4.2` |
| [react](https://github.com/facebook/react/tree/HEAD/packages/react) | `19.1.1` | `19.2.0` |
| [@types/react](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/react) | `19.1.16` | `19.2.4` |
| [react-dom](https://github.com/facebook/react/tree/HEAD/packages/react-dom) | `19.1.1` | `19.2.0` |
| [@types/react-dom](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/react-dom) | `19.1.9` | `19.2.3` |
| [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin) | `8.45.0` | `8.46.4` |
| [@typescript-eslint/parser](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/parser) | `8.45.0` | `8.46.4` |
| [eslint](https://github.com/eslint/eslint) | `9.36.0` | `9.39.1` |
| [eslint-plugin-astro](https://github.com/ota-meshi/eslint-plugin-astro) | `1.3.1` | `1.5.0` |
| [jsdom](https://github.com/jsdom/jsdom) | `27.0.0` | `27.2.0` |
| [vite-plugin-static-copy](https://github.com/sapphi-red/vite-plugin-static-copy) | `3.1.3` | `3.1.4` |


Updates `@astrojs/check` from 0.9.4 to 0.9.5
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/withastro/language-tools/blob/main/packages/astro-check/CHANGELOG.md"><code>@​astrojs/check</code>'s changelog</a>.</em></p>
<blockquote>
<h2>0.9.5</h2>
<h3>Patch Changes</h3>
<ul>
<li>d415d4e: When no errors or warnings are detected, display &quot;0 errors&quot; or &quot;0 warnings&quot; in a dimmed color on the console instead of red or yellow.</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/withastro/language-tools/commits/HEAD/packages/astro-check">compare view</a></li>
</ul>
</details>
<details>
<summary>Maintainer changes</summary>
<p>This version was pushed to npm by <a href="https://www.npmjs.com/~matthewp">matthewp</a>, a new releaser for <code>@​astrojs/check</code> since your current version.</p>
</details>
<br />

Updates `@astrojs/react` from 4.4.0 to 4.4.2
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/withastro/astro/releases"><code>@​astrojs/react</code>'s releases</a>.</em></p>
<blockquote>
<h2><code>@​astrojs/react</code><a href="https://github.com/4"><code>@​4</code></a>.4.2</h2>
<h3>Patch Changes</h3>
<ul>
<li>
<p><a href="https://redirect.github.com/withastro/astro/pull/14715">#14715</a> <a href="https://github.com/withastro/astro/commit/3d55c5d0fb520d470b33d391e5b68861f5b51271"><code>3d55c5d</code></a> Thanks <a href="https://github.com/ascorbic"><code>@​ascorbic</code></a>! - Adds support for client hydration in <code>getContainerRenderer()</code></p>
<p>The <code>getContainerRenderer()</code> function is exported by Astro framework integrations to simplify the process of rendering framework components when using the experimental Container API inside a Vite or Vitest environment. This update adds the client hydration entrypoint to the returned object, enabling client-side interactivity for components rendered using this function. Previously this required users to manually call <code>container.addClientRenderer()</code> with the appropriate client renderer entrypoint.</p>
<p>See <a href="https://github.com/withastro/astro/blob/main/examples/container-with-vitest/test/ReactWrapper.test.ts">the <code>container-with-vitest</code> demo</a> for a usage example, and <a href="https://docs.astro.build/en/reference/container-reference/#renderers-option">the Container API documentation</a> for more information on using framework components with the experimental Container API.</p>
</li>
</ul>
<h2><code>@​astrojs/react</code><a href="https://github.com/4"><code>@​4</code></a>.4.1</h2>
<h3>Patch Changes</h3>
<ul>
<li><a href="https://redirect.github.com/withastro/astro/pull/14621">#14621</a> <a href="https://github.com/withastro/astro/commit/e3175d9ccbf070150ab2229b2564ca0b12a86c30"><code>e3175d9</code></a> Thanks <a href="https://github.com/GameRoMan"><code>@​GameRoMan</code></a>! - Updates <code>vite</code> version to fix CVE</li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/withastro/astro/blob/main/packages/integrations/react/CHANGELOG.md"><code>@​astrojs/react</code>'s changelog</a>.</em></p>
<blockquote>
<h2>4.4.2</h2>
<h3>Patch Changes</h3>
<ul>
<li>
<p><a href="https://redirect.github.com/withastro/astro/pull/14715">#14715</a> <a href="https://github.com/withastro/astro/commit/3d55c5d0fb520d470b33d391e5b68861f5b51271"><code>3d55c5d</code></a> Thanks <a href="https://github.com/ascorbic"><code>@​ascorbic</code></a>! - Adds support for client hydration in <code>getContainerRenderer()</code></p>
<p>The <code>getContainerRenderer()</code> function is exported by Astro framework integrations to simplify the process of rendering framework components when using the experimental Container API inside a Vite or Vitest environment. This update adds the client hydration entrypoint to the returned object, enabling client-side interactivity for components rendered using this function. Previously this required users to manually call <code>container.addClientRenderer()</code> with the appropriate client renderer entrypoint.</p>
<p>See <a href="https://github.com/withastro/astro/blob/main/examples/container-with-vitest/test/ReactWrapper.test.ts">the <code>container-with-vitest</code> demo</a> for a usage example, and <a href="https://docs.astro.build/en/reference/container-reference/#renderers-option">the Container API documentation</a> for more information on using framework components with the experimental Container API.</p>
</li>
</ul>
<h2>4.4.1</h2>
<h3>Patch Changes</h3>
<ul>
<li><a href="https://redirect.github.com/withastro/astro/pull/14621">#14621</a> <a href="https://github.com/withastro/astro/commit/e3175d9ccbf070150ab2229b2564ca0b12a86c30"><code>e3175d9</code></a> Thanks <a href="https://github.com/GameRoMan"><code>@​GameRoMan</code></a>! - Updates <code>vite</code> version to fix CVE</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/withastro/astro/commit/7a5f28006e9b1f6ad77c7884991ba551ca9ff35b"><code>7a5f280</code></a> [ci] release (<a href="https://github.com/withastro/astro/tree/HEAD/packages/integrations/react/issues/14702">#14702</a>)</li>
<li><a href="https://github.com/withastro/astro/commit/3d55c5d0fb520d470b33d391e5b68861f5b51271"><code>3d55c5d</code></a> feat: return <code>clientEntrypoint</code> from <code>getContainerRenderer</code> (<a href="https://github.com/withastro/astro/tree/HEAD/packages/integrations/react/issues/14715">#14715</a>)</li>
<li><a href="https://github.com/withastro/astro/commit/eb8aa77013ec40af667d280678fc479adcf23444"><code>eb8aa77</code></a> [ci] release (<a href="https://github.com/withastro/astro/tree/HEAD/packages/integrations/react/issues/14630">#14630</a>)</li>
<li><a href="https://github.com/withastro/astro/commit/e3175d9ccbf070150ab2229b2564ca0b12a86c30"><code>e3175d9</code></a> Update vite (<a href="https://github.com/withastro/astro/tree/HEAD/packages/integrations/react/issues/14621">#14621</a>)</li>
<li>See full diff in <a href="https://github.com/withastro/astro/commits/@astrojs/react@4.4.2/packages/integrations/react">compare view</a></li>
</ul>
</details>
<details>
<summary>Maintainer changes</summary>
<p>This version was pushed to npm by [GitHub Actions](<a href="https://www.npmjs.com/~GitHub">https://www.npmjs.com/~GitHub</a> Actions), a new releaser for <code>@​astrojs/react</code> since your current version.</p>
</details>
<br />

Updates `react` from 19.1.1 to 19.2.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/facebook/react/releases">react's releases</a>.</em></p>
<blockquote>
<h2>19.2.0 (Oct 1, 2025)</h2>
<p>Below is a list of all new features, APIs, and bug fixes.</p>
<p>Read the <a href="https://react.dev/blog/2025/10/01/react-19-2">React 19.2 release post</a> for more information.</p>
<h2>New React Features</h2>
<ul>
<li><a href="https://react.dev/reference/react/Activity"><code>&lt;Activity&gt;</code></a>: A new API to hide and restore the UI and internal state of its children.</li>
<li><a href="https://react.dev/reference/react/useEffectEvent"><code>useEffectEvent</code></a> is a React Hook that lets you extract non-reactive logic into an <a href="https://react.dev/learn/separating-events-from-effects#declaring-an-effect-event">Effect Event</a>.</li>
<li><a href="https://react.dev/reference/react/cacheSignal"><code>cacheSignal</code></a> (for RSCs) lets your know when the <code>cache()</code> lifetime is over.</li>
<li><a href="https://react.dev/reference/developer-tooling/react-performance-tracks">React Performance tracks</a> appear on the Performance panel’s timeline in your browser developer tools</li>
</ul>
<h2>New React DOM Features</h2>
<ul>
<li>Added resume APIs for partial pre-rendering with Web Streams:
<ul>
<li><a href="https://react.dev/reference/react-dom/server/resume"><code>resume</code></a>: to resume a prerender to a stream.</li>
<li><a href="https://react.dev/reference/react-dom/static/resumeAndPrerender"><code>resumeAndPrerender</code></a>: to resume a prerender to HTML.</li>
</ul>
</li>
<li>Added resume APIs for partial pre-rendering with Node Streams:
<ul>
<li><a href="https://react.dev/reference/react-dom/server/resumeToPipeableStream"><code>resumeToPipeableStream</code></a>: to resume a prerender to a stream.</li>
<li><a href="https://react.dev/reference/react-dom/static/resumeAndPrerenderToNodeStream"><code>resumeAndPrerenderToNodeStream</code></a>: to resume a prerender to HTML.</li>
</ul>
</li>
<li>Updated <a href="https://react.dev/reference/react-dom/static/prerender"><code>prerender</code></a> APIs to return a <code>postponed</code> state that can be passed to the <code>resume</code> APIs.</li>
</ul>
<h2>Notable changes</h2>
<ul>
<li>React DOM now batches suspense boundary reveals, matching the behavior of client side rendering. This change is especially noticeable when animating the reveal of Suspense boundaries e.g. with the upcoming <code>&lt;ViewTransition&gt;</code> Component. React will batch as much reveals as possible before the first paint while trying to hit popular first-contentful paint metrics.</li>
<li>Add Node Web Streams (<code>prerender</code>, <code>renderToReadableStream</code>) to server-side-rendering APIs for Node.js</li>
<li>Use underscore instead of <code>:</code> IDs generated by useId</li>
</ul>
<h2>All Changes</h2>
<h3>React</h3>
<ul>
<li><code>&lt;Activity /&gt;</code> was developed over many years, starting before <code>ClassComponent.setState</code> (<a href="https://github.com/acdlite"><code>@​acdlite</code></a> <a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> and many others)</li>
<li>Stringify context as &quot;SomeContext&quot; instead of &quot;SomeContext.Provider&quot; (<a href="https://github.com/kassens"><code>@​kassens</code></a> <a href="https://redirect.github.com/facebook/react/pull/33507">#33507</a>)</li>
<li>Include stack of cause of React instrumentation errors with <code>%o</code> placeholder (<a href="https://github.com/eps1lon"><code>@​eps1lon</code></a> <a href="https://redirect.github.com/facebook/react/pull/34198">#34198</a>)</li>
<li>Fix infinite <code>useDeferredValue</code> loop in popstate event (<a href="https://github.com/acdlite"><code>@​acdlite</code></a> <a href="https://redirect.github.com/facebook/react/pull/32821">#32821</a>)</li>
<li>Fix a bug when an initial value was passed to <code>useDeferredValue</code> (<a href="https://github.com/acdlite"><code>@​acdlite</code></a> <a href="https://redirect.github.com/facebook/react/pull/34376">#34376</a>)</li>
<li>Fix a crash when submitting forms with Client Actions (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/33055">#33055</a>)</li>
<li>Hide/unhide the content of dehydrated suspense boundaries if they resuspend (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/32900">#32900</a>)</li>
<li>Avoid stack overflow on wide trees during Hot Reload (<a href="https://github.com/sophiebits"><code>@​sophiebits</code></a> <a href="https://redirect.github.com/facebook/react/pull/34145">#34145</a>)</li>
<li>Improve Owner and Component stacks in various places (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a>, <a href="https://github.com/eps1lon"><code>@​eps1lon</code></a>: <a href="https://redirect.github.com/facebook/react/pull/33629">#33629</a>, <a href="https://redirect.github.com/facebook/react/pull/33724">#33724</a>, <a href="https://redirect.github.com/facebook/react/pull/32735">#32735</a>, <a href="https://redirect.github.com/facebook/react/pull/33723">#33723</a>)</li>
<li>Add <code>cacheSignal</code> (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/33557">#33557</a>)</li>
</ul>
<h3>React DOM</h3>
<ul>
<li>Block on Suspensey Fonts during reveal of server-side-rendered content (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/33342">#33342</a>)</li>
<li>Use underscore instead of <code>:</code> for IDs generated by <code>useId</code> (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a>, <a href="https://github.com/eps1lon"><code>@​eps1lon</code></a>: <a href="https://redirect.github.com/facebook/react/pull/32001">#32001</a>, <a href="https://redirect.github.com/facebook/react/pull/33342">facebook/react#33342</a><a href="https://redirect.github.com/facebook/react/pull/33099">#33099</a>, <a href="https://redirect.github.com/facebook/react/pull/33422">#33422</a>)</li>
<li>Stop warning when ARIA 1.3 attributes are used (<a href="https://github.com/Abdul-Omira"><code>@​Abdul-Omira</code></a> <a href="https://redirect.github.com/facebook/react/pull/34264">#34264</a>)</li>
<li>Allow <code>nonce</code> to be used on hoistable styles (<a href="https://github.com/Andarist"><code>@​Andarist</code></a> <a href="https://redirect.github.com/facebook/react/pull/32461">#32461</a>)</li>
<li>Warn for using a React owned node as a Container if it also has text content (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/32774">#32774</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/facebook/react/blob/main/CHANGELOG.md">react's changelog</a>.</em></p>
<blockquote>
<h2>19.2.0 (October 1st, 2025)</h2>
<p>Below is a list of all new features, APIs, and bug fixes.</p>
<p>Read the <a href="https://react.dev/blog/2025/10/01/react-19-2">React 19.2 release post</a> for more information.</p>
<h3>New React Features</h3>
<ul>
<li><a href="https://react.dev/reference/react/Activity"><code>&lt;Activity&gt;</code></a>: A new API to hide and restore the UI and internal state of its children.</li>
<li><a href="https://react.dev/reference/react/useEffectEvent"><code>useEffectEvent</code></a> is a React Hook that lets you extract non-reactive logic into an <a href="https://react.dev/learn/separating-events-from-effects#declaring-an-effect-event">Effect Event</a>.</li>
<li><a href="https://react.dev/reference/react/cacheSignal"><code>cacheSignal</code></a> (for RSCs) lets your know when the <code>cache()</code> lifetime is over.</li>
<li><a href="https://react.dev/reference/dev-tools/react-performance-tracks">React Performance tracks</a> appear on the Performance panel’s timeline in your browser developer tools</li>
</ul>
<h3>New React DOM Features</h3>
<ul>
<li>Added resume APIs for partial pre-rendering with Web Streams:
<ul>
<li><a href="https://react.dev/reference/react-dom/server/resume"><code>resume</code></a>: to resume a prerender to a stream.</li>
<li><a href="https://react.dev/reference/react-dom/static/resumeAndPrerender"><code>resumeAndPrerender</code></a>: to resume a prerender to HTML.</li>
</ul>
</li>
<li>Added resume APIs for partial pre-rendering with Node Streams:
<ul>
<li><a href="https://react.dev/reference/react-dom/server/resumeToPipeableStream"><code>resumeToPipeableStream</code></a>: to resume a prerender to a stream.</li>
<li><a href="https://react.dev/reference/react-dom/static/resumeAndPrerenderToNodeStream"><code>resumeAndPrerenderToNodeStream</code></a>: to resume a prerender to HTML.</li>
</ul>
</li>
<li>Updated <a href="https://react.dev/reference/react-dom/static/prerender"><code>prerender</code></a> APIs to return a <code>postponed</code> state that can be passed to the <code>resume</code> APIs.</li>
</ul>
<h3>Notable changes</h3>
<ul>
<li>React DOM now batches suspense boundary reveals, matching the behavior of client side rendering. This change is especially noticeable when animating the reveal of Suspense boundaries e.g. with the upcoming <code>&lt;ViewTransition&gt;</code> Component. React will batch as much reveals as possible before the first paint while trying to hit popular first-contentful paint metrics.</li>
<li>Add Node Web Streams (<code>prerender</code>, <code>renderToReadableStream</code>) to server-side-rendering APIs for Node.js</li>
<li>Use underscore instead of <code>:</code> IDs generated by useId</li>
</ul>
<h3>All Changes</h3>
<h4>React</h4>
<ul>
<li><code>&lt;Activity /&gt;</code> was developed over many years, starting before <code>ClassComponent.setState</code> (<a href="https://github.com/acdlite"><code>@​acdlite</code></a> <a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> and many others)</li>
<li>Stringify context as &quot;SomeContext&quot; instead of &quot;SomeContext.Provider&quot; (<a href="https://github.com/kassens"><code>@​kassens</code></a> <a href="https://redirect.github.com/facebook/react/pull/33507">#33507</a>)</li>
<li>Include stack of cause of React instrumentation errors with <code>%o</code> placeholder (<a href="https://github.com/eps1lon"><code>@​eps1lon</code></a> <a href="https://redirect.github.com/facebook/react/pull/34198">#34198</a>)</li>
<li>Fix infinite <code>useDeferredValue</code> loop in popstate event (<a href="https://github.com/acdlite"><code>@​acdlite</code></a> <a href="https://redirect.github.com/facebook/react/pull/32821">#32821</a>)</li>
<li>Fix a bug when an initial value was passed to <code>useDeferredValue</code> (<a href="https://github.com/acdlite"><code>@​acdlite</code></a> <a href="https://redirect.github.com/facebook/react/pull/34376">#34376</a>)</li>
<li>Fix a crash when submitting forms with Client Actions (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/33055">#33055</a>)</li>
<li>Hide/unhide the content of dehydrated suspense boundaries if they resuspend (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/32900">#32900</a>)</li>
<li>Avoid stack overflow on wide trees during Hot Reload (<a href="https://github.com/sophiebits"><code>@​sophiebits</code></a> <a href="https://redirect.github.com/facebook/react/pull/34145">#34145</a>)</li>
<li>Improve Owner and Component stacks in various places (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a>, <a href="https://github.com/eps1lon"><code>@​eps1lon</code></a>: <a href="https://redirect.github.com/facebook/react/pull/33629">#33629</a>, <a href="https://redirect.github.com/facebook/react/pull/33724">#33724</a>, <a href="https://redirect.github.com/facebook/react/pull/32735">#32735</a>, <a href="https://redirect.github.com/facebook/react/pull/33723">#33723</a>)</li>
<li>Add <code>cacheSignal</code> (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/33557">#33557</a>)</li>
</ul>
<h4>React DOM</h4>
<ul>
<li>Block on Suspensey Fonts during reveal of server-side-rendered content (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/33342">#33342</a>)</li>
<li>Use underscore instead of <code>:</code> for IDs generated by <code>useId</code> (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a>, <a href="https://github.com/eps1lon"><code>@​eps1lon</code></a>: <a href="https://redirect.github.com/facebook/react/pull/32001">#32001</a>, <a href="https://redirect.github.com/facebook/react/pull/33342">facebook/react#33342</a><a href="https://redirect.github.com/facebook/react/pull/33099">#33099</a>, <a href="https://redirect.github.com/facebook/react/pull/33422">#33422</a>)</li>
<li>Stop warning when ARIA 1.3 attributes are used (<a href="https://github.com/Abdul-Omira"><code>@​Abdul-Omira</code></a> <a href="https://redirect.github.com/facebook/react/pull/34264">#34264</a>)</li>
<li>Allow <code>nonce</code> to be used on hoistable styles (<a href="https://github.com/Andarist"><code>@​Andarist</code></a> <a href="https://redirect.github.com/facebook/react/pull/32461">#32461</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/facebook/react/commit/5667a41fe4d81aa806f6c1e8814b17975e33b317"><code>5667a41</code></a> Bump next prerelease version numbers (<a href="https://github.com/facebook/react/tree/HEAD/packages/react/issues/34639">#34639</a>)</li>
<li><a href="https://github.com/facebook/react/commit/8bb7241f4c773376893701bfe8b8ff03687342a0"><code>8bb7241</code></a> Bump useEffectEvent to Canary (<a href="https://github.com/facebook/react/tree/HEAD/packages/react/issues/34610">#34610</a>)</li>
<li><a href="https://github.com/facebook/react/commit/e3c9656d20618ed321aea85cb3d844cbd1dce078"><code>e3c9656</code></a> Ensure Performance Track are Clamped and Don't overlap (<a href="https://github.com/facebook/react/tree/HEAD/packages/react/issues/34509">#34509</a>)</li>
<li><a href="https://github.com/facebook/react/commit/68f00c901c05e3a91f6cc77b660bc2334700f163"><code>68f00c9</code></a> Release Activity in Canary (<a href="https://github.com/facebook/react/tree/HEAD/packages/react/issues/34374">#34374</a>)</li>
<li><a href="https://github.com/facebook/react/commit/0e10ee906e3ea55e4d717d4db498e1159235b06b"><code>0e10ee9</code></a> [Reconciler] Set ProfileMode for Host Root Fiber by default in dev (<a href="https://github.com/facebook/react/tree/HEAD/packages/react/issues/34432">#34432</a>)</li>
<li><a href="https://github.com/facebook/react/commit/3bf8ab430eb2182e787e0f1c74c0d9ccab89e4ac"><code>3bf8ab4</code></a> Add missing Activity export to development mode (<a href="https://github.com/facebook/react/tree/HEAD/packages/react/issues/34439">#34439</a>)</li>
<li><a href="https://github.com/facebook/react/commit/1549bda33f0df963ae27a590b7191f3de99dad31"><code>1549bda</code></a> [Flight] Only assign <code>_store</code> in dev mode when creating lazy types (<a href="https://github.com/facebook/react/tree/HEAD/packages/react/issues/34354">#34354</a>)</li>
<li><a href="https://github.com/facebook/react/commit/bb6f0c8d2f29754347db0ff28186dc89c128b6ca"><code>bb6f0c8</code></a> [Flight] Fix wrong missing key warning when static child is blocked (<a href="https://github.com/facebook/react/tree/HEAD/packages/react/issues/34350">#34350</a>)</li>
<li><a href="https://github.com/facebook/react/commit/05addfc6631ca72099631476b0a1592753858d30"><code>05addfc</code></a> Update Flow to 0.266 (<a href="https://github.com/facebook/react/tree/HEAD/packages/react/issues/34271">#34271</a>)</li>
<li><a href="https://github.com/facebook/react/commit/ec5dd0ab3acb206dd4aa46c6d5573c235c8eae98"><code>ec5dd0a</code></a> Update Flow to 0.257 (<a href="https://github.com/facebook/react/tree/HEAD/packages/react/issues/34253">#34253</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/facebook/react/commits/v19.2.0/packages/react">compare view</a></li>
</ul>
</details>
<br />

Updates `@types/react` from 19.1.16 to 19.2.4
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/react">compare view</a></li>
</ul>
</details>
<br />

Updates `react-dom` from 19.1.1 to 19.2.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/facebook/react/releases">react-dom's releases</a>.</em></p>
<blockquote>
<h2>19.2.0 (Oct 1, 2025)</h2>
<p>Below is a list of all new features, APIs, and bug fixes.</p>
<p>Read the <a href="https://react.dev/blog/2025/10/01/react-19-2">React 19.2 release post</a> for more information.</p>
<h2>New React Features</h2>
<ul>
<li><a href="https://react.dev/reference/react/Activity"><code>&lt;Activity&gt;</code></a>: A new API to hide and restore the UI and internal state of its children.</li>
<li><a href="https://react.dev/reference/react/useEffectEvent"><code>useEffectEvent</code></a> is a React Hook that lets you extract non-reactive logic into an <a href="https://react.dev/learn/separating-events-from-effects#declaring-an-effect-event">Effect Event</a>.</li>
<li><a href="https://react.dev/reference/react/cacheSignal"><code>cacheSignal</code></a> (for RSCs) lets your know when the <code>cache()</code> lifetime is over.</li>
<li><a href="https://react.dev/reference/developer-tooling/react-performance-tracks">React Performance tracks</a> appear on the Performance panel’s timeline in your browser developer tools</li>
</ul>
<h2>New React DOM Features</h2>
<ul>
<li>Added resume APIs for partial pre-rendering with Web Streams:
<ul>
<li><a href="https://react.dev/reference/react-dom/server/resume"><code>resume</code></a>: to resume a prerender to a stream.</li>
<li><a href="https://react.dev/reference/react-dom/static/resumeAndPrerender"><code>resumeAndPrerender</code></a>: to resume a prerender to HTML.</li>
</ul>
</li>
<li>Added resume APIs for partial pre-rendering with Node Streams:
<ul>
<li><a href="https://react.dev/reference/react-dom/server/resumeToPipeableStream"><code>resumeToPipeableStream</code></a>: to resume a prerender to a stream.</li>
<li><a href="https://react.dev/reference/react-dom/static/resumeAndPrerenderToNodeStream"><code>resumeAndPrerenderToNodeStream</code></a>: to resume a prerender to HTML.</li>
</ul>
</li>
<li>Updated <a href="https://react.dev/reference/react-dom/static/prerender"><code>prerender</code></a> APIs to return a <code>postponed</code> state that can be passed to the <code>resume</code> APIs.</li>
</ul>
<h2>Notable changes</h2>
<ul>
<li>React DOM now batches suspense boundary reveals, matching the behavior of client side rendering. This change is especially noticeable when animating the reveal of Suspense boundaries e.g. with the upcoming <code>&lt;ViewTransition&gt;</code> Component. React will batch as much reveals as possible before the first paint while trying to hit popular first-contentful paint metrics.</li>
<li>Add Node Web Streams (<code>prerender</code>, <code>renderToReadableStream</code>) to server-side-rendering APIs for Node.js</li>
<li>Use underscore instead of <code>:</code> IDs generated by useId</li>
</ul>
<h2>All Changes</h2>
<h3>React</h3>
<ul>
<li><code>&lt;Activity /&gt;</code> was developed over many years, starting before <code>ClassComponent.setState</code> (<a href="https://github.com/acdlite"><code>@​acdlite</code></a> <a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> and many others)</li>
<li>Stringify context as &quot;SomeContext&quot; instead of &quot;SomeContext.Provider&quot; (<a href="https://github.com/kassens"><code>@​kassens</code></a> <a href="https://redirect.github.com/facebook/react/pull/33507">#33507</a>)</li>
<li>Include stack of cause of React instrumentation errors with <code>%o</code> placeholder (<a href="https://github.com/eps1lon"><code>@​eps1lon</code></a> <a href="https://redirect.github.com/facebook/react/pull/34198">#34198</a>)</li>
<li>Fix infinite <code>useDeferredValue</code> loop in popstate event (<a href="https://github.com/acdlite"><code>@​acdlite</code></a> <a href="https://redirect.github.com/facebook/react/pull/32821">#32821</a>)</li>
<li>Fix a bug when an initial value was passed to <code>useDeferredValue</code> (<a href="https://github.com/acdlite"><code>@​acdlite</code></a> <a href="https://redirect.github.com/facebook/react/pull/34376">#34376</a>)</li>
<li>Fix a crash when submitting forms with Client Actions (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/33055">#33055</a>)</li>
<li>Hide/unhide the content of dehydrated suspense boundaries if they resuspend (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/32900">#32900</a>)</li>
<li>Avoid stack overflow on wide trees during Hot Reload (<a href="https://github.com/sophiebits"><code>@​sophiebits</code></a> <a href="https://redirect.github.com/facebook/react/pull/34145">#34145</a>)</li>
<li>Improve Owner and Component stacks in various places (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a>, <a href="https://github.com/eps1lon"><code>@​eps1lon</code></a>: <a href="https://redirect.github.com/facebook/react/pull/33629">#33629</a>, <a href="https://redirect.github.com/facebook/react/pull/33724">#33724</a>, <a href="https://redirect.github.com/facebook/react/pull/32735">#32735</a>, <a href="https://redirect.github.com/facebook/react/pull/33723">#33723</a>)</li>
<li>Add <code>cacheSignal</code> (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/33557">#33557</a>)</li>
</ul>
<h3>React DOM</h3>
<ul>
<li>Block on Suspensey Fonts during reveal of server-side-rendered content (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/33342">#33342</a>)</li>
<li>Use underscore instead of <code>:</code> for IDs generated by <code>useId</code> (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a>, <a href="https://github.com/eps1lon"><code>@​eps1lon</code></a>: <a href="https://redirect.github.com/facebook/react/pull/32001">#32001</a>, <a href="https://redirect.github.com/facebook/react/pull/33342">facebook/react#33342</a><a href="https://redirect.github.com/facebook/react/pull/33099">#33099</a>, <a href="https://redirect.github.com/facebook/react/pull/33422">#33422</a>)</li>
<li>Stop warning when ARIA 1.3 attributes are used (<a href="https://github.com/Abdul-Omira"><code>@​Abdul-Omira</code></a> <a href="https://redirect.github.com/facebook/react/pull/34264">#34264</a>)</li>
<li>Allow <code>nonce</code> to be used on hoistable styles (<a href="https://github.com/Andarist"><code>@​Andarist</code></a> <a href="https://redirect.github.com/facebook/react/pull/32461">#32461</a>)</li>
<li>Warn for using a React owned node as a Container if it also has text content (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/32774">#32774</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/facebook/react/blob/main/CHANGELOG.md">react-dom's changelog</a>.</em></p>
<blockquote>
<h2>19.2.0 (October 1st, 2025)</h2>
<p>Below is a list of all new features, APIs, and bug fixes.</p>
<p>Read the <a href="https://react.dev/blog/2025/10/01/react-19-2">React 19.2 release post</a> for more information.</p>
<h3>New React Features</h3>
<ul>
<li><a href="https://react.dev/reference/react/Activity"><code>&lt;Activity&gt;</code></a>: A new API to hide and restore the UI and internal state of its children.</li>
<li><a href="https://react.dev/reference/react/useEffectEvent"><code>useEffectEvent</code></a> is a React Hook that lets you extract non-reactive logic into an <a href="https://react.dev/learn/separating-events-from-effects#declaring-an-effect-event">Effect Event</a>.</li>
<li><a href="https://react.dev/reference/react/cacheSignal"><code>cacheSignal</code></a> (for RSCs) lets your know when the <code>cache()</code> lifetime is over.</li>
<li><a href="https://react.dev/reference/dev-tools/react-performance-tracks">React Performance tracks</a> appear on the Performance panel’s timeline in your browser developer tools</li>
</ul>
<h3>New React DOM Features</h3>
<ul>
<li>Added resume APIs for partial pre-rendering with Web Streams:
<ul>
<li><a href="https://react.dev/reference/react-dom/server/resume"><code>resume</code></a>: to resume a prerender to a stream.</li>
<li><a href="https://react.dev/reference/react-dom/static/resumeAndPrerender"><code>resumeAndPrerender</code></a>: to resume a prerender to HTML.</li>
</ul>
</li>
<li>Added resume APIs for partial pre-rendering with Node Streams:
<ul>
<li><a href="https://react.dev/reference/react-dom/server/resumeToPipeableStream"><code>resumeToPipeableStream</code></a>: to resume a prerender to a stream.</li>
<li><a href="https://react.dev/reference/react-dom/static/resumeAndPrerenderToNodeStream"><code>resumeAndPrerenderToNodeStream</code></a>: to resume a prerender to HTML.</li>
</ul>
</li>
<li>Updated <a href="https://react.dev/reference/react-dom/static/prerender"><code>prerender</code></a> APIs to return a <code>postponed</code> state that can be passed to the <code>resume</code> APIs.</li>
</ul>
<h3>Notable changes</h3>
<ul>
<li>React DOM now batches suspense boundary reveals, matching the behavior of client side rendering. This change is especially noticeable when animating the reveal of Suspense boundaries e.g. with the upcoming <code>&lt;ViewTransition&gt;</code> Component. React will batch as much reveals as possible before the first paint while trying to hit popular first-contentful paint metrics.</li>
<li>Add Node Web Streams (<code>prerender</code>, <code>renderToReadableStream</code>) to server-side-rendering APIs for Node.js</li>
<li>Use underscore instead of <code>:</code> IDs generated by useId</li>
</ul>
<h3>All Changes</h3>
<h4>React</h4>
<ul>
<li><code>&lt;Activity /&gt;</code> was developed over many years, starting before <code>ClassComponent.setState</code> (<a href="https://github.com/acdlite"><code>@​acdlite</code></a> <a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> and many others)</li>
<li>Stringify context as &quot;SomeContext&quot; instead of &quot;SomeContext.Provider&quot; (<a href="https://github.com/kassens"><code>@​kassens</code></a> <a href="https://redirect.github.com/facebook/react/pull/33507">#33507</a>)</li>
<li>Include stack of cause of React instrumentation errors with <code>%o</code> placeholder (<a href="https://github.com/eps1lon"><code>@​eps1lon</code></a> <a href="https://redirect.github.com/facebook/react/pull/34198">#34198</a>)</li>
<li>Fix infinite <code>useDeferredValue</code> loop in popstate event (<a href="https://github.com/acdlite"><code>@​acdlite</code></a> <a href="https://redirect.github.com/facebook/react/pull/32821">#32821</a>)</li>
<li>Fix a bug when an initial value was passed to <code>useDeferredValue</code> (<a href="https://github.com/acdlite"><code>@​acdlite</code></a> <a href="https://redirect.github.com/facebook/react/pull/34376">#34376</a>)</li>
<li>Fix a crash when submitting forms with Client Actions (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/33055">#33055</a>)</li>
<li>Hide/unhide the content of dehydrated suspense boundaries if they resuspend (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/32900">#32900</a>)</li>
<li>Avoid stack overflow on wide trees during Hot Reload (<a href="https://github.com/sophiebits"><code>@​sophiebits</code></a> <a href="https://redirect.github.com/facebook/react/pull/34145">#34145</a>)</li>
<li>Improve Owner and Component stacks in various places (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a>, <a href="https://github.com/eps1lon"><code>@​eps1lon</code></a>: <a href="https://redirect.github.com/facebook/react/pull/33629">#33629</a>, <a href="https://redirect.github.com/facebook/react/pull/33724">#33724</a>, <a href="https://redirect.github.com/facebook/react/pull/32735">#32735</a>, <a href="https://redirect.github.com/facebook/react/pull/33723">#33723</a>)</li>
<li>Add <code>cacheSignal</code> (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/33557">#33557</a>)</li>
</ul>
<h4>React DOM</h4>
<ul>
<li>Block on Suspensey Fonts during reveal of server-side-rendered content (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a> <a href="https://redirect.github.com/facebook/react/pull/33342">#33342</a>)</li>
<li>Use underscore instead of <code>:</code> for IDs generated by <code>useId</code> (<a href="https://github.com/sebmarkbage"><code>@​sebmarkbage</code></a>, <a href="https://github.com/eps1lon"><code>@​eps1lon</code></a>: <a href="https://redirect.github.com/facebook/react/pull/32001">#32001</a>, <a href="https://redirect.github.com/facebook/react/pull/33342">facebook/react#33342</a><a href="https://redirect.github.com/facebook/react/pull/33099">#33099</a>, <a href="https://redirect.github.com/facebook/react/pull/33422">#33422</a>)</li>
<li>Stop warning when ARIA 1.3 attributes are used (<a href="https://github.com/Abdul-Omira"><code>@​Abdul-Omira</code></a> <a href="https://redirect.github.com/facebook/react/pull/34264">#34264</a>)</li>
<li>Allow <code>nonce</code> to be used on hoistable styles (<a href="https://github.com/Andarist"><code>@​Andarist</code></a> <a href="https://redirect.github.com/facebook/react/pull/32461">#32461</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/facebook/react/commit/861811347b8fa936b4a114fc022db9b8253b3d86"><code>8618113</code></a> Bump scheduler version (<a href="https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/34671">#34671</a>)</li>
<li><a href="https://github.com/facebook/react/commit/1bd1f01f2a46fa453de5099280b54385ca7773b1"><code>1bd1f01</code></a> Ship partial-prerendering APIs to Canary (<a href="https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/34633">#34633</a>)</li>
<li><a href="https://github.com/facebook/react/commit/2f0649a0b27516eaab549b18af15eed0420e3446"><code>2f0649a</code></a> [Fizz] Remove <code>nonce</code> option from resume-and-prerender APIs (<a href="https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/34664">#34664</a>)</li>
<li><a href="https://github.com/facebook/react/commit/5667a41fe4d81aa806f6c1e8814b17975e33b317"><code>5667a41</code></a> Bump next prerelease version numbers (<a href="https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/34639">#34639</a>)</li>
<li><a href="https://github.com/facebook/react/commit/e08f53b182fa63df6ec5938fec44d096343806d3"><code>e08f53b</code></a> Match <code>react-dom/static</code> test entrypoints and published entrypoints (<a href="https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/34599">#34599</a>)</li>
<li><a href="https://github.com/facebook/react/commit/8bb7241f4c773376893701bfe8b8ff03687342a0"><code>8bb7241</code></a> Bump useEffectEvent to Canary (<a href="https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/34610">#34610</a>)</li>
<li><a href="https://github.com/facebook/react/commit/83c88ad470d680060f807ef81ed4c14b3b71fd3b"><code>83c88ad</code></a> Handle fabric root level fragment with compareDocumentPosition (<a href="https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/34533">#34533</a>)</li>
<li><a href="https://github.com/facebook/react/commit/68f00c901c05e3a91f6cc77b660bc2334700f163"><code>68f00c9</code></a> Release Activity in Canary (<a href="https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/34374">#34374</a>)</li>
<li><a href="https://github.com/facebook/react/commit/3168e08f8389d258de9eb7c8d19b9d44a0f250f2"><code>3168e08</code></a> [flags] enable opt-in for enableDefaultTransitionIndicator (<a href="https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/34373">#34373</a>)</li>
<li><a href="https://github.com/facebook/react/commit/3434ff4f4b89ad9388c6109312ef95c14652ae21"><code>3434ff4</code></a> Add scrollIntoView to fragment instances (<a href="https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/32814">#32814</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/facebook/react/commits/v19.2.0/packages/react-dom">compare view</a></li>
</ul>
</details>
<br />

Updates `@types/react-dom` from 19.1.9 to 19.2.3
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/react-dom">compare view</a></li>
</ul>
</details>
<br />

Updates `@typescript-eslint/eslint-plugin` from 8.45.0 to 8.46.4
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/typescript-eslint/typescript-eslint/releases"><code>@​typescript-eslint/eslint-plugin</code>'s releases</a>.</em></p>
<blockquote>
<h2>v8.46.4</h2>
<h2>8.46.4 (2025-11-10)</h2>
<h3>🩹 Fixes</h3>
<ul>
<li><strong>eslint-plugin:</strong> [no-deprecated] fix double-report on computed literal identifiers (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11006">#11006</a>, <a href="https://redirect.github.com/typescript-eslint/typescript-eslint/issues/10958">#10958</a>)</li>
<li><strong>eslint-plugin:</strong> handle override modifier in promise-function-async fixer (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11730">#11730</a>)</li>
<li><strong>parser:</strong> error when both <code>projectService</code> and <code>project</code> are set (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11333">#11333</a>)</li>
</ul>
<h3>❤️ Thank You</h3>
<ul>
<li>Evgeny Stepanovych <a href="https://github.com/undsoft"><code>@​undsoft</code></a></li>
<li>Kentaro Suzuki <a href="https://github.com/sushichan044"><code>@​sushichan044</code></a></li>
<li>Maria Solano <a href="https://github.com/MariaSolOs"><code>@​MariaSolOs</code></a></li>
</ul>
<p>You can read about our <a href="https://typescript-eslint.io/users/versioning">versioning strategy</a> and <a href="https://typescript-eslint.io/users/releases">releases</a> on our website.</p>
<h2>v8.46.3</h2>
<h2>8.46.3 (2025-11-03)</h2>
<h3>🩹 Fixes</h3>
<ul>
<li><strong>eslint-plugin:</strong> [no-misused-promises] expand union type to retrieve target property (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11706">#11706</a>)</li>
<li><strong>eslint-plugin:</strong> [no-duplicate-enum-values] support signed numbers (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11722">#11722</a>, <a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11723">#11723</a>)</li>
</ul>
<h3>❤️ Thank You</h3>
<ul>
<li>Evgeny Stepanovych <a href="https://github.com/undsoft"><code>@​undsoft</code></a></li>
<li>tao</li>
</ul>
<p>You can read about our <a href="https://typescript-eslint.io/users/versioning">versioning strategy</a> and <a href="https://typescript-eslint.io/users/releases">releases</a> on our website.</p>
<h2>v8.46.2</h2>
<h2>8.46.2 (2025-10-20)</h2>
<h3>🩹 Fixes</h3>
<ul>
<li><strong>eslint-plugin:</strong> [prefer-optional-chain] skip optional chaining when it could change the result (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11702">#11702</a>)</li>
<li><strong>typescript-estree:</strong> forbid invalid modifiers in object methods (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11689">#11689</a>)</li>
</ul>
<h3>❤️ Thank You</h3>
<ul>
<li>fisker Cheung <a href="https://github.com/fisker"><code>@​fisker</code></a></li>
<li>mdm317</li>
</ul>
<p>You can read about our <a href="https://typescript-eslint.io/users/versioning">versioning strategy</a> and <a href="https://typescript-eslint.io/users/releases">releases</a> on our website.</p>
<h2>v8.46.1</h2>
<h2>8.46.1 (2025-10-13)</h2>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/CHANGELOG.md"><code>@​typescript-eslint/eslint-plugin</code>'s changelog</a>.</em></p>
<blockquote>
<h2>8.46.4 (2025-11-10)</h2>
<h3>🩹 Fixes</h3>
<ul>
<li><strong>parser:</strong> error when both <code>projectService</code> and <code>project</code> are set (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11333">#11333</a>)</li>
<li><strong>eslint-plugin:</strong> handle override modifier in promise-function-async fixer (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11730">#11730</a>)</li>
<li><strong>eslint-plugin:</strong> [no-deprecated] fix double-report on computed literal identifiers (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11006">#11006</a>, <a href="https://redirect.github.com/typescript-eslint/typescript-eslint/issues/10958">#10958</a>)</li>
</ul>
<h3>❤️ Thank You</h3>
<ul>
<li>Evgeny Stepanovych <a href="https://github.com/undsoft"><code>@​undsoft</code></a></li>
<li>Kentaro Suzuki <a href="https://github.com/sushichan044"><code>@​sushichan044</code></a></li>
<li>Maria Solano <a href="https://github.com/MariaSolOs"><code>@​MariaSolOs</code></a></li>
</ul>
<p>You can read about our <a href="https://typescript-eslint.io/users/versioning">versioning strategy</a> and <a href="https://typescript-eslint.io/users/releases">releases</a> on our website.</p>
<h2>8.46.3 (2025-11-03)</h2>
<h3>🩹 Fixes</h3>
<ul>
<li><strong>eslint-plugin:</strong> [no-duplicate-enum-values] support signed numbers (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11722">#11722</a>, <a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11723">#11723</a>)</li>
<li><strong>eslint-plugin:</strong> [no-misused-promises] expand union type to retrieve target property (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11706">#11706</a>)</li>
</ul>
<h3>❤️ Thank You</h3>
<ul>
<li>Evgeny Stepanovych <a href="https://github.com/undsoft"><code>@​undsoft</code></a></li>
<li>tao</li>
</ul>
<p>You can read about our <a href="https://typescript-eslint.io/users/versioning">versioning strategy</a> and <a href="https://typescript-eslint.io/users/releases">releases</a> on our website.</p>
<h2>8.46.2 (2025-10-20)</h2>
<h3>🩹 Fixes</h3>
<ul>
<li><strong>eslint-plugin:</strong> [prefer-optional-chain] skip optional chaining when it could change the result (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11702">#11702</a>)</li>
</ul>
<h3>❤️ Thank You</h3>
<ul>
<li>mdm317</li>
</ul>
<p>You can read about our <a href="https://typescript-eslint.io/users/versioning">versioning strategy</a> and <a href="https://typescript-eslint.io/users/releases">releases</a> on our website.</p>
<h2>8.46.1 (2025-10-13)</h2>
<h3>🩹 Fixes</h3>
<ul>
<li><strong>eslint-plugin:</strong> [no-misused-promises] special-case <code>.finally</code> not to report when a promise returning function is provided as an argument (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11667">#11667</a>)</li>
<li><strong>eslint-plugin:</strong> [prefer-optional-chain] include mixed &quot;nullish comparison style&quot; chains in checks (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11533">#11533</a>)</li>
</ul>
<h3>❤️ Thank You</h3>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/843f144797c0a94272cdb002c00c5639cf0797c6"><code>843f144</code></a> chore(release): publish 8.46.4</li>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/997e0c005d2d80a726249cafb7cbdf4ec287aea3"><code>997e0c0</code></a> fix(parser): error when both <code>projectService</code> and <code>project</code> are set (<a href="https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin/issues/11333">#11333</a>)</li>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/7c6944e74b29a3310515a9de9333e20116165b58"><code>7c6944e</code></a> chore: fix typos (<a href="https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin/issues/11744">#11744</a>)</li>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/189a7f76fc85661e0bebdedebd24a60c255e920d"><code>189a7f7</code></a> fix(eslint-plugin): handle override modifier in promise-function-async fixer ...</li>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/c779f3cd80c41ecfc279fd9c66651314b97d843e"><code>c779f3c</code></a> fix(eslint-plugin): [no-deprecated] fix double-report on computed literal ide...</li>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/ea2ee6b65a2f14dd2c3fc8d12be969cbeaef80a8"><code>ea2ee6b</code></a> chore(eslint-plugin): use correct type for return type of <code>createValidator</code> (...</li>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/d9f3497dfb72e90fd7dc977c77d41b0eb9df4909"><code>d9f3497</code></a> chore(release): publish 8.46.3</li>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/26a9f9485faa45d269fd701b5fb8b11c97d75144"><code>26a9f94</code></a> fix(eslint-plugin): [no-duplicate-enum-values] support signed numbers (<a href="https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin/issues/11722">#11722</a>...</li>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/b8219d13dafd6bc5e425b51ad96810df1156b871"><code>b8219d1</code></a> fix(eslint-plugin): [no-misused-promises] expand union type to retrieve targe...</li>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/55ca033ee88cc95cfac4ad6dea2257fbeb1d4657"><code>55ca033</code></a> chore(release): publish 8.46.2</li>
<li>Additional commits viewable in <a href="https://github.com/typescript-eslint/typescript-eslint/commits/v8.46.4/packages/eslint-plugin">compare view</a></li>
</ul>
</details>
<br />

Updates `@typescript-eslint/parser` from 8.45.0 to 8.46.4
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/typescript-eslint/typescript-eslint/releases"><code>@​typescript-eslint/parser</code>'s releases</a>.</em></p>
<blockquote>
<h2>v8.46.4</h2>
<h2>8.46.4 (2025-11-10)</h2>
<h3>🩹 Fixes</h3>
<ul>
<li><strong>eslint-plugin:</strong> [no-deprecated] fix double-report on computed literal identifiers (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11006">#11006</a>, <a href="https://redirect.github.com/typescript-eslint/typescript-eslint/issues/10958">#10958</a>)</li>
<li><strong>eslint-plugin:</strong> handle override modifier in promise-function-async fixer (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11730">#11730</a>)</li>
<li><strong>parser:</strong> error when both <code>projectService</code> and <code>project</code> are set (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11333">#11333</a>)</li>
</ul>
<h3>❤️ Thank You</h3>
<ul>
<li>Evgeny Stepanovych <a href="https://github.com/undsoft"><code>@​undsoft</code></a></li>
<li>Kentaro Suzuki <a href="https://github.com/sushichan044"><code>@​sushichan044</code></a></li>
<li>Maria Solano <a href="https://github.com/MariaSolOs"><code>@​MariaSolOs</code></a></li>
</ul>
<p>You can read about our <a href="https://typescript-eslint.io/users/versioning">versioning strategy</a> and <a href="https://typescript-eslint.io/users/releases">releases</a> on our website.</p>
<h2>v8.46.3</h2>
<h2>8.46.3 (2025-11-03)</h2>
<h3>🩹 Fixes</h3>
<ul>
<li><strong>eslint-plugin:</strong> [no-misused-promises] expand union type to retrieve target property (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11706">#11706</a>)</li>
<li><strong>eslint-plugin:</strong> [no-duplicate-enum-values] support signed numbers (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11722">#11722</a>, <a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11723">#11723</a>)</li>
</ul>
<h3>❤️ Thank You</h3>
<ul>
<li>Evgeny Stepanovych <a href="https://github.com/undsoft"><code>@​undsoft</code></a></li>
<li>tao</li>
</ul>
<p>You can read about our <a href="https://typescript-eslint.io/users/versioning">versioning strategy</a> and <a href="https://typescript-eslint.io/users/releases">releases</a> on our website.</p>
<h2>v8.46.2</h2>
<h2>8.46.2 (2025-10-20)</h2>
<h3>🩹 Fixes</h3>
<ul>
<li><strong>eslint-plugin:</strong> [prefer-optional-chain] skip optional chaining when it could change the result (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11702">#11702</a>)</li>
<li><strong>typescript-estree:</strong> forbid invalid modifiers in object methods (<a href="https://redirect.github.com/typescript-eslint/typescript-eslint/pull/11689">#11689</a>)</li>
</ul>
<h3>❤️ Thank You</h3>
<ul>
<li>fisker Cheung <a href="https://github.com/fisker"><code>@​fisker</code></a></li>
<li>mdm317</li>
</ul>
<p>You can read about our <a href="https://typescript-eslint.io/users/versioning">versioning strategy</a> and <a href="https://typescript-eslint.io/users/releases">releases</a> on our website.</p>
<h2>v8.46.1</h2>
<h2>8.46.1 (2025-10-13)</h2>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/parser/CHANGELOG.md"><code>@​typescript-eslint/parser</code>'s changelog</a>.</em></p>
<blockquote>
<h2>8.46.4 (2025-11-10)</h2>
<p>This was a version bump only for parser to align it with other projects, there were no code changes.</p>
<p>You can read about our <a href="https://typescript-eslint.io/users/versioning">versioning strategy</a> and <a href="https://typescript-eslint.io/users/releases">releases</a> on our website.</p>
<h2>8.46.3 (2025-11-03)</h2>
<p>This was a version bump only for parser to align it with other projects, there were no code changes.</p>
<p>You can read about our <a href="https://typescript-eslint.io/users/versioning">versioning strategy</a> and <a href="https://typescript-eslint.io/users/releases">releases</a> on our website.</p>
<h2>8.46.2 (2025-10-20)</h2>
<p>This was a version bump only for parser to align it with other projects, there were no code changes.</p>
<p>You can read about our <a href="https://typescript-eslint.io/users/versioning">versioning strategy</a> and <a href="https://typescript-eslint.io/users/releases">releases</a> on our website.</p>
<h2>8.46.1 (2025-10-13)</h2>
<p>This was a version bump only for parser to align it with other projects, there were no code changes.</p>
<p>You can read about our <a href="https://typescript-eslint.io/users/versioning">versioning strategy</a> and <a href="https://typescript-eslint.io/users/releases">releases</a> on our website.</p>
<h2>8.46.0 (2025-10-06)</h2>
<p>This was a version bump only for parser to align it with other projects, there were no code changes.</p>
<p>You can read about our <a href="https://typescript-eslint.io/users/versioning">versioning strategy</a> and <a href="https://typescript-eslint.io/users/releases">releases</a> on our website.</p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/843f144797c0a94272cdb002c00c5639cf0797c6"><code>843f144</code></a> chore(release): publish 8.46.4</li>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/d9f3497dfb72e90fd7dc977c77d41b0eb9df4909"><code>d9f3497</code></a> chore(release): publish 8.46.3</li>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/55ca033ee88cc95cfac4ad6dea2257fbeb1d4657"><code>55ca033</code></a> chore(release): publish 8.46.2</li>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/3f5fbf698e75ddd87874885ffbf937913761cdb0"><code>3f5fbf6</code></a> chore(release): publish 8.46.1</li>
<li><a href="https://github.com/typescript-eslint/typescript-eslint/commit/aec785e33d63b248231c3e68c9aeb792caf21acc"><code>aec785e</code></a> chore(release): publish 8.46.0</li>
<li>See full diff in <a href="https://github.com/typescript-eslint/typescript-eslint/commits/v8.46.4/packages/parser">compare view</a></li>
</ul>
</details>
<br />

Updates `eslint` from 9.36.0 to 9.39.1
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/eslint/eslint/releases">eslint's releases</a>.</em></p>
<blockquote>
<h2>v9.39.1</h2>
<h2>Bug Fixes</h2>
<ul>
<li><a href="https://github.com/eslint/eslint/commit/650753ee3976784343ceb40170619dab1aa9fe0d"><code>650753e</code></a> fix: Only pass node to JS lang visitor methods (<a href="https://redirect.github.com/eslint/eslint/issues/20283">#20283</a>) (Nicholas C. Zakas)</li>
</ul>
<h2>Documentation</h2>
<ul>
<li><a href="https://github.com/eslint/eslint/commit/51b51f4f1ce82ef63264c4e45d9ef579bcd73f8e"><code>51b51f4</code></a> docs: add a section on when to use extends vs cascading (<a href="https://redirect.github.com/eslint/eslint/issues/20268">#20268</a>) (Tanuj Kanti)</li>
<li><a href="https://github.com/eslint/eslint/commit/b44d42699dcd1729b7ecb50ca70e4c1c17f551f1"><code>b44d426</code></a> docs: Update README (GitHub Actions Bot)</li>
</ul>
<h2>Chores</h2>
<ul>
<li><a href="https://github.com/eslint/eslint/commit/92db329211c8da5ce8340a4d4c05ce9c12845381"><code>92db329</code></a> chore: update <code>@eslint/js</code> version to 9.39.1 (<a href="https://redirect.github.com/eslint/eslint/issues/20284">#20284</a>) (Francesco Trotta)</li>
<li><a href="https://github.com/eslint/eslint/commit/c7ebefc9eaf99b76b30b0d3cf9960807a47367c4"><code>c7ebefc</code></a> chore: package.json update for <code>@​eslint/js</code> release (Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/61778f6ca33c0f63962a91d6a75a4fa5db9f47d2"><code>61778f6</code></a> chore: update eslint-config-eslint dependency <code>@​eslint/js</code> to ^9.39.0 (<a href="https://redirect.github.com/eslint/eslint/issues/20275">#20275</a>) (renovate[bot])</li>
<li><a href="https://github.com/eslint/eslint/commit/d9ca2fcd9ad63331bfd329a69534e1ff04f231e8"><code>d9ca2fc</code></a> ci: Add rangeStrategy to eslint group in renovate config (<a href="https://redirect.github.com/eslint/eslint/issues/20266">#20266</a>) (唯然)</li>
<li><a href="https://github.com/eslint/eslint/commit/009e5076ff5a4bd845f55e17676e3bb88f47c280"><code>009e507</code></a> test: fix version tests for ESLint v10 (<a href="https://redirect.github.com/eslint/eslint/issues/20274">#20274</a>) (Milos Djermanovic)</li>
</ul>
<h2>v9.39.0</h2>
<h2>Features</h2>
<ul>
<li><a href="https://github.com/eslint/eslint/commit/cc57d87a3f119e9d39c55e044e526ae067fa31ce"><code>cc57d87</code></a> feat: update error loc to key in <code>no-dupe-class-members</code> (<a href="https://redirect.github.com/eslint/eslint/issues/20259">#20259</a>) (Tanuj Kanti)</li>
<li><a href="https://github.com/eslint/eslint/commit/126552fcf35da3ddcefa527db06dabc54c04041c"><code>126552f</code></a> feat: update error location in <code>for-direction</code> and <code>no-dupe-args</code> (<a href="https://redirect.github.com/eslint/eslint/issues/20258">#20258</a>) (Tanuj Kanti)</li>
<li><a href="https://github.com/eslint/eslint/commit/167d0970d3802a66910e9820f31dcd717fab0b2a"><code>167d097</code></a> feat: update <code>complexity</code> rule to highlight only static block header (<a href="https://redirect.github.com/eslint/eslint/issues/20245">#20245</a>) (jaymarvelz)</li>
</ul>
<h2>Bug Fixes</h2>
<ul>
<li><a href="https://github.com/eslint/eslint/commit/15f5c7c168d0698683943f51dd617f14a5e6815c"><code>15f5c7c</code></a> fix: forward traversal <code>step.args</code> to visitors (<a href="https://redirect.github.com/eslint/eslint/issues/20253">#20253</a>) (jaymarvelz)</li>
<li><a href="https://github.com/eslint/eslint/commit/5a1a534e877f7c4c992885867f923df307c3929d"><code>5a1a534</code></a> fix: allow JSDoc comments in object-shorthand rule (<a href="https://redirect.github.com/eslint/eslint/issues/20167">#20167</a>) (Nitin Kumar)</li>
<li><a href="https://github.com/eslint/eslint/commit/e86b813eb660f1a5adc8e143a70d9b683cd12362"><code>e86b813</code></a> fix: Use more types from <code>@​eslint/core</code> (<a href="https://redirect.github.com/eslint/eslint/issues/20257">#20257</a>) (Nicholas C. Zakas)</li>
<li><a href="https://github.com/eslint/eslint/commit/927272d1f0d5683b029b729d368a96527f283323"><code>927272d</code></a> fix: correct <code>Scope</code> typings (<a href="https://redirect.github.com/eslint/eslint/issues/20198">#20198</a>) (jaymarvelz)</li>
<li><a href="https://github.com/eslint/eslint/commit/37f76d9c539bb6fc816fedb7be4486b71a58620a"><code>37f76d9</code></a> fix: use <code>AST.Program</code> type for Program node (<a href="https://redirect.github.com/eslint/eslint/issues/20244">#20244</a>) (Francesco Trotta)</li>
<li><a href="https://github.com/eslint/eslint/commit/ae07f0b3334ebd22ae2e7b09bca5973b96aa9768"><code>ae07f0b</code></a> fix: unify timing report for concurrent linting (<a href="https://redirect.github.com/eslint/eslint/issues/20188">#20188</a>) (jaymarvelz)</li>
<li><a href="https://github.com/eslint/eslint/commit/b165d471be6062f4475b972155b02654a974a0e9"><code>b165d47</code></a> fix: correct <code>Rule</code> typings (<a href="https://redirect.github.com/eslint/eslint/issues/20199">#20199</a>) (jaymarvelz)</li>
<li><a href="https://github.com/eslint/eslint/commit/fb97cda70d87286a7dbd2457f578ef578d6905e8"><code>fb97cda</code></a> fix: improve error message for missing fix function in suggestions (<a href="https://redirect.github.com/eslint/eslint/issues/20218">#20218</a>) (jaymarvelz)</li>
</ul>
<h2>Documentation</h2>
<ul>
<li><a href="https://github.com/eslint/eslint/commit/d3e81e30ee6be5a21151b7a17ef10a714b6059c0"><code>d3e81e3</code></a> docs: Always recommend to include a files property (<a href="https://redirect.github.com/eslint/eslint/issues/20158">#20158</a>) (Percy Ma)</li>
<li><a href="https://github.com/eslint/eslint/commit/0f0385f1404dcadaba4812120b1ad02334dbd66a"><code>0f0385f</code></a> docs: use consistent naming recommendation (<a href="https://redirect.github.com/eslint/eslint/issues/20250">#20250</a>) (Alex M. Spieslechner)</li>
<li><a href="https://github.com/eslint/eslint/commit/a3b145609ac649fac837c8c0515cbb2a9321ca40"><code>a3b1456</code></a> docs: Update README (GitHub Actions Bot)</li>
<li><a href="https://github.com/eslint/eslint/commit/cf5f2dd58dd98084a21da04fe7b9054b9478d552"><code>cf5f2dd</code></a> docs: fix correct tag of <code>no-useless-constructor</code> (<a href="https://redirect.github.com/eslint/eslint/issues/20255">#20255</a>) (Tanuj Kanti)</li>
<li><a href="https://github.com/eslint/eslint/commit/10b995c8e5473de8d66d3cd99d816e046f35e3ec"><code>10b995c</code></a> docs: add TS options and examples for <code>nofunc</code> in <code>no-use-before-define</code> (<a href="https://redirect.github.com/eslint/eslint/issues/20249">#20249</a>) (Tanuj Kanti)</li>
<li><a href="https://github.com/eslint/eslint/commit/2584187e4a305ea7a98e1a5bd4dca2a60ad132f8"><code>2584187</code></a> docs: remove repetitive word in comment (<a href="https://redirect.github.com/eslint/eslint/issues/20242">#20242</a>) (reddaisyy)</li>
<li><a href="https://github.com/eslint/eslint/commit/637216bd4f2aae7c928ad04a4e40eecffb50c9e5"><code>637216b</code></a> docs: update CLI flags migration instructions (<a href="https://redirect.github.com/eslint/eslint/issues/20238">#20238</a>) (jaymarvelz)</li>
<li><a href="https://github.com/eslint/eslint/commit/e7cda3bdf1bdd664e6033503a3315ad81736b200"><code>e7cda3b</code></a> docs: Update README (GitHub Actions B...

_Description has been truncated_