### PR TITLE
feat: add a chart to show artists discovered over time

### DIFF
--- a/app/src/components/Charts/DetailedCharts/ArtistDiscovery/ArtistDiscovery.test.tsx
+++ b/app/src/components/Charts/DetailedCharts/ArtistDiscovery/ArtistDiscovery.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import * as queries from './query'
+import * as query from '../../../../db/queries/queryDB'
+import * as db from '../../../../db/getDB'
+
+import { ArtistDiscovery } from '.'
+
+const artistDiscoveryData: queries.ArtistDiscoveryQueryResult[] = [
+    {
+        year: 2020,
+        new_artists: 2,
+        cumulative_artists: 2,
+        avg_listens_per_artist: 1.5,
+    },
+    {
+        year: 2021,
+        new_artists: 1,
+        cumulative_artists: 3,
+        avg_listens_per_artist: 1,
+    },
+    {
+        year: 2022,
+        new_artists: 0,
+        cumulative_artists: 3,
+        avg_listens_per_artist: 0,
+    },
+    {
+        year: 2023,
+        new_artists: 0,
+        cumulative_artists: 3,
+        avg_listens_per_artist: 2,
+    },
+]
+
+describe('ArtistDiscovery Component', () => {
+    beforeEach(() => {
+        vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue(artistDiscoveryData)
+
+        vi.spyOn(db, 'getDB').mockResolvedValue({
+            db: vi.fn(),
+            conn: vi.fn(),
+        } as unknown as Awaited<ReturnType<typeof db.getDB>>)
+    })
+
+    it('should render the cumulative mode by default', async () => {
+        const { container } = render(<ArtistDiscovery />)
+
+        await screen.findByText('Artists Discovered Over Time')
+        await screen.findByRole('button', {
+            name: /cumulative number of unique artists/i,
+        })
+
+        expect(query.queryDBAsJSON).toHaveBeenCalledTimes(1)
+
+        const svg = container.querySelector('svg')
+        expect(svg).toBeTruthy()
+    })
+
+    it('should switch the mode on click', async () => {
+        render(<ArtistDiscovery />)
+
+        const button = await screen.findByRole('button', {
+            name: /cumulative number of unique artists/i,
+        })
+
+        fireEvent.click(button)
+
+        await screen.findByRole('button', {
+            name: /newly discovered artists/i,
+        })
+
+        fireEvent.click(button)
+
+        await screen.findByRole('button', {
+            name: /cumulative number of unique artists/i,
+        })
+    })
+})

--- a/app/src/components/Charts/DetailedCharts/ArtistDiscovery/fixtures/seed.json
+++ b/app/src/components/Charts/DetailedCharts/ArtistDiscovery/fixtures/seed.json
@@ -1,0 +1,14 @@
+[
+    { "ts": "2020-01-10T10:00:00Z", "artist_name": "artist_a" },
+    { "ts": "2020-02-15T12:00:00Z", "artist_name": "artist_a" },
+    { "ts": "2020-03-20T14:00:00Z", "artist_name": "artist_b" },
+
+    { "ts": "2021-01-05T09:00:00Z", "artist_name": "artist_a" },
+    { "ts": "2021-02-10T11:00:00Z", "artist_name": "artist_b" },
+    { "ts": "2021-03-12T13:00:00Z", "artist_name": "artist_c" },
+
+    { "ts": "2023-04-01T08:00:00Z", "artist_name": "artist_a" },
+    { "ts": "2023-05-01T08:00:00Z", "artist_name": "artist_a" },
+    { "ts": "2023-06-01T08:00:00Z", "artist_name": "artist_b" },
+    { "ts": "2023-07-01T08:00:00Z", "artist_name": "artist_b" }
+]

--- a/app/src/components/Charts/DetailedCharts/ArtistDiscovery/index.tsx
+++ b/app/src/components/Charts/DetailedCharts/ArtistDiscovery/index.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+import { queryDBAsJSON } from '../../../../db/queries/queryDB'
+import { queryArtistDiscovery, type ArtistDiscoveryQueryResult } from './query'
+import { ArtistDiscoveryPlot } from './plot'
+
+export function ArtistDiscovery() {
+    const [data, setData] = useState<ArtistDiscoveryQueryResult[]>([])
+
+    useEffect(() => {
+        const fetchData = async () => {
+            const result = await queryDBAsJSON<ArtistDiscoveryQueryResult>(
+                queryArtistDiscovery()
+            )
+            setData(result)
+        }
+        fetchData()
+    }, [])
+
+    if (data.length === 0) return null
+
+    return (
+        <div className="group p-6 my-4 bg-white dark:bg-slate-900/80 backdrop-blur-md rounded-2xl border border-gray-300/60 dark:border-slate-700/50 text-gray-900 dark:text-gray-100 transition-all duration-300 hover:shadow-glass-lg hover:scale-[1.01] animate-fade-in">
+            <ArtistDiscoveryPlot data={data} />
+        </div>
+    )
+}

