### PR TITLE
feat(streamProvider): throw descriptive error when Deezer sheet is missing

### DIFF
--- a/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.test.ts
+++ b/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.test.ts
@@ -191,9 +191,35 @@ describe('DeezerStreamProvider', () => {
             )
 
             await expect(provider.readFile(file)).rejects.toThrow(
-                'sheet not found'
+                '10_listeningHistory'
             )
             expect(mockDB.dropFile).toHaveBeenCalledWith('_deezer_tmp.xlsx')
+        })
+
+        it('should throw a descriptive error when the DuckDB query fails', async () => {
+            const mockConn = {
+                query: vi.fn().mockRejectedValue(new Error('unknown sheet')),
+            }
+            const mockDB = {
+                registerFileBuffer: vi.fn().mockResolvedValue(undefined),
+                dropFile: vi.fn().mockResolvedValue(undefined),
+            }
+
+            const getDB = await import('../../db/getDB')
+            vi.spyOn(getDB, 'getDB').mockResolvedValue({
+                db: mockDB as never,
+                conn: mockConn as never,
+            })
+
+            const file = mockFile(
+                new ArrayBuffer(8),
+                'deezer-data_1234567890.xlsx',
+                { type: XLSX_TYPE }
+            )
+
+            await expect(provider.readFile(file)).rejects.toThrow(
+                'Failed to read Deezer export'
+            )
         })
     })
 

--- a/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.ts
+++ b/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.ts
@@ -25,6 +25,12 @@ export class DeezerStreamProvider extends StreamProvider<DeezerRawStreamRecord> 
             return result
                 .toArray()
                 .map((row) => row.toJSON() as DeezerRawStreamRecord)
+        } catch (error) {
+            throw new Error(
+                `Failed to read Deezer export: sheet "${SHEET_NAME}" not found. ` +
+                    `Make sure the file is a valid Deezer listening history export.`,
+                { cause: error }
+            )
         } finally {
             await db.dropFile(TMP_FILE_NAME)
         }


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

When DuckDB fails to read the Deezer XLSX (e.g. unexpected sheet name in a future export format), the raw internal error bubbles up to the UI with no actionable context.

## 🎹 Proposal

Adds a `catch` block inside `readFile()` that rethrows with a user-friendly message including the expected sheet name (`10_listeningHistory`). The existing `finally` block (temp file cleanup) is preserved and still always runs.

Updates the existing error propagation test and adds a dedicated test for the descriptive message.

## 🎶 Comments

The `catch` is intentionally broad — any DuckDB error during the query is wrapped, since the most likely cause is always a missing or renamed sheet.

## 🎤 Test

- Run `moon run app:test -- src/streamProvider/DeezerStreamProvider` — all tests pass.