### PR TITLE
chore(ci): rearrange run workflow conditions

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     paths:
       - "app/**"
-      - ".github/workflows/app-deploy-preview.yml"
+      - ".github/workflows/app-build.yml"
+      - ".moon/toolchains.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/app-deploy-preview.yml
+++ b/.github/workflows/app-deploy-preview.yml
@@ -7,6 +7,10 @@ on:
       - reopened
       - synchronize
       - closed
+    paths:
+      - "app/**"
+      - ".github/workflows/app-deploy-preview.yml"
+      - ".moon/toolchains.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/datasets-generate-synthetic.yml
+++ b/.github/workflows/datasets-generate-synthetic.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
     paths:
       - "synthetic-datasets/synthetic_datasets/**/*.py"
+      - ".github/workflows/datasets-generate-synthetic.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/datasets-test-synthetic.yml
+++ b/.github/workflows/datasets-test-synthetic.yml
@@ -3,6 +3,10 @@ name: Audit datasets generator
 on:
   push:
     branches: ["main"]
+    paths:
+      - "synthetic-datasets/**"
+      - ".github/workflows/datasets-test-synthetic.yml"
+      - ".moon/toolchains.yml"
   pull_request:
     branches: ["main"]
     paths:


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).

## 🔇 Problem

- app-build workflow is not launched when it is modified
- generate-synthetic workflow is not launched when it is modified
- not all workflows are launched when the moon toolchains file is modified 
- app preview is deployed all the time 

## 🎹 Proposal

- Run the workflow when there are changes.
- Deploy the application preview only if the application/files, `app-deploy-preview.yml`, and `.moon/toolchains.yml` are modified.

## 🎶 Comments

<!-- Additional information, tips or problems encountered. -->

## 🎤 Test

<!-- Instructions for reproducing the problem and how you tested the fix. -->
