### PR TITLE
feat: add top 5 for tracks, artists and albums to Simple View

### DIFF
--- a/app/src/components/Charts/DetailedCharts/TopAlbums/TopAlbums.test.tsx
+++ b/app/src/components/Charts/DetailedCharts/TopAlbums/TopAlbums.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import * as query from '../../../../db/queries/queryDB'
+import * as db from '../../../../db/getDB'
+import { TopAlbumsQueryResult } from './query'
+
+import { TopAlbums } from '.'
+describe('TopAlbums Component', () => {
+    beforeEach(() => {
+        vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue([
+            {
+                album_name: 'album_a',
+                count_streams: 10n,
+                ms_played: 0n,
+            },
+        ] as unknown as TopAlbumsQueryResult[])
+
+        vi.spyOn(db, 'getDB').mockResolvedValue({
+            db: vi.fn(),
+            conn: vi.fn(),
+        } as unknown as Awaited<ReturnType<typeof db.getDB>>)
+    })
+
+    it('should render the svg', async () => {
+        const { container } = render(<TopAlbums year={2006} />)
+
+        await waitFor(() => {
+            expect(container.querySelectorAll('svg')).toHaveLength(1)
+        })
+        screen.getByText('Top Albums')
+        screen.getByText('album_a')
+    })
+})

--- a/app/src/components/Charts/DetailedCharts/TopAlbums/fixtures/seed.json
+++ b/app/src/components/Charts/DetailedCharts/TopAlbums/fixtures/seed.json
@@ -1,0 +1,93 @@
+[
+    {
+        "ts": "2006-10-13T22:15:32Z",
+        "track_uri": "uri_1",
+        "master_metadata_track_name": "track_a",
+        "master_metadata_album_album_name": "album_a",
+        "ms_played": 11
+    },
+    {
+        "ts": "2006-04-20T10:47:56Z",
+        "track_uri": "uri_2",
+        "master_metadata_track_name": "track_a",
+        "master_metadata_album_album_name": "album_b",
+        "ms_played": 22
+    },
+    {
+        "ts": "2006-01-17T04:41:23Z",
+        "track_uri": "uri_3",
+        "master_metadata_track_name": "track_b",
+        "master_metadata_album_album_name": "album_a",
+        "ms_played": 33
+    },
+    {
+        "ts": "2006-10-27T06:35:17Z",
+        "track_uri": "uri_1",
+
+        "master_metadata_track_name": "track_a",
+        "master_metadata_album_album_name": "album_a",
+        "ms_played": 11
+    },
+    {
+        "ts": "2006-06-01T04:18:22Z",
+        "track_uri": "uri_1",
+
+        "master_metadata_track_name": "track_a",
+        "master_metadata_album_album_name": "album_a",
+        "ms_played": 11
+    },
+    {
+        "ts": "2006-12-09T06:46:46Z",
+        "track_uri": "uri_1",
+
+        "master_metadata_track_name": "track_a",
+        "master_metadata_album_album_name": "album_a",
+        "ms_played": 11
+    },
+    {
+        "ts": "2025-10-13T22:15:32Z",
+        "track_uri": "uri_1",
+
+        "master_metadata_track_name": "track_a",
+        "master_metadata_album_album_name": "album_a",
+        "ms_played": 11
+    },
+    {
+        "ts": "2025-04-20T10:47:56Z",
+        "track_uri": "uri_2",
+        "master_metadata_track_name": "track_a",
+        "master_metadata_album_album_name": "album_b",
+        "ms_played": 22
+    },
+    {
+        "ts": "2025-01-17T04:41:23Z",
+        "track_uri": "uri_3",
+        "master_metadata_track_name": "track_b",
+        "master_metadata_album_album_name": "album_a",
+        "ms_played": 33
+    },
+    {
+        "ts": "2025-10-27T06:35:17Z",
+        "track_uri": "uri_1",
+
+        "master_metadata_track_name": "track_a",
+        "master_metadata_album_album_name": "album_a",
+        "ms_played": 11
+    },
+    {
+        "ts": "2025-06-01T04:18:22Z",
+        "track_uri": "uri_1",
+
+        "master_metadata_track_name": "track_a",
+        "master_metadata_album_album_name": "album_a",
+        "ms_played": 11
+    },
+    {
+        "ts": "2025-12-09T06:46:46Z",
+        "track_uri": "uri_1",
+
+        "master_metadata_track_name": "track_a",
+        "master_metadata_album_album_name": "album_a",
+        "ms_played": 11
+    }
+]

--- a/app/src/components/Charts/DetailedCharts/TopAlbums/index.tsx
+++ b/app/src/components/Charts/DetailedCharts/TopAlbums/index.tsx
@@ -1,0 +1,16 @@
+import { type TopAlbumsQueryResult, queryTopAlbumsByYear } from './query'
+import { buildPlot } from './plot'
+import { Common } from '../Common'
+
+interface TopAlbumsProps {
+    year: number
+}
+
+export function TopAlbums({ year }: TopAlbumsProps) {
+    return (
+        <Common<TopAlbumsQueryResult>
+            query={queryTopAlbumsByYear(year)}
+            buildPlot={buildPlot}
+        />
+    )
+}

