### PR TITLE
fix: bump app dependencies to cover critical vulnerabilities 

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -39,5 +39,10 @@
     },
     "engines": {
         "node": ">=24 <25"
+    },
+    "pnpm": {
+        "overrides": {
+            "lodash": "^4.17.23"
+        }
     }
 }

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lodash: ^4.17.23
+
 importers:
 
   .:
@@ -2745,8 +2748,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -7166,7 +7169,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.21: {}
+  lodash@4.17.23: {}
 
   longest-streak@3.1.0: {}
 
@@ -8844,7 +8847,7 @@ snapshots:
       '@vscode/l10n': 0.0.18
       ajv: 8.17.1
       ajv-draft-04: 1.0.0(ajv@8.17.1)
-      lodash: 4.17.21
+      lodash: 4.17.23
       prettier: 3.7.4
       request-light: 0.5.8
       vscode-json-languageservice: 4.1.8


### PR DESCRIPTION

## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).

## 🔇 Problem

`pnpm audit --production` reported some critical/high vulnerability 
```
▪▪▪▪ app:audit (7dbb73a5)
(node:2426) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
(Use `node --trace-deprecation ...` to show where the warning was created)
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ devalue vulnerable to denial of service due to         │
│                     │ memory/CPU exhaustion in devalue.parse                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ devalue                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=5.1.0 <5.6.2                                         │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=5.6.2                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ . > @astrojs/tailwind@6.0.2 > astro@5.16.6 >           │
│                     │ devalue@5.6.1                                          │
│                     │                                                        │
│                     │ . > astro@5.16.6 > devalue@5.6.1                       │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-g2pg-6438-jwpf      │
└─────────────────────┴────────────────────────────────────────────────────────┘
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ h3 v1 has Request Smuggling (TE.TE) issue              │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ h3                                                     │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <=1.15.4                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=1.15.5                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ . > @astrojs/tailwind@6.0.2 > astro@5.16.6 >           │
│                     │ unstorage@1.17.3 > h3@1.15.4                           │
│                     │                                                        │
│                     │ . > astro@5.16.6 > unstorage@1.17.3 > h3@1.15.4        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-mp2g-9vg9-f4cg      │
└─────────────────────┴────────────────────────────────────────────────────────┘
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ Devalue is vulnerable to denial of service due to      │
│                     │ memory exhaustion in devalue.parse                     │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ devalue                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=5.3.0 <=5.6.1                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=5.6.2                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ . > @astrojs/tailwind@6.0.2 > astro@5.16.6 >           │
│                     │ devalue@5.6.1                                          │
│                     │                                                        │
│                     │ . > astro@5.16.6 > devalue@5.6.1                       │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-vw5p-8cq8-m7mv      │
└─────────────────────┴────────────────────────────────────────────────────────┘
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ moderate            │ Lodash has Prototype Pollution Vulnerability in        │
│                     │ `_.unset` and `_.omit` functions                       │
├─────────────────────┼──────────────────────────────────────────────���─────────┤
│ Package             │ lodash                                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=4.0.0 <=4.17.22                                      │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=4.17.23                                              │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ . > @astrojs/check@0.9.6 >                             │
│                     │ @astrojs/language-server@2.16.2 >                      │
│                     │ volar-service-yaml@0.0.67 >                            │
│                     │ yaml-language-server@1.19.2 > lodash@4.17.21           │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-xxjr-mmjv-4gpg      │
└─────────────────────┴────────────────────────────────────────────────────────┘
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ low                 │ jsdiff has a Denial of Service vulnerability in        │
│                     │ parsePatch and applyPatch                              │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ diff                                                   │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=5.0.0 <5.2.2                                         │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=5.2.2                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ . > @astrojs/tailwind@6.0.2 > astro@5.16.6 >           │
│                     │ diff@5.2.0                                             │
│                     │                                                        │
│                     │ . > astro@5.16.6 > diff@5.2.0                          │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-73rr-hh4g-fpgx      │
└─────────────────────┴────────────────────────────────────────────────────────┘
5 vulnerabilities found
Severity: 1 low | 1 moderate | 3 high
```

## 🎹 Proposal

1. bump of astro to [astro@5.16.11](https://github.com/withastro/astro/releases/tag/astro%405.16.11)
Changelog: 
> Patch Changes
> 
>     [#15017](https://github.com/withastro/astro/pull/15017) [9e7a3c8](https://github.com/withastro/astro/commit/9e7a3c86198956e558384235b71a6c12e87fc5fb) Thanks [@ixchio](https://github.com/ixchio)! - Fixes CSS double-bundling when the same CSS file is imported in both a page's frontmatter and a component's script tag
> 
>     [#15225](https://github.com/withastro/astro/pull/15225) [6fe62e1](https://github.com/withastro/astro/commit/6fe62e169cf9e1054cba95ce4084d8a58bdd0a66) Thanks [@ematipico](https://github.com/ematipico)! - Updates to the latest version of devalue



2. override lodash version to  [lodash@4.17.23](https://github.com/lodash/lodash/releases/tag/4.17.23) using [`pnpm overrides`](https://pnpm.io/settings#overrides)