### PR TITLE
refactor(db): centralize year SQL condition building with buildYearCondition

### DIFF
--- a/app/src/components/Charts/DetailedCharts/StreamPerDayOfWeek/query.tsx
+++ b/app/src/components/Charts/DetailedCharts/StreamPerDayOfWeek/query.tsx
@@ -1,8 +1,9 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryStreamPerDayOfWeek from './StreamPerDayOfWeek.sql?raw'
 
 export function streamPerDayOfWeekQueryByYear(year: number | undefined) {
-    const yearCondition = year ? `YEAR(ts:: DATETIME) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryStreamPerDayOfWeek
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/DetailedCharts/StreamPerHour/query.tsx
+++ b/app/src/components/Charts/DetailedCharts/StreamPerHour/query.tsx
@@ -1,8 +1,9 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryStreamPerHour from './StreamPerHour.sql?raw'
 
 export function queryStreamsPerHoursByYear(year: number | undefined) {
-    const yearCondition = year ? `YEAR(ts::DATETIME) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryStreamPerHour
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/DetailedCharts/StreamPerMonth/query.tsx
+++ b/app/src/components/Charts/DetailedCharts/StreamPerMonth/query.tsx
@@ -1,8 +1,9 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryStreamPerMonth from './StreamPerMonth.sql?raw'
 
 export function queryByYear(year: number | undefined) {
-    const yearCondition = year ? `YEAR(ts::DATE) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryStreamPerMonth
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/DetailedCharts/SummaryPerYear/query.tsx
+++ b/app/src/components/Charts/DetailedCharts/SummaryPerYear/query.tsx
@@ -1,11 +1,14 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQuerySummaryPerYear from './SummaryPerYear.sql?raw'
 
 export function summarizePerYearQuery(year: number | undefined) {
-    const yearCondition = year ? `ranked_streams.year = ${year}` : '1=1'
     return sqlQuerySummaryPerYear
         .replaceAll('${table}', TABLE)
-        .replaceAll('${year_condition}', yearCondition)
+        .replaceAll(
+            '${year_condition}',
+            buildYearCondition(year, 'ranked_streams.year')
+        )
 }
 
 export type SummaryPerYearQueryResult = {

--- a/app/src/components/Charts/DetailedCharts/TopAlbums/query.tsx
+++ b/app/src/components/Charts/DetailedCharts/TopAlbums/query.tsx
@@ -1,8 +1,9 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryTopAlbumsByYear from './TopAlbums.sql?raw'
 
 export function queryTopAlbumsByYear(year: number | undefined) {
-    const yearCondition = year ? `YEAR(ts:: DATETIME) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryTopAlbumsByYear
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/DetailedCharts/TopArtists/query.tsx
+++ b/app/src/components/Charts/DetailedCharts/TopArtists/query.tsx
@@ -1,8 +1,9 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryTopArtistsByYear from './TopArtists.sql?raw'
 
 export function queryTopArtistsByYear(year: number | undefined) {
-    const yearCondition = year ? `YEAR(ts:: DATETIME) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryTopArtistsByYear
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/DetailedCharts/TopTracks/query.tsx
+++ b/app/src/components/Charts/DetailedCharts/TopTracks/query.tsx
@@ -1,8 +1,9 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryTopTracksByYear from './TopTracks.sql?raw'
 
 export function queryTopTracksByYear(year: number | undefined) {
-    const yearCondition = year ? `YEAR(ts:: DATETIME) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryTopTracksByYear
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/SimpleCharts/ArtistLoyalty/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/ArtistLoyalty/query.tsx
@@ -1,4 +1,5 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryArtistLoyalty from './ArtistLoyalty.sql?raw'
 
 export type ArtistLoyaltyResult = {
@@ -9,8 +10,7 @@ export type ArtistLoyaltyResult = {
 }
 
 export function queryArtistLoyalty(year: number | undefined): string {
-    const yearCondition =
-        year !== undefined ? `year(ts::date) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryArtistLoyalty
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/SimpleCharts/ConcentrationScore/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/ConcentrationScore/query.tsx
@@ -1,4 +1,5 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryConcentrationScore from './ConcentrationScore.sql?raw'
 
 export type ConcentrationResult = {
@@ -8,8 +9,7 @@ export type ConcentrationResult = {
 }
 
 export function queryConcentrationScore(year: number | undefined): string {
-    const yearCondition =
-        year !== undefined ? `year(ts::date) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryConcentrationScore
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/SimpleCharts/FavoriteWeekday/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/FavoriteWeekday/query.tsx
@@ -1,4 +1,5 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryFavoriteWeekday from './FavoriteWeekday.sql?raw'
 
 export type FavoriteWeekdayResult = {
@@ -8,8 +9,7 @@ export type FavoriteWeekdayResult = {
 }
 
 export function queryFavoriteWeekday(year: number | undefined): string {
-    const yearCondition =
-        year !== undefined ? `year(ts::date) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryFavoriteWeekday
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/SimpleCharts/ListeningRhythm/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/ListeningRhythm/query.tsx
@@ -1,4 +1,5 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryListeningRhythm from './ListeningRhythm.sql?raw'
 
 export type ListeningRhythmResult = {
@@ -10,8 +11,7 @@ export type ListeningRhythmResult = {
 }
 
 export function queryListeningRhythm(year: number | undefined): string {
-    const yearCondition =
-        year !== undefined ? `year(ts::date) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryListeningRhythm
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/SimpleCharts/NewVsOld/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/query.tsx
@@ -1,4 +1,8 @@
 import { TABLE } from '../../../../db/queries/constants'
+import {
+    buildYearCondition,
+    buildYearOrLatest,
+} from '../../../../db/queries/buildYearCondition'
 import sqlQueryNewVsOld from './NewVsOld.sql?raw'
 
 export type NewVsOldResult = {
@@ -9,12 +13,8 @@ export type NewVsOldResult = {
 }
 
 export function queryNewVsOld(year: number | undefined): string {
-    const yearCondition =
-        year !== undefined ? `year(ts::date) = ${year}` : '1=1'
-    const yearForNew =
-        year !== undefined
-            ? String(year)
-            : `(select max(year(ts::date)) from ${TABLE})`
+    const yearCondition = buildYearCondition(year)
+    const yearForNew = buildYearOrLatest(year)
     return sqlQueryNewVsOld
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/SimpleCharts/PrincipalPlatform/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/PrincipalPlatform/query.tsx
@@ -1,4 +1,5 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryPrincipalPlatform from './PrincipalPlatform.sql?raw'
 
 export type PlatformResult = {
@@ -8,8 +9,7 @@ export type PlatformResult = {
 }
 
 export function queryPrincipalPlatform(year: number | undefined): string {
-    const yearCondition =
-        year !== undefined ? `year(ts::date) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryPrincipalPlatform
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/SimpleCharts/Regularity/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/Regularity/query.tsx
@@ -1,4 +1,5 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryRegularity from './Regularity.sql?raw'
 
 export type RegularityResult = {
@@ -8,8 +9,7 @@ export type RegularityResult = {
 }
 
 export function queryRegularity(year: number | undefined): string {
-    const yearCondition =
-        year !== undefined ? `year(ts::date) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     let query = sqlQueryRegularity
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/SimpleCharts/RepeatBehavior/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/RepeatBehavior/query.tsx
@@ -1,4 +1,5 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryRepeatBehavior from './RepeatBehavior.sql?raw'
 
 export type RepeatResult = {
@@ -9,8 +10,7 @@ export type RepeatResult = {
 }
 
 export function queryRepeatBehavior(year: number | undefined): string {
-    const yearCondition =
-        year !== undefined ? `year(ts::date) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryRepeatBehavior
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/SimpleCharts/SeasonalPatterns/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/SeasonalPatterns/query.tsx
@@ -1,4 +1,5 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQuerySeasonalPatterns from './SeasonalPatterns.sql?raw'
 
 export type SeasonalResult = {
@@ -10,8 +11,7 @@ export type SeasonalResult = {
 }
 
 export function querySeasonalPatterns(year: number | undefined): string {
-    const yearCondition =
-        year !== undefined ? `year(ts::date) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQuerySeasonalPatterns
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/SimpleCharts/SkipRate/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/SkipRate/query.tsx
@@ -1,4 +1,5 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQuerySkipRate from './SkipRate.sql?raw'
 
 export type SkipRateResult = {
@@ -7,8 +8,7 @@ export type SkipRateResult = {
 }
 
 export function querySkipRate(year: number | undefined): string {
-    const yearCondition =
-        year !== undefined ? `year(ts::date) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQuerySkipRate
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/SimpleCharts/TopAlbums/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopAlbums/query.tsx
@@ -1,4 +1,5 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryTopAlbums from './TopAlbums.sql?raw'
 
 export type TopAlbumsResult = {
@@ -9,8 +10,7 @@ export type TopAlbumsResult = {
 }
 
 export function queryTopAlbums(year: number | undefined): string {
-    const yearCondition =
-        year !== undefined ? `year(ts::date) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryTopAlbums
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/SimpleCharts/TopArtists/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopArtists/query.tsx
@@ -1,4 +1,5 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryTopArtists from './TopArtists.sql?raw'
 
 export type TopArtistsResult = {
@@ -8,8 +9,7 @@ export type TopArtistsResult = {
 }
 
 export function queryTopArtists(year: number | undefined): string {
-    const yearCondition =
-        year !== undefined ? `year(ts::date) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryTopArtists
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/SimpleCharts/TopTracks/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopTracks/query.tsx
@@ -1,4 +1,5 @@
 import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryTopTracks from './TopTracks.sql?raw'
 
 export type TopTracksResult = {
@@ -9,8 +10,7 @@ export type TopTracksResult = {
 }
 
 export function queryTopTracks(year: number | undefined): string {
-    const yearCondition =
-        year !== undefined ? `year(ts::date) = ${year}` : '1=1'
+    const yearCondition = buildYearCondition(year)
     return sqlQueryTopTracks
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/db/queries/buildYearCondition.test.ts
+++ b/app/src/db/queries/buildYearCondition.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { buildYearCondition, buildYearOrLatest } from './buildYearCondition'
+import { TABLE } from './constants'
+
+describe('buildYearCondition', () => {
+    it('returns a no-op condition when year is undefined', () => {
+        expect(buildYearCondition(undefined)).toBe('1=1')
+    })
+
+    it('returns an integer condition for a given year', () => {
+        expect(buildYearCondition(2024)).toBe('year(ts::date) = 2024')
+    })
+
+    it('truncates fractional years to integers', () => {
+        expect(buildYearCondition(2024.9)).toBe('year(ts::date) = 2024')
+    })
+
+    it('uses a custom column expression when provided', () => {
+        expect(buildYearCondition(2024, 'ranked_streams.year')).toBe(
+            'ranked_streams.year = 2024'
+        )
+    })
+
+    it('returns a no-op condition with a custom column when year is undefined', () => {
+        expect(buildYearCondition(undefined, 'ranked_streams.year')).toBe('1=1')
+    })
+})
+
+describe('buildYearOrLatest', () => {
+    it('returns the year as a string when year is defined', () => {
+        expect(buildYearOrLatest(2024)).toBe('2024')
+    })
+
+    it('truncates fractional years to integers', () => {
+        expect(buildYearOrLatest(2024.9)).toBe('2024')
+    })
+
+    it('returns a max-year subquery when year is undefined', () => {
+        const result = buildYearOrLatest(undefined)
+        expect(result).toContain('select max(year(ts::date))')
+        expect(result).toContain(TABLE)
+    })
+})

--- a/app/src/db/queries/buildYearCondition.ts
+++ b/app/src/db/queries/buildYearCondition.ts
@@ -1,0 +1,29 @@
+import { TABLE } from './constants'
+
+/**
+ * Builds a SQL WHERE condition fragment for filtering by year.
+ *
+ * Returns '1=1' (no-op) when year is undefined, allowing callers to
+ * unconditionally include the condition in their queries.
+ *
+ * @param column - SQL column expression to compare against. Defaults to
+ *   'year(ts::date)' for raw stream tables. Pass a pre-aggregated column
+ *   name (e.g. 'ranked_streams.year') when filtering on a CTE that already
+ *   extracts the year.
+ */
+export function buildYearCondition(
+    year: number | undefined,
+    column = 'year(ts::date)'
+): string {
+    if (year === undefined) return '1=1'
+    return `${column} = ${Math.trunc(year)}`
+}
+
+/**
+ * Builds a SQL expression that resolves to the given year as a number,
+ * or falls back to the most recent year in the table when year is undefined.
+ */
+export function buildYearOrLatest(year: number | undefined): string {
+    if (year !== undefined) return String(Math.trunc(year))
+    return `(select max(year(ts::date)) from ${TABLE})`
+}


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Each chart query builder had its own inline year condition, with inconsistencies across the codebase:

- Mix of `year ?` (falsy) and `year !== undefined` checks
- Some used `YEAR(ts:: DATETIME)` (with a stray space), others `year(ts::date)`
- No `Math.trunc` guard — a float year would be interpolated as-is
- `NewVsOld` duplicated the `buildYearOrLatest` subquery inline

## 🎹 Proposal

Extracts a shared `buildYearCondition(year, column?)` helper in `app/src/db/queries/buildYearCondition.ts`:

- Returns `'1=1'` when `year` is `undefined` (consistent `!== undefined` check)
- Returns `` `${column} = ${Math.trunc(year)}` `` otherwise — integer guaranteed
- Default column is `'year(ts::date)'` for raw stream tables
- Accepts a custom column expression for CTEs with a pre-aggregated year (e.g. `SummaryPerYear` filters on `ranked_streams.year`)

Also extracts `buildYearOrLatest` (used by `NewVsOld`) in the same file.

All query builders are updated to use these helpers. No query signatures, component props, or hooks are changed.

## 🎶 Comments

`SummaryPerYear` cannot use the default column (`year(ts::date)`) because its `${year_condition}` is applied inside a CTE where `year` is already a pre-aggregated integer column. It calls `buildYearCondition(year, 'ranked_streams.year')` instead.

## 🎤 Test

- `buildYearCondition.test.ts`: unit tests covering undefined, integer, fractional, and custom column cases
- `buildYearOrLatest.test.ts`: included in the same file
- Run `moon run app:test` — 309/309 tests pass