--- a/app/src/components/Charts/DetailedCharts/TopAlbums/plot.tsx
+++ b/app/src/components/Charts/DetailedCharts/TopAlbums/plot.tsx
@@ -1,0 +1,74 @@
+import * as Plot from '@observablehq/plot'
+import { TopAlbumsQueryResult } from './query'
+import { formatDuration } from '../../../../utils/formatDuration'
+
+export function buildPlot(
+    data: TopAlbumsQueryResult[],
+    isDark: boolean = false
+): ReturnType<typeof Plot.plot> {
+    if (data.length === 0) {
+        return Plot.plot()
+    }
+
+    const yDomain = [...data.map((d) => d.album_name, 'Note')]
+
+    return Plot.plot({
+        title: 'Top Albums',
+        subtitle:
+            '⚠️ This chart is for informational purposes only. The data only includes album names, and multiple albums may share the same name.',
+        color: { scheme: isDark ? 'warm' : 'viridis' },
+        style: {
+            background: 'transparent',
+        },
+        width: 700,
+        height: 420,
+        marginLeft: 160,
+        x: {
+            label: null,
+            ticks: [],
+        },
+        y: {
+            label: null,
+            domain: yDomain,
+        },
+        marks: [
+            Plot.barX(
+                data.map((d) => ({
+                    name: d.album_name,
+                    count: d.count_streams,
+                    duration: formatDuration(d.ms_played),
+                })),
+                {
+                    x: 'count',
+                    y: 'name',
+                    fill: 'count',
+                    channels: {
+                        duration: 'duration',
+                    },
+                    tip: {
+                        format: {
+                            duration: true,
+                        },
+                    },
+                }
+            ),
+            Plot.text(
+                data.map((d) => ({
+                    name: d.album_name,
+                    count: Number(d.count_streams),
+                    label: Number(d.count_streams).toString(),
+                })),
+                {
+                    x: 'count',
+                    y: 'name',
+                    text: 'label',
+                    dx: 5,
+                    dy: 0,
+                    fill: isDark ? '#f1f1f1' : '#1f1f1f',
+                    textAnchor: 'start',
+                    fontSize: 12,
+                }
+            ),
+        ],
+    })
+}

--- a/app/src/components/Charts/DetailedCharts/TopAlbums/query.test.ts
+++ b/app/src/components/Charts/DetailedCharts/TopAlbums/query.test.ts
@@ -1,0 +1,56 @@
+import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
+import { DuckDBConnection } from '@duckdb/node-api'
+import { queryTopAlbumsByYear } from './query'
+import { TABLE } from '../../../../db/queries/constants'
+
+const seedPath =
+    'src/components/Charts/DetailedCharts/TopAlbums/fixtures/seed.json'
+let conn: DuckDBConnection
+
+beforeAll(async () => {
+    conn = await DuckDBConnection.create()
+})
+
+afterAll(() => {
+    conn.closeSync()
+})
+
+beforeEach(async () => {
+    await conn.run(`CREATE OR REPLACE TABLE ${TABLE} AS (FROM '${seedPath}')`)
+})
+
+describe('TopAlbums query', () => {
+    it('returns the tracks top 10 for all years', async () => {
+        const result = await conn.runAndReadAll(queryTopAlbumsByYear(undefined))
+        const rows = result.getRowObjects()
+        expect(rows).toEqual([
+            {
+                album_name: 'album_a',
+                ms_played: 154,
+                count_streams: 10,
+            },
+            {
+                album_name: 'album_b',
+                ms_played: 44,
+                count_streams: 2,
+            },
+        ])
+    })
+
+    it('returns the tracks top 10 for a specific year', async () => {
+        const result = await conn.runAndReadAll(queryTopAlbumsByYear(2006))
+        const rows = result.getRowObjects()
+        expect(rows).toEqual([
+            {
+                album_name: 'album_a',
+                ms_played: 77,
+                count_streams: 5,
+            },
+            {
+                album_name: 'album_b',
+                ms_played: 22,
+                count_streams: 1,
+            },
+        ])
+    })
+})

--- a/app/src/components/Charts/DetailedCharts/TopAlbums/query.tsx
+++ b/app/src/components/Charts/DetailedCharts/TopAlbums/query.tsx
@@ -1,0 +1,21 @@
+import { TABLE } from '../../../../db/queries/constants'
+
+export function queryTopAlbumsByYear(year: number | undefined) {
+    return `
+SELECT
+  master_metadata_album_album_name AS album_name,
+  COUNT(*)::DOUBLE AS count_streams,
+  SUM(ms_played)::DOUBLE AS ms_played
+FROM ${TABLE}
+${year ? `WHERE YEAR(ts:: DATETIME) = ${year}` : ''}
+GROUP BY master_metadata_album_album_name
+ORDER BY count_streams DESC
+LIMIT 10
+`
+}
+
+export type TopAlbumsQueryResult = {
+    album_name: string
+    count_streams: number
+    ms_played: number
+}

