### PR TITLE
chore: remove preview label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -68,7 +68,3 @@
 
 - name: "hacktoberfest"
   color: "000000"
-
-- name: "preview"
-  color: "171f2b"
-  description: "Deploy the app preview"


### PR DESCRIPTION


## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).

## 🔇 Problem

`preview` label is no longer used since the switch to previews on GitHub Action.

## 🎹 Proposal

Remove it.

## 🎶 Comments

<!-- Additional information, tips or problems encountered. -->

## 🎤 Test

<!-- Instructions for reproducing the problem and how you tested the fix. -->