--- a/app/src/components/Charts/DetailedCharts/ArtistDiscovery/plot.tsx
+++ b/app/src/components/Charts/DetailedCharts/ArtistDiscovery/plot.tsx
@@ -1,0 +1,144 @@
+import * as Plot from '@observablehq/plot'
+import { useEffect, useRef } from 'react'
+import type { ArtistDiscoveryQueryResult } from './query'
+import * as d3 from 'd3'
+
+import { useState } from 'react'
+
+export function ArtistDiscoveryPlot({
+    data,
+}: {
+    data: ArtistDiscoveryQueryResult[]
+}) {
+    const containerRef = useRef<HTMLDivElement>(null)
+    const [mode, setMode] = useState<'cumulative' | 'new'>('cumulative')
+
+    function toggleMode() {
+        setMode(mode === 'cumulative' ? 'new' : 'cumulative')
+    }
+
+    useEffect(() => {
+        if (!data?.length || !containerRef.current) return
+
+        const vMain = (d: ArtistDiscoveryQueryResult) => d.cumulative_artists
+        const vAvg = (d: ArtistDiscoveryQueryResult) => d.avg_listens_per_artist
+
+        const visibleSeries =
+            mode === 'cumulative'
+                ? data.map(vMain)
+                : data.map((d) => d.new_artists)
+
+        const maxVisible = d3.max(visibleSeries)!
+
+        const yAvg = d3.scaleLinear<number, number>(
+            d3.extent(data, vAvg) as [number, number],
+            [0, maxVisible]
+        )
+
+        const marks = [
+            Plot.axisY({
+                anchor: 'right',
+                label: 'Number of Artists',
+            }),
+
+            Plot.axisY(yAvg.ticks(), {
+                anchor: 'left',
+                label: 'Avg listens per artist',
+                y: yAvg,
+                tickFormat: yAvg.tickFormat(),
+            }),
+
+            Plot.ruleY([0]),
+        ]
+
+        if (mode === 'cumulative') {
+            marks.push(
+                Plot.areaY(data, {
+                    x: 'year',
+                    y: 'cumulative_artists',
+                    fill: 'url(#gradient-cumulative)',
+                    fillOpacity: 0.3,
+                }),
+                Plot.lineY(data, {
+                    x: 'year',
+                    y: 'cumulative_artists',
+                    stroke: '#8b5cf6',
+                    strokeWidth: 2.5,
+                }),
+                Plot.dot(data, {
+                    x: 'year',
+                    y: 'cumulative_artists',
+                    fill: '#8b5cf6',
+                    r: 4,
+                })
+            )
+        }
+
+        if (mode === 'new') {
+            marks.push(
+                Plot.lineY(data, {
+                    x: 'year',
+                    y: 'new_artists',
+                    stroke: '#06b6d4',
+                    strokeWidth: 2,
+                }),
+                Plot.dot(data, {
+                    x: 'year',
+                    y: 'new_artists',
+                    fill: '#06b6d4',
+                    r: 3,
+                })
+            )
+        }
+
+        marks.push(
+            Plot.lineY(
+                data,
+                Plot.mapY((D: number[]) => D.map(yAvg), {
+                    x: 'year',
+                    y: 'avg_listens_per_artist',
+                    stroke: '#f59e0b',
+                    strokeWidth: 2.5,
+                    strokeDasharray: '5,3',
+                })
+            )
+        )
+
+        const plot = Plot.plot({
+            title: 'Artists Discovered Over Time',
+            subtitle: `${mode === 'cumulative' ? 'Cumulative unique artists' : 'New discoveries'} and avg listens per artist per year`,
+            width: 800,
+            height: 400,
+            marginLeft: 90,
+            marginRight: 120,
+            x: { label: 'Year', tickFormat: 'd' },
+            y: { label: null, grid: true },
+            marks,
+        })
+
+        containerRef.current.innerHTML = ''
+        containerRef.current.append(plot)
+
+        return () => plot.remove()
+    }, [data, mode])
+
+    const modeLabel = mode == 'cumulative' ? '↗️ Cumulative' : '🆕 New'
+    const modeAriaLabel =
+        mode === 'cumulative'
+            ? 'Show cumulative number of unique artists'
+            : 'Show newly discovered artists'
+
+    return (
+        <>
+            <button
+                onClick={toggleMode}
+                className="absolute top-2 right-2 px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-slate-800/80 backdrop-blur-sm rounded-full hover:bg-brand-purple/20 hover:text-brand-purple dark:hover:bg-brand-purple/20 dark:hover:text-brand-purple transition-all duration-300 border border-gray-300/50 dark:border-slate-700/50"
+                aria-label={modeAriaLabel}
+            >
+                {modeLabel}
+            </button>
+
+            <div ref={containerRef} />
+        </>
+    )
+}