--- a/app/src/components/Charts/DetailedView.tsx
+++ b/app/src/components/Charts/DetailedView.tsx
@@ -13,6 +13,7 @@ import {
 import { queryDBAsJSON } from '../../db/queries/queryDB'
 import { TopTracks } from './DetailedCharts/TopTracks'
 import { TopArtists } from './DetailedCharts/TopArtists'
+import { TopAlbums } from './DetailedCharts/TopAlbums'
 import { Streaks } from './DetailedCharts/Streaks'
 import { Top10Evolution } from './DetailedCharts/Top10Evolution'
 import { StreamPerDayOfWeek } from './DetailedCharts/StreamPerDayOfWeek'
@@ -71,6 +72,7 @@ export function DetailedView() {
                     <SummaryPerYear year={year} />
                     <TopTracks year={year} />
                     <TopArtists year={year} />
+                    <TopAlbums year={year} />
                 </>
             )}
 

--- a/app/src/components/Charts/SimpleCharts/TopAlbums/TopAlbums.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopAlbums/TopAlbums.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TopAlbums } from './TopAlbums'
+
+describe('TopAlbums Component', () => {
+    it('renders correctly with data', async () => {
+        const numberOfTracks = 10
+        const data = Array.from({ length: numberOfTracks }, (_, i) => ({
+            album_name: `album_${i + 1}`,
+            artist_name: `artist_${(i % 3) + 1}`,
+            count_streams: i + 1,
+            ms_played: i + 1,
+        }))
+
+        render(<TopAlbums data={data} />)
+
+        screen.getByRole('heading', { name: /💿 Top Albums/ })
+
+        const items = screen.getAllByRole('listitem')
+        expect(items).toHaveLength(numberOfTracks)
+        expect(items[0].textContent).toBe('🥇album_1artist_11')
+        expect(items[1].textContent).toBe('🥈album_2artist_22')
+        expect(items[2].textContent).toBe('🥉album_3artist_33')
+        expect(items[3].textContent).toBe('4️⃣album_4artist_14')
+        expect(items[4].textContent).toBe('5️⃣album_5artist_25')
+        // Items beyond the top 5 should not display any ranking emoji
+        expect(items[5].textContent).toBe('album_6artist_36')
+    })
+})

