### PR TITLE
docs(security): add security architecture section to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,3 +13,15 @@ We only support updates to the 0.3.x versions of Tracksy.
 
 If you discover a vulnerability in Tracksy, please do not post an issue on GitHub. 
 Instead you should use [the private security reporting feature provided by Github on this project](https://github.com/Gudsfile/tracksy/security/advisories/new).
+
+## Security Architecture
+
+Tracksy is designed as a **privacy-first, client-side-only** application.
+
+### No server-side data processing
+
+All user data stays in the browser. There is no backend, no API, and no database server. Uploaded streaming history files are processed entirely within the user's browser session using [DuckDB WASM](https://duckdb.org/docs/api/wasm), which runs as a local in-memory database. No user data is ever transmitted to an external server.
+
+### File upload handling
+
+While uploaded files are checked against expected filename patterns and MIME types, these validations are intentionally lightweight and do not provide strong guarantees regarding file integrity or safety prior to processing.


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

`SECURITY.md` only contained the supported versions table and vulnerability reporting instructions. Contributors and security auditors had no documentation on Tracksy's security architecture or threat model.

## 🎹 Proposal

Adds a "Security Architecture" section.

## 🎶 Comments

## 🎤 Test
