### PR TITLE
docs: introduce ADRs

### DIFF
--- a/docs/decisions/adr-template.md
+++ b/docs/decisions/adr-template.md
@@ -1,0 +1,25 @@
+<!-- This is a copy-paste from https://github.com/adr/madr/blob/develop/template/adr-template-minimal.md -->
+
+# {short title, representative of solved problem and found solution}
+
+## Context and Problem Statement
+
+{Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story. You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
+
+## Considered Options
+
+* {title of option 1}
+* {title of option 2}
+* {title of option 3}
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "{title of option 1}", because {justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force {force} | … | comes out best (see below)}.
+
+<!-- This is an optional element. Feel free to remove. -->
+### Consequences
+
+* Good, because {positive consequence, e.g., improvement of one or more desired qualities, …}
+* Bad, because {negative consequence, e.g., compromising one or more desired qualities, …}
+* … <!-- numbers of consequences can vary -->


### PR DESCRIPTION
Why ?
In open source, people rotate constantly. Maintainers leave, contributors pop in for one PR, reviewers skim. An ADR answers “why did you do this?” without needing tribal knowledge or ancient PR archaeology.

How ?
We use MADR to keep Architecture Decision Records lightweight, consistent, and easy to maintain, so contributors can understand why decisions were made without digging through old issues or PRs.

More details :
 - https://github.com/adr/madr

**Side note:** We will later move this ADR directory into our blog once merged 