### PR TITLE
fix: apply model transformation in the demo workflow

### DIFF
--- a/app/src/db/queries/insertUrlInDatabase.ts
+++ b/app/src/db/queries/insertUrlInDatabase.ts
@@ -5,4 +5,12 @@ export async function insertUrlInDatabase(jsonUrl: URL) {
     const { conn } = await getDB()
     await conn.query(DROP_TABLE_QUERY)
     await conn.insertJSONFromPath(jsonUrl.toString(), { name: TABLE })
+    // The Spotify track URI is renamed to track_uri to match the `StreamRecord` model.
+    // `insertUrlInDatabase` is only used by the `DemoButton`, which provides a Spotify file.
+    // It's acceptable to apply this transformation here as a temporary hotfix, but ideally,
+    // we should use the transformation from `SpotifyStreamProvider` and automatically detect
+    // the correct provider to use.
+    await conn.query(
+        `ALTER TABLE ${TABLE} RENAME COLUMN spotify_track_uri TO track_uri`
+    )
 }


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).

## 🔇 Problem

The demo workflow does not apply the Spotify column overlay to the more generic template introduced in #264 .

## 🎹 Proposal

Rename the Spotify track URI to track_uri to match the `StreamRecord` model.

## 🎶 Comments

`insertUrlInDatabase` is only used by the `DemoButton`, which provides a Spotify file.
 It's acceptable to apply this transformation here as a temporary hotfix, but ideally, we should use the transformation from `SpotifyStreamProvider` and automatically detect the correct provider to use.

## 🎤 Test

<!-- Instructions for reproducing the problem and how you tested the fix. -->
