### PR TITLE
refactor(streamProvider): use satisfies instead of unsafe cast in SpotifyStreamProvider.transform()

### DIFF
--- a/app/src/streamProvider/SpotifyStreamProvider/SpotifyStreamProvider.ts
+++ b/app/src/streamProvider/SpotifyStreamProvider/SpotifyStreamProvider.ts
@@ -37,22 +37,21 @@ export class SpotifyStreamProvider extends StreamProvider<SpotifyRawStreamRecord
      * @returns Array of stream records in canonical format
      */
     transform(rawData: SpotifyRawStreamRecord[]): StreamRecord[] {
-        const data = rawData.map(
+        return rawData.map(
             ({
                 spotify_track_uri,
                 master_metadata_track_name,
                 master_metadata_album_artist_name,
                 master_metadata_album_album_name,
                 ...rest
-            }) => ({
-                ...rest,
-                track_uri: spotify_track_uri,
-                track_name: master_metadata_track_name,
-                artist_name: master_metadata_album_artist_name,
-                album_name: master_metadata_album_album_name,
-            })
+            }) =>
+                ({
+                    ...rest,
+                    track_uri: spotify_track_uri,
+                    track_name: master_metadata_track_name,
+                    artist_name: master_metadata_album_artist_name,
+                    album_name: master_metadata_album_album_name,
+                }) satisfies StreamRecord
         )
-
-        return data as StreamRecord[]
     }
 }


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

`SpotifyStreamProvider.transform()` used `as StreamRecord[]` to bypass TypeScript's type checker. This cast silently masks any future mismatch between `SpotifyRawStreamRecord` and `StreamRecord` if either interface evolves.

## 🎹 Proposal

Replaces `as StreamRecord[]` with `satisfies StreamRecord` on the mapped object. TypeScript now verifies at compile time that all required fields of `StreamRecord` are present, without a cast.

`...rest` is preserved so that any extra columns from the raw record (e.g. provider-specific fields, or new fields added in future Spotify export formats) are forwarded through to the output. `StreamRecord` already carries an index signature (`[key: string]: unknown`) to accommodate this.

## 🎶 Comments

`satisfies` checks the *shape* at the point of the expression without widening the type, making this strictly safer than the original cast while keeping the passthrough behaviour.

## 🎤 Test

- Run `moon run app:test -- src/streamProvider/SpotifyStreamProvider` — all 16 tests pass, including the `should preserve extra columns` integration test.