--- a/app/src/components/Charts/DetailedCharts/ArtistDiscovery/query.test.tsx
+++ b/app/src/components/Charts/DetailedCharts/ArtistDiscovery/query.test.tsx
@@ -1,0 +1,64 @@
+import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
+import { queryArtistDiscovery } from './query'
+import { DuckDBConnection, DuckDBValue } from '@duckdb/node-api'
+import { TABLE } from '../../../../db/queries/constants'
+
+const seedPath =
+    'src/components/Charts/DetailedCharts/ArtistDiscovery/fixtures/seed.json'
+
+let conn: DuckDBConnection
+
+describe.only('ArtistDiscovery Query', () => {
+    beforeAll(async () => {
+        conn = await DuckDBConnection.create()
+    })
+
+    afterAll(() => {
+        conn.closeSync()
+    })
+
+    beforeEach(async () => {
+        await conn.run(
+            `CREATE OR REPLACE TABLE ${TABLE} AS (FROM '${seedPath}')`
+        )
+    })
+
+    it.only('should return one row per year with correct discovery metrics', async () => {
+        const result = await conn.runAndReadAll(queryArtistDiscovery())
+        const rows = result
+            .getRowObjects()
+            .toSorted(
+                (
+                    a: Record<string, DuckDBValue>,
+                    b: Record<string, DuckDBValue>
+                ) => (a.year as number) - (b.year as number)
+            )
+
+        expect(rows).toEqual([
+            {
+                year: 2020,
+                new_artists: 2,
+                cumulative_artists: 2,
+                avg_listens_per_artist: 1.5,
+            },
+            {
+                year: 2021,
+                new_artists: 1,
+                cumulative_artists: 3,
+                avg_listens_per_artist: 1,
+            },
+            {
+                year: 2022,
+                new_artists: 0,
+                cumulative_artists: 3,
+                avg_listens_per_artist: 0,
+            },
+            {
+                year: 2023,
+                new_artists: 0,
+                cumulative_artists: 3,
+                avg_listens_per_artist: 2,
+            },
+        ])
+    })
+})

--- a/app/src/components/Charts/DetailedCharts/ArtistDiscovery/query.tsx
+++ b/app/src/components/Charts/DetailedCharts/ArtistDiscovery/query.tsx
@@ -1,0 +1,77 @@
+import { TABLE } from '../../../../db/queries/constants'
+
+export type ArtistDiscoveryQueryResult = {
+    year: number
+    new_artists: number
+    cumulative_artists: number
+    avg_listens_per_artist: number
+}
+
+export function queryArtistDiscovery(): string {
+    return `
+    WITH artist_first_year AS (
+      SELECT
+        artist_name AS artist,
+        MIN(YEAR(ts::DATE)) AS discovery_year
+      FROM ${TABLE}
+      WHERE artist_name IS NOT NULL
+      GROUP BY artist_name
+    ),
+    yearly_discoveries AS (
+      SELECT
+        discovery_year AS year,
+        COUNT(*) AS new_artists
+      FROM artist_first_year
+      GROUP BY discovery_year
+    ),
+    year_bounds AS (
+      SELECT
+        MIN(YEAR(ts::DATE)) AS min_year,
+        MAX(YEAR(ts::DATE)) AS max_year
+      FROM ${TABLE}
+    ),
+    all_years AS (
+      SELECT year
+      FROM year_bounds,
+      generate_series(min_year, max_year) AS t(year)
+    ),
+    filled_years AS (
+      SELECT
+        all_years.year,
+        COALESCE(yearly_discoveries.new_artists, 0) AS new_artists
+      FROM all_years all_years
+      LEFT JOIN yearly_discoveries ON all_years.year = yearly_discoveries.year
+    ),
+    cumulative AS (
+      SELECT
+        year,
+        new_artists,
+        SUM(new_artists) OVER (ORDER BY year) AS cumulative_artists
+      FROM filled_years
+    ),
+    artist_listens AS (
+      SELECT
+        YEAR(ts::DATE) AS year,
+        artist_name AS artist,
+        COUNT(*) AS listen_count
+      FROM ${TABLE}
+      WHERE artist_name IS NOT NULL
+      GROUP BY YEAR(ts::DATE), artist_name
+    ),
+    avg_listens AS (
+      SELECT
+        year,
+        AVG(listen_count) AS avg_listens_per_artist
+      FROM artist_listens
+      GROUP BY year
+    )
+    SELECT
+      cumulative.year::INT AS year,
+      cumulative.new_artists::DOUBLE AS new_artists,
+      cumulative.cumulative_artists::DOUBLE AS cumulative_artists,
+      COALESCE(avg_listens.avg_listens_per_artist, 0)::DOUBLE AS avg_listens_per_artist
+    FROM cumulative
+    LEFT JOIN avg_listens using(year)
+    ORDER BY cumulative.year
+  `
+}

