### PR TITLE
feat: start on the simple view

### DIFF
--- a/app/src/components/Results/Results.test.tsx
+++ b/app/src/components/Results/Results.test.tsx
@@ -22,45 +22,43 @@ describe('Results Component', () => {
         screen.getByRole('button', { name: '✨ Simple View' })
         screen.getByRole('button', { name: '🔬 Expert View' })
 
-        // Should default to Expert view
+        // Simple default to Simple view
+        // Simple View contains specific charts like "Concentration Score" or just checking absent Expert content
         // Expert View contains the "Work in Progress" section
-        screen.getByText(/Work in Progress/i)
+        expect(screen.queryByText(/Work in Progress/i)).toBeNull()
     })
 
     it('switches to simple view when Simple View button is clicked', async () => {
         render(<Results />)
         const simpleButton = screen.getByRole('button', {
-            name: '✨ Simple View',
+            name: '🔬 Expert View',
         })
 
         fireEvent.click(simpleButton)
 
-        // Simple view content should be visible
-        // Simple View contains specific charts like "Concentration Score" or just checking absent Expert content
-        expect(screen.queryByText(/Work in Progress/i)).toBeNull()
+        // Expert view content should be visible
+        screen.queryByText(/Work in Progress/i)
 
         // We can check if RangeSlider is present (common) but distinguishing is key.
-        // SimpleView renders FunFacts.
-        // But let's check for absence of Expert content first which proves switch.
     })
 
     it('switches to expert view when Expert View button is clicked', async () => {
         render(<Results />)
 
-        // First switch to simple view
+        // First switch to expert view
         const simpleButton = screen.getByRole('button', {
-            name: '✨ Simple View',
+            name: '🔬 Expert View',
         })
         fireEvent.click(simpleButton)
-        expect(screen.queryByText(/Work in Progress/i)).toBeNull()
+        screen.getByText(/Work in Progress/i)
 
-        // Then switch back to expert view
+        // Then switch back to simple view
         const expertButton = screen.getByRole('button', {
-            name: '🔬 Expert View',
+            name: '✨ Simple View',
         })
         fireEvent.click(expertButton)
 
-        // Expert View content should be visible again
-        screen.getByText(/Work in Progress/i)
+        // Expert View content should not be visible again
+        expect(screen.queryByText(/Work in Progress/i)).toBeNull()
     })
 })

--- a/app/src/components/Results/Results.tsx
+++ b/app/src/components/Results/Results.tsx
@@ -3,7 +3,7 @@ import { SimpleView } from '../Charts/SimpleView'
 import { useState } from 'react'
 
 export function Results() {
-    const [activeTab, setActiveTab] = useState<'simple' | 'expert'>('expert')
+    const [activeTab, setActiveTab] = useState<'simple' | 'expert'>('simple')
 
     return (
         <div className="py-8 animate-slide-up">
@@ -41,7 +41,7 @@ export function Results() {
             </div>
 
             <div className="min-h-screen">
-                {activeTab === 'simple' ? <SimpleView /> : <ExpertView />}
+                {activeTab === 'expert' ? <ExpertView /> : <SimpleView />}
             </div>
         </div>
     )


### PR DESCRIPTION
Closes #205 

Start on the simple view rather than the expert view.

To highlight the simplified view and allow users to view their data in more detail using the expert view if they wish.