--- a/app/src/components/Charts/SimpleCharts/TopAlbums/TopAlbums.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopAlbums/TopAlbums.tsx
@@ -1,0 +1,46 @@
+import type { FC } from 'react'
+import type { TopAlbumsResult } from './query'
+import { memo } from 'react'
+
+type Props = {
+    data: TopAlbumsResult[]
+}
+
+const rankEmojis = ['🥇', '🥈', '🥉', '4️⃣', '5️⃣']
+
+export const TopAlbums: FC<Props> = memo(function TopAlbums({ data }) {
+    return (
+        <div className="group p-6 bg-white dark:bg-slate-900/80 backdrop-blur-md rounded-2xl border border-gray-300/60 dark:border-slate-700/50 text-gray-900 dark:text-gray-100 transition-all duration-300 hover:shadow-glass-lg hover:scale-[1.01] animate-fade-in">
+            <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                💿 Top Albums
+            </h3>
+            <ul className="space-y-2" role="list">
+                {data.map((album, index) => (
+                    <li
+                        key={`${album.album_name}-${album.artist_name}`}
+                        className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors"
+                        role="listitem"
+                    >
+                        <span className="text-xl flex-shrink-0">
+                            {rankEmojis[index]}
+                        </span>
+                        <div
+                            className="flex-1 min-w-0"
+                            title={album.album_name}
+                        >
+                            <div className="font-medium truncate">
+                                {album.album_name}
+                            </div>
+                            <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                                {album.artist_name}
+                            </div>
+                        </div>
+                        <div className="text-sm font-bold text-brand-purple dark:text-brand-purple flex-shrink-0">
+                            {album.count_streams.toLocaleString()}
+                        </div>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    )
+})

--- a/app/src/components/Charts/SimpleCharts/TopAlbums/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopAlbums/index.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+import { queryDBAsJSON } from '../../../../db/queries/queryDB'
+import { queryTopAlbums, TopAlbumsResult } from './query'
+import { TopAlbums as TopAlbumsView } from './TopAlbums'
+
+export function TopAlbums({ year }: { year: number }) {
+    const [data, setData] = useState<TopAlbumsResult[]>([])
+
+    useEffect(() => {
+        const fetch = async () => {
+            const sql = queryTopAlbums(year)
+            const result = await queryDBAsJSON<TopAlbumsResult>(sql)
+            if (result && result.length > 0) setData(result)
+        }
+        fetch()
+    }, [year])
+
+    if (data.length === 0) return null
+    return <TopAlbumsView data={data} />
+}

--- a/app/src/components/Charts/SimpleCharts/TopAlbums/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/TopAlbums/query.test.ts
@@ -1,0 +1,130 @@
+import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
+import { queryTopAlbums } from './query'
+import {
+    createTestConnection,
+    closeTestConnection,
+    testQuery,
+    createTestTable,
+    type TestStreamEntry,
+} from '../__tests__/test-utils'
+import type { DuckDBConnection } from '@duckdb/node-api'
+
+let conn: DuckDBConnection
+
+const testYear = 2025
+const testDate = `${testYear}-01-01`
+const anotherDate = `${testYear - 1}-01-01`
+
+const createStream = (overrides = {}) => ({
+    ts: testDate,
+    master_metadata_track_name: 'track1',
+    master_metadata_album_artist_name: 'artist1',
+    master_metadata_album_album_name: 'album1',
+    ms_played: 1,
+    ...overrides,
+})
+
+const testData: TestStreamEntry[] = [
+    ...Array.from({ length: 10 }, () =>
+        createStream({ master_metadata_album_album_name: 'album2' })
+    ),
+    ...Array.from({ length: 8 }, () =>
+        createStream({
+            master_metadata_album_album_name: 'album3',
+            master_metadata_album_artist_name: 'artist3',
+        })
+    ),
+    ...Array.from({ length: 6 }, () =>
+        createStream({ master_metadata_album_album_name: 'album4' })
+    ),
+    // Should be first in the top 5 albums
+    ...Array.from({ length: 6 }, () =>
+        createStream({ master_metadata_album_album_name: 'album1' })
+    ),
+    ...Array.from({ length: 6 }, () =>
+        createStream({
+            master_metadata_album_album_name: 'album1',
+            master_metadata_track_name: 'track2',
+        })
+    ),
+    ...Array.from({ length: 4 }, () =>
+        createStream({ master_metadata_album_album_name: 'album5' })
+    ),
+    // Should not be aggregated with the album5 of the artist1
+    ...Array.from({ length: 1 }, () =>
+        createStream({
+            master_metadata_album_album_name: 'album5',
+            master_metadata_album_artist_name: 'artist5',
+        })
+    ),
+    // Should be ignored because it is out of the top 5 albums
+    ...Array.from({ length: 2 }, () =>
+        createStream({ master_metadata_album_album_name: 'album6' })
+    ),
+    // Should be ignored because of another year
+    ...Array.from({ length: 5 }, () =>
+        createStream({
+            master_metadata_album_album_name: 'album7',
+            ts: anotherDate,
+        })
+    ),
+    // Should be ignored because album field is null
+    ...Array.from({ length: 100 }, () =>
+        createStream({ master_metadata_album_album_name: null })
+    ),
+    // Should be ignored because artist field is null
+    ...Array.from({ length: 100 }, () =>
+        createStream({ master_metadata_album_artist_name: null })
+    ),
+]
+
+describe('TopAlbums Query', () => {
+    beforeAll(async () => {
+        conn = await createTestConnection()
+    })
+
+    afterAll(() => {
+        closeTestConnection(conn)
+    })
+
+    beforeEach(async () => {
+        await createTestTable(conn, testData)
+    })
+
+    it('should return top albums ordered by stream count desc', async () => {
+        const rows = await testQuery(conn, queryTopAlbums(testYear))
+        expect(rows).toHaveLength(5)
+        expect(rows).toEqual([
+            {
+                album_name: 'album1',
+                artist_name: 'artist1',
+                count_streams: 12,
+                ms_played: 12,
+            },
+            {
+                album_name: 'album2',
+                artist_name: 'artist1',
+                count_streams: 10,
+                ms_played: 10,
+            },
+            {
+                album_name: 'album3',
+                artist_name: 'artist3',
+                count_streams: 8,
+                ms_played: 8,
+            },
+            {
+                album_name: 'album4',
+                artist_name: 'artist1',
+                count_streams: 6,
+                ms_played: 6,
+            },
+            {
+                album_name: 'album5',
+                artist_name: 'artist1',
+                count_streams: 4,
+                ms_played: 4,
+            },
+        ])
+    })
+})

--- a/app/src/components/Charts/SimpleCharts/TopAlbums/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopAlbums/query.tsx
@@ -1,0 +1,25 @@
+import { TABLE } from '../../../../db/queries/constants'
+
+export type TopAlbumsResult = {
+    album_name: string
+    artist_name: string
+    count_streams: number
+    ms_played: number
+}
+
+export function queryTopAlbums(year: number): string {
+    return `
+    SELECT
+      master_metadata_album_album_name AS album_name,
+      master_metadata_album_artist_name AS artist_name,
+      COUNT(*)::DOUBLE AS count_streams,
+      SUM(ms_played)::DOUBLE AS ms_played
+    FROM ${TABLE}
+    WHERE master_metadata_album_album_name IS NOT NULL
+      AND master_metadata_album_artist_name IS NOT NULL
+      AND YEAR(ts::DATE) = ${year}
+    GROUP BY master_metadata_album_album_name, master_metadata_album_artist_name
+    ORDER BY count_streams DESC
+    LIMIT 5
+    `
+}

--- a/app/src/components/Charts/SimpleCharts/TopArtists/TopArtists.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopArtists/TopArtists.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TopArtists } from './TopArtists'
+
+describe('TopArtists Component', () => {
+    it('renders correctly with data', async () => {
+        const numberOfTracks = 10
+        const data = Array.from({ length: numberOfTracks }, (_, i) => ({
+            artist_name: `artist_${i + 1}`,
+            count_streams: i + 1,
+            ms_played: i * 1000 + 1000,
+        }))
+
+        render(<TopArtists data={data} />)
+
+        screen.getByRole('heading', { name: /🎤 Top Artists/ })
+
+        const items = screen.getAllByRole('listitem')
+        expect(items).toHaveLength(numberOfTracks)
+        expect(items[0].textContent).toBe('🥇artist_11s1')
+        expect(items[1].textContent).toBe('🥈artist_22s2')
+        expect(items[2].textContent).toBe('🥉artist_33s3')
+        expect(items[3].textContent).toBe('4️⃣artist_44s4')
+        expect(items[4].textContent).toBe('5️⃣artist_55s5')
+        // Items beyond the top 5 should not display any ranking emoji
+        expect(items[5].textContent).toBe('artist_66s6')
+    })
+})

--- a/app/src/components/Charts/SimpleCharts/TopArtists/TopArtists.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopArtists/TopArtists.tsx
@@ -1,0 +1,47 @@
+import type { FC } from 'react'
+import type { TopArtistsResult } from './query'
+import { memo } from 'react'
+import { formatDuration } from '../../../../utils/formatDuration'
+
+type Props = {
+    data: TopArtistsResult[]
+}
+
+const rankEmojis = ['🥇', '🥈', '🥉', '4️⃣', '5️⃣']
+
+export const TopArtists: FC<Props> = memo(function TopArtists({ data }) {
+    return (
+        <div className="group p-6 bg-white dark:bg-slate-900/80 backdrop-blur-md rounded-2xl border border-gray-300/60 dark:border-slate-700/50 text-gray-900 dark:text-gray-100 transition-all duration-300 hover:shadow-glass-lg hover:scale-[1.01] animate-fade-in">
+            <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                🎤 Top Artists
+            </h3>
+            <ul className="space-y-2" role="list">
+                {data.map((artist, index) => (
+                    <li
+                        key={artist.artist_name}
+                        className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors"
+                        role="listitem"
+                    >
+                        <span className="text-xl flex-shrink-0">
+                            {rankEmojis[index]}
+                        </span>
+                        <div
+                            className="flex-1 min-w-0"
+                            title={artist.artist_name}
+                        >
+                            <div className="font-medium truncate">
+                                {artist.artist_name}
+                            </div>
+                            <div className="text-xs text-gray-500 dark:text-gray-400">
+                                {formatDuration(artist.ms_played).split(' ')[0]}
+                            </div>
+                        </div>
+                        <div className="text-sm font-bold text-brand-purple dark:text-brand-purple flex-shrink-0">
+                            {artist.count_streams.toLocaleString()}
+                        </div>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    )
+})

--- a/app/src/components/Charts/SimpleCharts/TopArtists/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopArtists/index.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+import { queryDBAsJSON } from '../../../../db/queries/queryDB'
+import { queryTopArtists, TopArtistsResult } from './query'
+import { TopArtists as TopArtistsView } from './TopArtists'
+
+export function TopArtists({ year }: { year: number }) {
+    const [data, setData] = useState<TopArtistsResult[]>([])
+
+    useEffect(() => {
+        const fetch = async () => {
+            const sql = queryTopArtists(year)
+            const result = await queryDBAsJSON<TopArtistsResult>(sql)
+            if (result && result.length > 0) setData(result)
+        }
+        fetch()
+    }, [year])
+
+    if (data.length === 0) return null
+    return <TopArtistsView data={data} />
+}

--- a/app/src/components/Charts/SimpleCharts/TopArtists/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/TopArtists/query.test.ts
@@ -1,0 +1,90 @@
+import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
+import { queryTopArtists } from './query'
+import {
+    createTestConnection,
+    closeTestConnection,
+    testQuery,
+    createTestTable,
+    type TestStreamEntry,
+} from '../__tests__/test-utils'
+import type { DuckDBConnection } from '@duckdb/node-api'
+
+let conn: DuckDBConnection
+
+const testYear = 2025
+const testDate = `${testYear}-01-01`
+const anotherDate = `${testYear - 1}-01-01`
+
+const createStream = (overrides = {}) => ({
+    ts: testDate,
+    master_metadata_track_name: 'track1',
+    master_metadata_album_artist_name: 'artist1',
+    ms_played: 1,
+    ...overrides,
+})
+
+const testData: TestStreamEntry[] = [
+    ...Array.from({ length: 10 }, () =>
+        createStream({ master_metadata_album_artist_name: 'artist2' })
+    ),
+    ...Array.from({ length: 8 }, () =>
+        createStream({ master_metadata_album_artist_name: 'artist3' })
+    ),
+    ...Array.from({ length: 6 }, () =>
+        createStream({ master_metadata_album_artist_name: 'artist4' })
+    ),
+    // Should be first in the top 5 artists
+    ...Array.from({ length: 6 }, () =>
+        createStream({ master_metadata_album_artist_name: 'artist1' })
+    ),
+    ...Array.from({ length: 6 }, () =>
+        createStream({
+            master_metadata_album_artist_name: 'artist1',
+            master_metadata_track_name: 'track2',
+        })
+    ),
+    ...Array.from({ length: 4 }, () =>
+        createStream({ master_metadata_album_artist_name: 'artist5' })
+    ),
+    // Should be ignored because it is out of the top 5 artists
+    ...Array.from({ length: 2 }, () =>
+        createStream({ master_metadata_album_artist_name: 'artist6' })
+    ),
+    // Should be ignored because of another year
+    ...Array.from({ length: 5 }, () =>
+        createStream({
+            master_metadata_album_artist_name: 'artist7',
+            ts: anotherDate,
+        })
+    ),
+    // Should be ignored because artist field is null
+    ...Array.from({ length: 100 }, () =>
+        createStream({ master_metadata_album_artist_name: null })
+    ),
+]
+
+describe('TopArtists Query', () => {
+    beforeAll(async () => {
+        conn = await createTestConnection()
+    })
+
+    afterAll(() => {
+        closeTestConnection(conn)
+    })
+
+    beforeEach(async () => {
+        await createTestTable(conn, testData)
+    })
+
+    it('should return top artists ordered by stream count desc', async () => {
+        const rows = await testQuery(conn, queryTopArtists(testYear))
+        expect(rows).toHaveLength(5)
+        expect(rows).toEqual([
+            { artist_name: 'artist1', count_streams: 12, ms_played: 12 },
+            { artist_name: 'artist2', count_streams: 10, ms_played: 10 },
+            { artist_name: 'artist3', count_streams: 8, ms_played: 8 },
+            { artist_name: 'artist4', count_streams: 6, ms_played: 6 },
+            { artist_name: 'artist5', count_streams: 4, ms_played: 4 },
+        ])
+    })
+})

--- a/app/src/components/Charts/SimpleCharts/TopArtists/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopArtists/query.tsx
@@ -1,0 +1,22 @@
+import { TABLE } from '../../../../db/queries/constants'
+
+export type TopArtistsResult = {
+    artist_name: string
+    count_streams: number
+    ms_played: number
+}
+
+export function queryTopArtists(year: number): string {
+    return `
+    SELECT
+      master_metadata_album_artist_name AS artist_name,
+      COUNT(*)::DOUBLE AS count_streams,
+      SUM(ms_played)::DOUBLE AS ms_played
+    FROM ${TABLE}
+    WHERE master_metadata_album_artist_name IS NOT NULL
+      AND YEAR(ts::DATE) = ${year}
+    GROUP BY master_metadata_album_artist_name
+    ORDER BY count_streams DESC
+    LIMIT 5
+    `
+}

--- a/app/src/components/Charts/SimpleCharts/TopTracks/TopTracks.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopTracks/TopTracks.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TopTracks } from './TopTracks'
+
+describe('TopTracks Component', () => {
+    it('renders correctly with data', async () => {
+        const numberOfTracks = 10
+        const data = Array.from({ length: numberOfTracks }, (_, i) => ({
+            track_name: `track_${i + 1}`,
+            artist_name: `artist_${(i % 3) + 1}`,
+            count_streams: i + 1,
+            ms_played: i + 1,
+        }))
+
+        render(<TopTracks data={data} />)
+
+        screen.getByRole('heading', { name: /🎵 Top Tracks/ })
+
+        const items = screen.getAllByRole('listitem')
+        expect(items).toHaveLength(numberOfTracks)
+        expect(items[0].textContent).toBe('🥇track_1artist_11')
+        expect(items[1].textContent).toBe('🥈track_2artist_22')
+        expect(items[2].textContent).toBe('🥉track_3artist_33')
+        expect(items[3].textContent).toBe('4️⃣track_4artist_14')
+        expect(items[4].textContent).toBe('5️⃣track_5artist_25')
+        // Items beyond the top 5 should not display any ranking emoji
+        expect(items[5].textContent).toBe('track_6artist_36')
+    })
+})

--- a/app/src/components/Charts/SimpleCharts/TopTracks/TopTracks.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopTracks/TopTracks.tsx
@@ -1,0 +1,46 @@
+import type { FC } from 'react'
+import type { TopTracksResult } from './query'
+import { memo } from 'react'
+
+type Props = {
+    data: TopTracksResult[]
+}
+
+const rankEmojis = ['🥇', '🥈', '🥉', '4️⃣', '5️⃣']
+
+export const TopTracks: FC<Props> = memo(function TopTracks({ data }) {
+    return (
+        <div className="group p-6 bg-white dark:bg-slate-900/80 backdrop-blur-md rounded-2xl border border-gray-300/60 dark:border-slate-700/50 text-gray-900 dark:text-gray-100 transition-all duration-300 hover:shadow-glass-lg hover:scale-[1.01] animate-fade-in">
+            <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                🎵 Top Tracks
+            </h3>
+            <ul className="space-y-2" role="list">
+                {data.map((track, index) => (
+                    <li
+                        key={`${track.track_name}-${track.artist_name}`}
+                        className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors"
+                        role="listitem"
+                    >
+                        <span className="text-xl flex-shrink-0">
+                            {rankEmojis[index]}
+                        </span>
+                        <div
+                            className="flex-1 min-w-0"
+                            title={track.track_name}
+                        >
+                            <div className="font-medium truncate">
+                                {track.track_name}
+                            </div>
+                            <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                                {track.artist_name}
+                            </div>
+                        </div>
+                        <div className="text-sm font-bold text-brand-purple dark:text-brand-purple flex-shrink-0">
+                            {track.count_streams.toLocaleString()}
+                        </div>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    )
+})

--- a/app/src/components/Charts/SimpleCharts/TopTracks/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopTracks/index.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+import { queryDBAsJSON } from '../../../../db/queries/queryDB'
+import { queryTopTracks, TopTracksResult } from './query'
+import { TopTracks as TopTracksView } from './TopTracks'
+
+export function TopTracks({ year }: { year: number }) {
+    const [data, setData] = useState<TopTracksResult[]>([])
+
+    useEffect(() => {
+        const fetch = async () => {
+            const sql = queryTopTracks(year)
+            const result = await queryDBAsJSON<TopTracksResult>(sql)
+            if (result && result.length > 0) setData(result)
+        }
+        fetch()
+    }, [year])
+
+    if (data.length === 0) return null
+    return <TopTracksView data={data} />
+}

--- a/app/src/components/Charts/SimpleCharts/TopTracks/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/TopTracks/query.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
+import { queryTopTracks } from './query'
+import {
+    createTestConnection,
+    closeTestConnection,
+    testQuery,
+    createTestTable,
+    type TestStreamEntry,
+} from '../__tests__/test-utils'
+import type { DuckDBConnection } from '@duckdb/node-api'
+
+let conn: DuckDBConnection
+
+const testYear = 2025
+const testDate = `${testYear}-01-01`
+const anotherDate = `${testYear - 1}-01-01`
+
+const createStream = (overrides = {}) => ({
+    ts: testDate,
+    master_metadata_track_name: 'track1',
+    master_metadata_album_artist_name: 'artist1',
+    ms_played: 1,
+    ...overrides,
+})
+
+const testData: TestStreamEntry[] = [
+    ...Array.from({ length: 10 }, () =>
+        createStream({ master_metadata_track_name: 'track2' })
+    ),
+    ...Array.from({ length: 8 }, () =>
+        createStream({ master_metadata_track_name: 'track3' })
+    ),
+    ...Array.from({ length: 6 }, () =>
+        createStream({ master_metadata_track_name: 'track4' })
+    ),
+    // Should be first in the top 5 tracks
+    ...Array.from({ length: 12 }, () =>
+        createStream({ master_metadata_track_name: 'track1' })
+    ),
+    ...Array.from({ length: 4 }, () =>
+        createStream({ master_metadata_track_name: 'track5' })
+    ),
+    // Should be ignored because it is out of the top 5 tracks
+    ...Array.from({ length: 2 }, () =>
+        createStream({ master_metadata_track_name: 'track6' })
+    ),
+    // Should be ignored because of another year
+    ...Array.from({ length: 10 }, () =>
+        createStream({ master_metadata_track_name: 'track4', ts: anotherDate })
+    ),
+    // Should be ignored because track field is null
+    ...Array.from({ length: 100 }, () =>
+        createStream({ master_metadata_track_name: null })
+    ),
+    // Should be ignored because artist field is null
+    ...Array.from({ length: 100 }, () =>
+        createStream({ master_metadata_album_artist_name: null })
+    ),
+]
+
+describe('TopTracks Query', () => {
+    beforeAll(async () => {
+        conn = await createTestConnection()
+    })
+
+    afterAll(() => {
+        closeTestConnection(conn)
+    })
+
+    beforeEach(async () => {
+        await createTestTable(conn, testData)
+    })
+
+    it('should return top tracks ordered by stream count desc', async () => {
+        const rows = await testQuery(conn, queryTopTracks(testYear))
+        expect(rows).toHaveLength(5)
+        expect(rows).toEqual([
+            {
+                track_name: 'track1',
+                artist_name: 'artist1',
+                count_streams: 12,
+                ms_played: 12,
+            },
+            {
+                track_name: 'track2',
+                artist_name: 'artist1',
+                count_streams: 10,
+                ms_played: 10,
+            },
+            {
+                track_name: 'track3',
+                artist_name: 'artist1',
+                count_streams: 8,
+                ms_played: 8,
+            },
+            {
+                track_name: 'track4',
+                artist_name: 'artist1',
+                count_streams: 6,
+                ms_played: 6,
+            },
+            {
+                track_name: 'track5',
+                artist_name: 'artist1',
+                count_streams: 4,
+                ms_played: 4,
+            },
+        ])
+    })
+})

--- a/app/src/components/Charts/SimpleCharts/TopTracks/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopTracks/query.tsx
@@ -1,0 +1,25 @@
+import { TABLE } from '../../../../db/queries/constants'
+
+export type TopTracksResult = {
+    track_name: string
+    artist_name: string
+    count_streams: number
+    ms_played: number
+}
+
+export function queryTopTracks(year: number): string {
+    return `
+    SELECT
+      master_metadata_track_name AS track_name,
+      master_metadata_album_artist_name AS artist_name,
+      COUNT(*)::DOUBLE AS count_streams,
+      SUM(ms_played)::DOUBLE AS ms_played
+    FROM ${TABLE}
+    WHERE master_metadata_track_name IS NOT NULL
+      AND master_metadata_album_artist_name IS NOT NULL
+      AND YEAR(ts::DATE) = ${year}
+    GROUP BY master_metadata_track_name, master_metadata_album_artist_name
+    ORDER BY count_streams DESC
+    LIMIT 5
+    `
+}

--- a/app/src/components/Charts/SimpleCharts/__tests__/test-utils.ts
+++ b/app/src/components/Charts/SimpleCharts/__tests__/test-utils.ts
@@ -6,6 +6,7 @@ export type TestStreamEntry = {
     track_uri?: string
     master_metadata_track_name?: string
     master_metadata_album_artist_name?: string
+    master_metadata_album_album_name?: string
     ms_played?: number
     reason_end?: string
     platform?: string
@@ -25,6 +26,7 @@ export async function createTestTable(
             track_uri TEXT,
             master_metadata_track_name TEXT,
             master_metadata_album_artist_name TEXT,
+            master_metadata_album_album_name TEXT,
             ms_played INTEGER,
             reason_end TEXT,
             platform TEXT
@@ -46,6 +48,10 @@ export async function createTestTable(
 
         if (entry.master_metadata_album_artist_name)
             appender.appendVarchar(entry.master_metadata_album_artist_name)
+        else appender.appendNull()
+
+        if (entry.master_metadata_album_album_name)
+            appender.appendVarchar(entry.master_metadata_album_album_name)
         else appender.appendNull()
 
         if (entry.ms_played) appender.appendInteger(entry.ms_played)

--- a/app/src/components/Charts/SimpleView.test.tsx
+++ b/app/src/components/Charts/SimpleView.test.tsx
@@ -50,6 +50,18 @@ import {
     type FavoriteWeekdayResult,
     queryFavoriteWeekday,
 } from './SimpleCharts/FavoriteWeekday/query'
+import {
+    type TopTracksResult,
+    queryTopTracks,
+} from './SimpleCharts/TopTracks/query'
+import {
+    type TopArtistsResult,
+    queryTopArtists,
+} from './SimpleCharts/TopArtists/query'
+import {
+    type TopAlbumsResult,
+    queryTopAlbums,
+} from './SimpleCharts/TopAlbums/query'
 
 const summarizedDataMock: SummarizeDataQueryResult[] = [
     {
@@ -57,6 +69,32 @@ const summarizedDataMock: SummarizeDataQueryResult[] = [
         max_datetime: '1734134400000',
         max_monthly_duration: 39959692,
         min_datetime: '1577836800000',
+    },
+]
+
+const topTracksMock: TopTracksResult[] = [
+    {
+        track_name: 'Track 1',
+        artist_name: 'Artist 1',
+        count_streams: 1000,
+        ms_played: 1000,
+    },
+]
+
+const topArtistsMock: TopArtistsResult[] = [
+    {
+        artist_name: 'Artist 1',
+        count_streams: 1000,
+        ms_played: 1000,
+    },
+]
+
+const topAlbumsMock: TopAlbumsResult[] = [
+    {
+        album_name: 'Album 1',
+        artist_name: 'Artist 1',
+        count_streams: 1000,
+        ms_played: 1000,
     },
 ]
 
@@ -156,6 +194,12 @@ const favoriteWeekdayMock: FavoriteWeekdayResult[] = [
 it('renders all SimpleView', async () => {
     vi.spyOn(db, 'queryDBAsJSON').mockImplementation((query) => {
         if (query === summarizeQuery) return Promise.resolve(summarizedDataMock)
+        if (query === queryTopTracks(2024))
+            return Promise.resolve(topTracksMock)
+        if (query === queryTopArtists(2024))
+            return Promise.resolve(topArtistsMock)
+        if (query === queryTopAlbums(2024))
+            return Promise.resolve(topAlbumsMock)
         if (query === queryConcentrationScore(2024))
             return Promise.resolve(concentrationMock)
         if (query === queryDiversityScore(2024))
@@ -191,6 +235,9 @@ it('renders all SimpleView', async () => {
     })
 
     // TODO: test funfact rendering
+    await screen.findByRole('heading', { name: '🎵 Top Tracks' })
+    await screen.findByRole('heading', { name: '🎤 Top Artists' })
+    await screen.findByRole('heading', { name: '💿 Top Albums' })
     await screen.findByRole('heading', { name: '📊 Concentration Score' })
     await screen.findByRole('heading', { name: '🎨 Loyalty vs Discovery' })
     await screen.findByRole('heading', { name: '⏰ Listening Rhythm' })

--- a/app/src/components/Charts/SimpleView.tsx
+++ b/app/src/components/Charts/SimpleView.tsx
@@ -10,6 +10,9 @@ import { FunFacts } from './SimpleCharts/FunFacts'
 import { PrincipalPlatform } from './SimpleCharts/PrincipalPlatform'
 import { DiversityScore } from './SimpleCharts/DiversityScore'
 import { FavoriteWeekday } from './SimpleCharts/FavoriteWeekday'
+import { TopArtists } from './SimpleCharts/TopArtists'
+import { TopAlbums } from './SimpleCharts/TopAlbums'
+import { TopTracks } from './SimpleCharts/TopTracks'
 import { RangeSlider } from '../RangeSlider/RangeSlider'
 import { queryDBAsJSON } from '../../db/queries/queryDB'
 import {
@@ -52,6 +55,9 @@ export function SimpleView() {
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                <TopTracks year={year} />
+                <TopArtists year={year} />
+                <TopAlbums year={year} />
                 <ConcentrationScore year={year} />
                 <DiversityScore year={year} />
                 <ListeningRhythm year={year} />


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).

## 🔇 Problem

Tops are only available on the DetailedView. 

## 🎹 Proposal

Add top 5 for Tracks, Artists and Albums.

## 🎶 Comments

<!-- Additional information, tips or problems encountered. -->

## 🎤 Test

| Dark mode | Light Mode | 
|------------|------------|
|  <img width="918" height="421" alt="top 5 in dark mode" src="https://github.com/user-attachments/assets/bfdec20f-7289-4871-8f7a-900383f15bfd" /> |  <img width="918" height="421" alt="top 5 in light mode" src="https://github.com/user-attachments/assets/a6f80c3d-1082-4845-a3d6-bd61da59fe3a" /> |