--- a/app/src/components/Charts/DetailedView.test.tsx
+++ b/app/src/components/Charts/DetailedView.test.tsx
@@ -39,6 +39,11 @@ import {
     streamPerDayOfWeekQueryByYear,
 } from './DetailedCharts/StreamPerDayOfWeek/query'
 
+import {
+    type ArtistDiscoveryQueryResult,
+    queryArtistDiscovery,
+} from './DetailedCharts/ArtistDiscovery/query'
+
 const summarizedDataMock: SummarizeDataQueryResult[] = [
     {
         max_count_hourly_stream: 1234,
@@ -337,6 +342,21 @@ const streamPerDayOfWeekResultMock: StreamPerDayOfWeekQueryResult[] = [
     },
 ]
 
+const artistDiscoveryResultMock: ArtistDiscoveryQueryResult[] = [
+    {
+        year: 2023,
+        new_artists: 50,
+        cumulative_artists: 50,
+        avg_listens_per_artist: 25.5,
+    },
+    {
+        year: 2024,
+        new_artists: 30,
+        cumulative_artists: 80,
+        avg_listens_per_artist: 18.3,
+    },
+]
+
 it('renders all Charts', async () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
@@ -352,6 +372,8 @@ it('renders all Charts', async () => {
             return Promise.resolve(topTracksResultMock)
         if (query === queryTopArtistsByYear(2024))
             return Promise.resolve(topArtistsResultMock)
+        if (query === queryArtistDiscovery())
+            return Promise.resolve(artistDiscoveryResultMock)
         if (query === queryTop10Evolution())
             return Promise.resolve(top10EvolutionResultMock)
         if (query === streamPerDayOfWeekQueryByYear(2024))

--- a/app/src/components/Charts/DetailedView.tsx
+++ b/app/src/components/Charts/DetailedView.tsx
@@ -17,6 +17,7 @@ import { TopAlbums } from './DetailedCharts/TopAlbums'
 import { Streaks } from './DetailedCharts/Streaks'
 import { Top10Evolution } from './DetailedCharts/Top10Evolution'
 import { StreamPerDayOfWeek } from './DetailedCharts/StreamPerDayOfWeek'
+import { ArtistDiscovery } from './DetailedCharts/ArtistDiscovery'
 import { DuckDBShell } from '../DuckDBShell/DuckDBShell'
 
 export function DetailedView() {
@@ -73,6 +74,7 @@ export function DetailedView() {
                     <TopTracks year={year} />
                     <TopArtists year={year} />
                     <TopAlbums year={year} />
+                    <ArtistDiscovery />
                 </>
             )}
 


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).

## 🔇 Problem

<!-- The need or intention covered by this Pull Request. -->

## 🎹 Proposal


- add artists discovered over time
- add avg listens/artists on the same chart
   - use a different scale for the avg (y2)
- add artists discovered by year
  - add a toggle to switch between "by year" and "cumulative"

adapat the scale to each mode

## 🎶 Comments

| artists discovered over time | artists discovered by year |
|-|-|
| <img width="781" height="439" alt="artists discovered over time" src="https://github.com/user-attachments/assets/d4c32536-baa4-4bea-a48f-4a6c5ce5b7dd" /> |  <img width="781" height="439" alt="artists discovered by year" src="https://github.com/user-attachments/assets/d861e9f6-ba28-4130-b3ce-f13203c0e993" /> |

## 🎤 Test

<!-- Instructions for reproducing the problem and how you tested the fix. -->
