### PR TITLE
feat(charts): improve chart loading and prevent stale query updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 # moon
 .moon/cache
 .moon/docker
+.moon/hooks
 
 node_modules

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -7,10 +7,10 @@ projects:
 vcs:
   hooks:
     pre-commit:
-      - moon app:format-check
-      - moon app:typecheck
-      - moon synthetic-datasets:typecheck
-      - moon synthetic-datasets:format-check
+      - moon run app:format-check
+      - moon run app:typecheck
+      - moon run synthetic-datasets:typecheck
+      - moon run synthetic-datasets:format-check
   defaultBranch: main
   client: git
 versionConstraint: ">=2.0.3,<=3.0.0"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,13 @@ To get started, you don't need to install Node.js, Python, or pnpm manually. Moo
     moon setup
     ```
 
+3. **Install the pre-commit hooks**:
+
+  ```bash
+  # This installs the Git hooks defined in .moon/workspace.yml
+  moon sync hooks
+  ```
+
 #### Available Commands
 
 Run tasks across the entire monorepo or for specific projects.

--- a/app/src/components/Charts/DetailedView.tsx
+++ b/app/src/components/Charts/DetailedView.tsx
@@ -11,6 +11,7 @@ import {
     type SummarizeDataQueryResult,
 } from './Summarize/summarizeQuery'
 import { queryDBAsJSON } from '../../db/queries/queryDB'
+import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import { TopTracks } from './DetailedCharts/TopTracks'
 import { TopArtists } from './DetailedCharts/TopArtists'
 import { TopAlbums } from './DetailedCharts/TopAlbums'
@@ -23,10 +24,11 @@ import { ArtistDiscovery } from './DetailedCharts/ArtistDiscovery'
 import { DuckDBShell } from '../DuckDBShell/DuckDBShell'
 
 export function DetailedView() {
-    const [year, setYear] = useState<number | undefined>(2006) // Spotify was founded on April 23, 2006.
+    const [year, setYear] = useState<number | undefined>(2006)
     const [summarize, setSummarize] = useState<
         SummarizeDataQueryResult | undefined
     >()
+    const debouncedYear = useDebouncedValue(year, 250)
 
     useEffect(() => {
         const initDataSummarize = async () => {
@@ -65,18 +67,20 @@ export function DetailedView() {
                         />
                     </div>
                     <StreamPerMonth
-                        year={year}
+                        year={debouncedYear}
                         maxValue={summarize.max_monthly_duration}
                     />
                     <StreamPerHour
-                        year={year}
+                        year={debouncedYear}
                         maxValue={Number(summarize.max_count_hourly_stream)}
                     />
-                    <SummaryPerYear year={year} />
-                    <TopTracks year={year} />
-                    <TopArtists year={year} />
-                    <TopAlbums year={year} />
+                    <SummaryPerYear year={debouncedYear} />
+                    <TopTracks year={debouncedYear} />
+                    <TopArtists year={debouncedYear} />
+                    <TopAlbums year={debouncedYear} />
                     <ArtistDiscovery />
+                    <StreamPerDayOfWeek year={debouncedYear} />
+                    <Top10AlbumsEvolution />
                 </>
             )}
 
@@ -94,9 +98,7 @@ export function DetailedView() {
 
                 <Streaks />
                 <Top10Evolution />
-                <Top10AlbumsEvolution />
                 <Top10TracksEvolution />
-                <StreamPerDayOfWeek year={year} />
             </section>
             <DuckDBShell />
         </>

--- a/app/src/components/Charts/SimpleCharts/ArtistLoyalty/ArtistLoyalty.tsx
+++ b/app/src/components/Charts/SimpleCharts/ArtistLoyalty/ArtistLoyalty.tsx
@@ -4,49 +4,53 @@ import { ChartCard, ChartHero } from '../shared'
 import { classifyArtistLoyalty } from './classifyArtistLoyalty'
 
 type Props = {
-    data: ArtistLoyaltyResult[]
+    data: ArtistLoyaltyResult[] | undefined
+    isLoading?: boolean
 }
 
-export const ArtistLoyalty: FC<Props> = ({ data }) => {
-    const totalArtists = data.reduce((sum, bin) => sum + bin.artist_count, 0)
+export const ArtistLoyalty: FC<Props> = ({ data, isLoading }) => {
+    const totalArtists = (data ?? []).reduce(
+        (sum, bin) => sum + bin.artist_count,
+        0
+    )
 
-    const classification = classifyArtistLoyalty(data)
+    const classification = classifyArtistLoyalty(data ?? [])
 
     const bins = [
         {
             label: '1 stream',
-            value: data[0]?.share_of_total_streams * 100 || 0,
+            value: (data?.[0]?.share_of_total_streams ?? 0) * 100,
             color: 'bg-teal-400',
             textColor: 'text-teal-700 dark:text-teal-400',
         },
         {
             label: '2-10 streams',
-            value: data[1]?.share_of_total_streams * 100 || 0,
+            value: (data?.[1]?.share_of_total_streams ?? 0) * 100,
             color: 'bg-orange-400',
             textColor: 'text-orange-700 dark:text-orange-400',
         },
         {
             label: '11-100 streams',
-            value: data[2]?.share_of_total_streams * 100 || 0,
+            value: (data?.[2]?.share_of_total_streams ?? 0) * 100,
             color: 'bg-violet-400',
             textColor: 'text-violet-700 dark:text-violet-400',
         },
         {
             label: '101-1000 streams',
-            value: data[3]?.share_of_total_streams * 100 || 0,
+            value: (data?.[3]?.share_of_total_streams ?? 0) * 100,
             color: 'bg-blue-400',
             textColor: 'text-blue-700 dark:text-blue-400',
         },
         {
             label: '1000+ streams',
-            value: data[4]?.share_of_total_streams * 100 || 0,
+            value: (data?.[4]?.share_of_total_streams ?? 0) * 100,
             color: 'bg-rose-500',
             textColor: 'text-rose-700 dark:text-rose-400',
         },
     ]
 
     return (
-        <ChartCard title="Artist Loyalty" emoji="🤝">
+        <ChartCard title="Artist Loyalty" emoji="🤝" isLoading={isLoading}>
             <ChartHero
                 label={classification.label}
                 sublabel={`${totalArtists.toLocaleString()} artists`}

--- a/app/src/components/Charts/SimpleCharts/ArtistLoyalty/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/ArtistLoyalty/index.tsx
@@ -3,11 +3,11 @@ import { queryArtistLoyalty, type ArtistLoyaltyResult } from './query'
 import { ArtistLoyalty as ArtistLoyaltyView } from './ArtistLoyalty'
 
 export function ArtistLoyalty({ year }: { year: number | undefined }) {
-    const { data } = useDBQueryMany<ArtistLoyaltyResult>({
+    const { data, isLoading } = useDBQueryMany<ArtistLoyaltyResult>({
         query: queryArtistLoyalty(year),
         year,
     })
 
-    if (!data?.length) return null
-    return <ArtistLoyaltyView data={data} />
+    if (!isLoading && !data?.length) return null
+    return <ArtistLoyaltyView data={data} isLoading={isLoading} />
 }

--- a/app/src/components/Charts/SimpleCharts/ConcentrationScore/ConcentrationScore.tsx
+++ b/app/src/components/Charts/SimpleCharts/ConcentrationScore/ConcentrationScore.tsx
@@ -3,20 +3,21 @@ import type { ConcentrationResult } from './query'
 import { ChartCard, LabeledProgressBar } from '../shared'
 
 type Props = {
-    data: ConcentrationResult
+    data: ConcentrationResult | undefined
+    isLoading?: boolean
 }
 
-export const ConcentrationScore: FC<Props> = ({ data }) => {
-    const { top5_pct, top10_pct, top20_pct } = data
-
-    const scores = [
-        { label: 'Top 5', value: top5_pct },
-        { label: 'Top 10', value: top10_pct },
-        { label: 'Top 20', value: top20_pct },
-    ]
+export const ConcentrationScore: FC<Props> = ({ data, isLoading }) => {
+    const scores = data
+        ? [
+              { label: 'Top 5', value: data.top5_pct },
+              { label: 'Top 10', value: data.top10_pct },
+              { label: 'Top 20', value: data.top20_pct },
+          ]
+        : []
 
     return (
-        <ChartCard title="Focus Mode" emoji="🔥">
+        <ChartCard title="Focus Mode" emoji="🔥" isLoading={isLoading}>
             <div className="text-sm text-gray-600 dark:text-gray-400 mb-4">
                 Share of listening time for your top artists
             </div>

--- a/app/src/components/Charts/SimpleCharts/ConcentrationScore/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/ConcentrationScore/index.tsx
@@ -3,11 +3,11 @@ import { queryConcentrationScore, type ConcentrationResult } from './query'
 import { ConcentrationScore as ConcentrationScoreView } from './ConcentrationScore'
 
 export function ConcentrationScore({ year }: { year: number | undefined }) {
-    const { data } = useDBQueryFirst<ConcentrationResult>({
+    const { data, isLoading } = useDBQueryFirst<ConcentrationResult>({
         query: queryConcentrationScore(year),
         year,
     })
 
-    if (!data) return null
-    return <ConcentrationScoreView data={data} />
+    if (!isLoading && !data) return null
+    return <ConcentrationScoreView data={data} isLoading={isLoading} />
 }

--- a/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.tsx
+++ b/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.tsx
@@ -4,82 +4,91 @@ import { formatDuration } from '../../../../utils/formatDuration'
 import { ChartCard } from '../shared'
 
 type Props = {
-    data: EvolutionResult[]
+    data: EvolutionResult[] | undefined
     year: number | undefined
+    isLoading?: boolean
 }
 
-export const EvolutionOverTime: FC<Props> = ({ data, year }) => {
-    if (data.length === 0) return null
-
-    const maxStreams = Math.max(...data.map((d) => d.streams))
-    const currentYearData = data.find((d) => d.year === year)
-    const totalStreams = data.reduce((acc, curr) => acc + curr.streams, 0)
-    const startYear = Math.min(...data.map((d) => d.year))
+export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
+    const maxStreams = data?.length
+        ? Math.max(...data.map((d) => d.streams))
+        : 0
+    const currentYearData = data?.find((d) => d.year === year)
+    const totalStreams = data?.reduce((acc, curr) => acc + curr.streams, 0) ?? 0
+    const startYear = data?.length ? Math.min(...data.map((d) => d.year)) : 0
 
     return (
         <ChartCard
             title="Soundtrack Growth"
             emoji="📈"
             className="flex flex-col justify-between h-full"
+            isLoading={isLoading}
         >
-            <div className="flex items-end gap-1 h-24 mt-4 mb-2">
-                {data.map((d) => {
-                    const height = (d.streams / maxStreams) * 100
-                    return (
-                        <div
-                            key={d.year}
-                            className="flex-1 bg-brand-blue dark:bg-brand-blue rounded-t relative group"
-                            style={{ height: `${height}%` }}
-                        >
-                            <div
-                                className={`absolute bottom-0 left-0 right-0 bg-brand-blue rounded-t transition-all duration-300 ${
-                                    d.year === year ? 'bg-brand-purple' : ''
-                                }`}
-                                style={{ height: '100%' }}
-                            ></div>
-                            <div className="opacity-0 group-hover:opacity-100 absolute bottom-full left-1/2 -translate-x-1/2 mb-1 bg-black text-white text-xs px-2 py-1 rounded pointer-events-none whitespace-nowrap z-10">
-                                {d.year}
-                                <br /> {d.streams.toLocaleString()} streams
-                                <br /> ({formatDuration(d.ms_played)})
-                            </div>
-                        </div>
-                    )
-                })}
-            </div>
-            <div className="flex justify-between text-xs text-gray-600 dark:text-gray-400 px-1">
-                <span>{startYear}</span>
-                <span>{Math.max(...data.map((d) => d.year))}</span>
-            </div>
+            {data && (
+                <>
+                    <div className="flex items-end gap-1 h-24 mt-4 mb-2">
+                        {data.map((d) => {
+                            const height = (d.streams / maxStreams) * 100
+                            return (
+                                <div
+                                    key={d.year}
+                                    className="flex-1 bg-brand-blue dark:bg-brand-blue rounded-t relative group"
+                                    style={{ height: `${height}%` }}
+                                >
+                                    <div
+                                        className={`absolute bottom-0 left-0 right-0 bg-brand-blue rounded-t transition-all duration-300 ${
+                                            d.year === year
+                                                ? 'bg-brand-purple'
+                                                : ''
+                                        }`}
+                                        style={{ height: '100%' }}
+                                    ></div>
+                                    <div className="opacity-0 group-hover:opacity-100 absolute bottom-full left-1/2 -translate-x-1/2 mb-1 bg-black text-white text-xs px-2 py-1 rounded pointer-events-none whitespace-nowrap z-10">
+                                        {d.year}
+                                        <br /> {d.streams.toLocaleString()}{' '}
+                                        streams
+                                        <br /> ({formatDuration(d.ms_played)})
+                                    </div>
+                                </div>
+                            )
+                        })}
+                    </div>
+                    <div className="flex justify-between text-xs text-gray-600 dark:text-gray-400 px-1">
+                        <span>{startYear}</span>
+                        <span>{Math.max(...data.map((d) => d.year))}</span>
+                    </div>
 
-            <ul
-                className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700"
-                role="list"
-            >
-                <li
-                    className="flex justify-between items-center"
-                    role="listitem"
-                >
-                    <span className="text-sm text-gray-600 dark:text-gray-400">
-                        Total streams
-                    </span>
-                    <span className="font-bold">
-                        {totalStreams.toLocaleString()}
-                    </span>
-                </li>
-                {currentYearData && (
-                    <li
-                        className="flex justify-between items-center mt-1"
-                        role="listitem"
+                    <ul
+                        className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700"
+                        role="list"
                     >
-                        <span className="text-sm text-gray-600 dark:text-gray-400">
-                            This year
-                        </span>
-                        <span className="font-bold text-brand-purple dark:text-brand-purple">
-                            {currentYearData.streams.toLocaleString()}
-                        </span>
-                    </li>
-                )}
-            </ul>
+                        <li
+                            className="flex justify-between items-center"
+                            role="listitem"
+                        >
+                            <span className="text-sm text-gray-600 dark:text-gray-400">
+                                Total streams
+                            </span>
+                            <span className="font-bold">
+                                {totalStreams.toLocaleString()}
+                            </span>
+                        </li>
+                        {currentYearData && (
+                            <li
+                                className="flex justify-between items-center mt-1"
+                                role="listitem"
+                            >
+                                <span className="text-sm text-gray-600 dark:text-gray-400">
+                                    This year
+                                </span>
+                                <span className="font-bold text-brand-purple dark:text-brand-purple">
+                                    {currentYearData.streams.toLocaleString()}
+                                </span>
+                            </li>
+                        )}
+                    </ul>
+                </>
+            )}
         </ChartCard>
     )
 }

--- a/app/src/components/Charts/SimpleCharts/EvolutionOverTime/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/EvolutionOverTime/index.tsx
@@ -3,11 +3,13 @@ import { queryEvolutionOverTime, type EvolutionResult } from './query'
 import { EvolutionOverTime as EvolutionOverTimeView } from './EvolutionOverTime'
 
 export function EvolutionOverTime({ year }: { year: number | undefined }) {
-    const { data } = useDBQueryMany<EvolutionResult>({
+    const { data, isLoading } = useDBQueryMany<EvolutionResult>({
         query: queryEvolutionOverTime(),
         year,
     })
 
-    if (!data?.length) return null
-    return <EvolutionOverTimeView data={data} year={year} />
+    if (!isLoading && !data?.length) return null
+    return (
+        <EvolutionOverTimeView data={data} year={year} isLoading={isLoading} />
+    )
 }

--- a/app/src/components/Charts/SimpleCharts/FavoriteWeekday/FavoriteWeekday.tsx
+++ b/app/src/components/Charts/SimpleCharts/FavoriteWeekday/FavoriteWeekday.tsx
@@ -3,7 +3,8 @@ import type { FavoriteWeekdayResult } from './query'
 import { ChartCard, ChartHero } from '../shared'
 
 type Props = {
-    data: FavoriteWeekdayResult[]
+    data: FavoriteWeekdayResult[] | undefined
+    isLoading?: boolean
 }
 
 const DAY_ABBREVIATIONS: Record<string, string> = {
@@ -16,53 +17,55 @@ const DAY_ABBREVIATIONS: Record<string, string> = {
     Sunday: 'Sun',
 }
 
-export const FavoriteWeekday: FC<Props> = ({ data }) => {
-    if (!data || data.length === 0) return null
-
-    const favoriteDay = data.reduce(
-        (max, day) => (day.pct > max.pct ? day : max),
-        data[0]
-    )
-    const maxPct = Math.max(...data.map((d) => d.pct))
+export const FavoriteWeekday: FC<Props> = ({ data, isLoading }) => {
+    const favoriteDay = data
+        ? data.reduce((max, day) => (day.pct > max.pct ? day : max), data[0])
+        : undefined
+    const maxPct = data ? Math.max(...data.map((d) => d.pct)) : 0
 
     return (
-        <ChartCard title="Your Power Day" emoji="📅">
-            <ChartHero
-                label={favoriteDay.day_name}
-                sublabel={`${favoriteDay.stream_count.toLocaleString()} streams`}
-                labelColor="text-orange-400"
-            />
+        <ChartCard title="Your Power Day" emoji="📅" isLoading={isLoading}>
+            {data && favoriteDay && (
+                <>
+                    <ChartHero
+                        label={favoriteDay.day_name}
+                        sublabel={`${favoriteDay.stream_count.toLocaleString()} streams`}
+                        labelColor="text-orange-400"
+                    />
 
-            <div className="grid grid-cols-7 gap-1">
-                {data.map((day) => {
-                    const isFavorite = day.day_name === favoriteDay.day_name
-                    const heightPct = (day.pct / maxPct) * 100
+                    <div className="grid grid-cols-7 gap-1">
+                        {data.map((day) => {
+                            const isFavorite =
+                                day.day_name === favoriteDay.day_name
+                            const heightPct = (day.pct / maxPct) * 100
 
-                    return (
-                        <div
-                            key={day.day_name}
-                            className="flex flex-col items-center gap-1"
-                        >
-                            <div className="text-[10px] font-medium text-gray-600 dark:text-gray-400">
-                                {DAY_ABBREVIATIONS[day.day_name]}
-                            </div>
-                            <div className="w-full h-16 bg-gray-200 dark:bg-slate-700/50 rounded-sm flex items-end overflow-hidden">
+                            return (
                                 <div
-                                    className={`w-full rounded-sm transition-all duration-300 ${
-                                        isFavorite
-                                            ? 'bg-orange-400'
-                                            : 'bg-yellow-400'
-                                    }`}
-                                    style={{ height: `${heightPct}%` }}
-                                ></div>
-                            </div>
-                            <div className="text-[9px] text-gray-600 dark:text-gray-400">
-                                {day.pct.toFixed(0)}%
-                            </div>
-                        </div>
-                    )
-                })}
-            </div>
+                                    key={day.day_name}
+                                    className="flex flex-col items-center gap-1"
+                                >
+                                    <div className="text-[10px] font-medium text-gray-600 dark:text-gray-400">
+                                        {DAY_ABBREVIATIONS[day.day_name]}
+                                    </div>
+                                    <div className="w-full h-16 bg-gray-200 dark:bg-slate-700/50 rounded-sm flex items-end overflow-hidden">
+                                        <div
+                                            className={`w-full rounded-sm transition-all duration-300 ${
+                                                isFavorite
+                                                    ? 'bg-orange-400'
+                                                    : 'bg-yellow-400'
+                                            }`}
+                                            style={{ height: `${heightPct}%` }}
+                                        ></div>
+                                    </div>
+                                    <div className="text-[9px] text-gray-600 dark:text-gray-400">
+                                        {day.pct.toFixed(0)}%
+                                    </div>
+                                </div>
+                            )
+                        })}
+                    </div>
+                </>
+            )}
         </ChartCard>
     )
 }

--- a/app/src/components/Charts/SimpleCharts/FavoriteWeekday/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/FavoriteWeekday/index.tsx
@@ -3,11 +3,11 @@ import { queryFavoriteWeekday, type FavoriteWeekdayResult } from './query'
 import { FavoriteWeekday as FavoriteWeekdayView } from './FavoriteWeekday'
 
 export function FavoriteWeekday({ year }: { year: number | undefined }) {
-    const { data } = useDBQueryMany<FavoriteWeekdayResult>({
+    const { data, isLoading } = useDBQueryMany<FavoriteWeekdayResult>({
         query: queryFavoriteWeekday(year),
         year,
     })
 
-    if (!data?.length) return null
-    return <FavoriteWeekdayView data={data} />
+    if (!isLoading && !data?.length) return null
+    return <FavoriteWeekdayView data={data} isLoading={isLoading} />
 }

--- a/app/src/components/Charts/SimpleCharts/ListeningRhythm/ListeningRhythm.tsx
+++ b/app/src/components/Charts/SimpleCharts/ListeningRhythm/ListeningRhythm.tsx
@@ -3,11 +3,18 @@ import type { ListeningRhythmResult } from './query'
 import { ChartCard, ChartHero, LabeledProgressBar } from '../shared'
 
 type Props = {
-    data: ListeningRhythmResult
+    data: ListeningRhythmResult | undefined
+    isLoading?: boolean
 }
 
-export const ListeningRhythm: FC<Props> = ({ data }) => {
-    const { morning, afternoon, evening, night, total } = data
+export const ListeningRhythm: FC<Props> = ({ data, isLoading }) => {
+    const {
+        morning = 0,
+        afternoon = 0,
+        evening = 0,
+        night = 0,
+        total = 0,
+    } = data ?? {}
     const percent = (count: number) => (total ? (count / total) * 100 : 0)
 
     const periods = [
@@ -22,7 +29,7 @@ export const ListeningRhythm: FC<Props> = ({ data }) => {
     )
 
     return (
-        <ChartCard title="Daily Vibes" emoji="⏰">
+        <ChartCard title="Daily Vibes" emoji="⏰" isLoading={isLoading}>
             <ChartHero
                 label={favorite.label}
                 sublabel={`${favorite.value?.toLocaleString()} streams`}

--- a/app/src/components/Charts/SimpleCharts/ListeningRhythm/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/ListeningRhythm/index.tsx
@@ -3,11 +3,11 @@ import { queryListeningRhythm, type ListeningRhythmResult } from './query'
 import { ListeningRhythm as ListeningRhythmView } from './ListeningRhythm'
 
 export function ListeningRhythm({ year }: { year: number | undefined }) {
-    const { data } = useDBQueryFirst<ListeningRhythmResult>({
+    const { data, isLoading } = useDBQueryFirst<ListeningRhythmResult>({
         query: queryListeningRhythm(year),
         year,
     })
 
-    if (!data) return null
-    return <ListeningRhythmView data={data} />
+    if (!isLoading && !data) return null
+    return <ListeningRhythmView data={data} isLoading={isLoading} />
 }

--- a/app/src/components/Charts/SimpleCharts/NewVsOld/NewVsOld.tsx
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/NewVsOld.tsx
@@ -3,16 +3,17 @@ import type { NewVsOldResult } from './query'
 import { ChartCard, ChartHero, InsightCard } from '../shared'
 
 type Props = {
-    data: NewVsOldResult
+    data: NewVsOldResult | undefined
+    isLoading?: boolean
 }
 
-export const NewVsOld: FC<Props> = ({ data }) => {
+export const NewVsOld: FC<Props> = ({ data, isLoading }) => {
     const {
-        new_artists_streams,
-        old_artists_streams,
-        new_artists_count,
-        total,
-    } = data
+        new_artists_streams = 0,
+        old_artists_streams = 0,
+        new_artists_count = 0,
+        total = 0,
+    } = data ?? {}
 
     const newPct = total ? (new_artists_streams / total) * 100 : 0
     const oldPct = total ? (old_artists_streams / total) * 100 : 0
@@ -25,7 +26,7 @@ export const NewVsOld: FC<Props> = ({ data }) => {
               : 'Balanced Tast'
 
     return (
-        <ChartCard title="Fresh vs Familiar" emoji="🆕">
+        <ChartCard title="Fresh vs Familiar" emoji="🆕" isLoading={isLoading}>
             <ChartHero label={top} />
 
             <div className="flex items-center gap-4 mb-4 text-xs text-gray-600 dark:text-gray-400">

--- a/app/src/components/Charts/SimpleCharts/NewVsOld/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/index.tsx
@@ -3,11 +3,11 @@ import { queryNewVsOld, type NewVsOldResult } from './query'
 import { NewVsOld as NewVsOldView } from './NewVsOld'
 
 export function NewVsOld({ year }: { year: number | undefined }) {
-    const { data } = useDBQueryFirst<NewVsOldResult>({
+    const { data, isLoading } = useDBQueryFirst<NewVsOldResult>({
         query: queryNewVsOld(year),
         year,
     })
 
-    if (!data) return null
-    return <NewVsOldView data={data} />
+    if (!isLoading && !data) return null
+    return <NewVsOldView data={data} isLoading={isLoading} />
 }

--- a/app/src/components/Charts/SimpleCharts/PrincipalPlatform/PrincipalPlatform.tsx
+++ b/app/src/components/Charts/SimpleCharts/PrincipalPlatform/PrincipalPlatform.tsx
@@ -3,35 +3,36 @@ import type { PlatformResult } from './query'
 import { ChartCard, ChartHero, LabeledProgressBar } from '../shared'
 
 type Props = {
-    data: PlatformResult[]
+    data: PlatformResult[] | undefined
+    isLoading?: boolean
 }
 
-export const PrincipalPlatform: FC<Props> = ({ data }) => {
-    if (data.length === 0) return null
-
-    const topPlatform = data[0]
-
+export const PrincipalPlatform: FC<Props> = ({ data, isLoading }) => {
     return (
-        <ChartCard title="Your Sound Machine" emoji="📱">
-            <ChartHero
-                label={topPlatform.platform}
-                sublabel={`${topPlatform.stream_count.toLocaleString()} streams`}
-                labelColor="text-brand-purple"
-            />
+        <ChartCard title="Your Sound Machine" emoji="📱" isLoading={isLoading}>
+            {data && (
+                <>
+                    <ChartHero
+                        label={data[0].platform}
+                        sublabel={`${data[0].stream_count.toLocaleString()} streams`}
+                        labelColor="text-brand-purple"
+                    />
 
-            <ul className="space-y-3" role="list">
-                {data.map((platform) => (
-                    <li key={platform.platform} role="listitem">
-                        <LabeledProgressBar
-                            label={platform.platform}
-                            value={`${platform.pct.toFixed(1)}%`}
-                            valueColor="text-gray-600 dark:text-gray-400"
-                            pct={platform.pct}
-                            barColor="bg-brand-purple"
-                        />
-                    </li>
-                ))}
-            </ul>
+                    <ul className="space-y-3" role="list">
+                        {data.map((platform) => (
+                            <li key={platform.platform} role="listitem">
+                                <LabeledProgressBar
+                                    label={platform.platform}
+                                    value={`${platform.pct.toFixed(1)}%`}
+                                    valueColor="text-gray-600 dark:text-gray-400"
+                                    pct={platform.pct}
+                                    barColor="bg-brand-purple"
+                                />
+                            </li>
+                        ))}
+                    </ul>
+                </>
+            )}
         </ChartCard>
     )
 }

--- a/app/src/components/Charts/SimpleCharts/PrincipalPlatform/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/PrincipalPlatform/index.tsx
@@ -3,11 +3,11 @@ import { queryPrincipalPlatform, type PlatformResult } from './query'
 import { PrincipalPlatform as PrincipalPlatformView } from './PrincipalPlatform'
 
 export function PrincipalPlatform({ year }: { year: number | undefined }) {
-    const { data } = useDBQueryMany<PlatformResult>({
+    const { data, isLoading } = useDBQueryMany<PlatformResult>({
         query: queryPrincipalPlatform(year),
         year,
     })
 
-    if (!data?.length) return null
-    return <PrincipalPlatformView data={data} />
+    if (!isLoading && !data?.length) return null
+    return <PrincipalPlatformView data={data} isLoading={isLoading} />
 }

--- a/app/src/components/Charts/SimpleCharts/Regularity/Regularity.tsx
+++ b/app/src/components/Charts/SimpleCharts/Regularity/Regularity.tsx
@@ -4,11 +4,16 @@ import { classifyRegularity } from './classifyRegularity'
 import { ChartCard, ChartHero } from '../shared'
 
 type Props = {
-    data: RegularityResult
+    data: RegularityResult | undefined
+    isLoading?: boolean
 }
 
-export const Regularity: FC<Props> = ({ data }) => {
-    const { days_with_streams, total_days, longest_pause_days } = data
+export const Regularity: FC<Props> = ({ data, isLoading }) => {
+    const {
+        days_with_streams = 0,
+        total_days = 1,
+        longest_pause_days = 0,
+    } = data ?? {}
 
     const regularity_pct = (days_with_streams / total_days) * 100
     const { label, color, strokeColor, emoji } =
@@ -25,6 +30,7 @@ export const Regularity: FC<Props> = ({ data }) => {
             title="Consistency Meter"
             emoji="⏳"
             className="flex flex-col h-full relative"
+            isLoading={isLoading}
         >
             <ChartHero
                 label={label}

--- a/app/src/components/Charts/SimpleCharts/Regularity/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/Regularity/index.tsx
@@ -3,11 +3,11 @@ import { queryRegularity, type RegularityResult } from './query'
 import { Regularity as RegularityView } from './Regularity'
 
 export function Regularity({ year }: { year: number | undefined }) {
-    const { data } = useDBQueryFirst<RegularityResult>({
+    const { data, isLoading } = useDBQueryFirst<RegularityResult>({
         query: queryRegularity(year),
         year,
     })
 
-    if (!data) return null
-    return <RegularityView data={data} />
+    if (!isLoading && !data) return null
+    return <RegularityView data={data} isLoading={isLoading} />
 }

--- a/app/src/components/Charts/SimpleCharts/RepeatBehavior/RepeatBehavior.tsx
+++ b/app/src/components/Charts/SimpleCharts/RepeatBehavior/RepeatBehavior.tsx
@@ -4,58 +4,63 @@ import { classifyRepeatBehavior } from './classifyRepeatBehavior'
 import { ChartCard, ChartHero } from '../shared'
 
 type Props = {
-    data: RepeatResult
+    data: RepeatResult | undefined
+    isLoading?: boolean
 }
 
-export const RepeatBehavior: FC<Props> = ({ data }) => {
+export const RepeatBehavior: FC<Props> = ({ data, isLoading }) => {
     const {
-        total_repeat_sequences,
-        max_consecutive,
-        most_repeated_track,
-        avg_repeat_length,
-    } = data
+        total_repeat_sequences = 0,
+        max_consecutive = 0,
+        most_repeated_track = '',
+        avg_repeat_length = 0,
+    } = data ?? {}
 
     const { classification, emoji } = classifyRepeatBehavior(
         total_repeat_sequences
     )
 
-    if (total_repeat_sequences === 0) return undefined
+    if (!isLoading && total_repeat_sequences === 0) return null
 
     return (
-        <ChartCard title="Replay Energy" emoji="🔁">
-            <ChartHero
-                label={classification}
-                sublabel={`${total_repeat_sequences} repeated sequences`}
-                emoji={emoji}
-            />
+        <ChartCard title="Replay Energy" emoji="🔁" isLoading={isLoading}>
+            {data && (
+                <>
+                    <ChartHero
+                        label={classification}
+                        sublabel={`${total_repeat_sequences} repeated sequences`}
+                        emoji={emoji}
+                    />
 
-            <div className="space-y-3">
-                <div className="bg-gray-200 dark:bg-slate-700/50 p-3 rounded-lg">
-                    <div className="text-xs text-gray-600 dark:text-gray-400 mb-1">
-                        Repeat Record
-                    </div>
-                    <div className="font-medium text-brand-purple dark:text-brand-purple line-clamp-1">
-                        "{most_repeated_track}"
-                    </div>
-                    <div className="text-sm font-bold mt-1">
-                        {max_consecutive} times in a row 🎸
-                    </div>
-                </div>
+                    <div className="space-y-3">
+                        <div className="bg-gray-200 dark:bg-slate-700/50 p-3 rounded-lg">
+                            <div className="text-xs text-gray-600 dark:text-gray-400 mb-1">
+                                Repeat Record
+                            </div>
+                            <div className="font-medium text-brand-purple dark:text-brand-purple line-clamp-1">
+                                "{most_repeated_track}"
+                            </div>
+                            <div className="text-sm font-bold mt-1">
+                                {max_consecutive} times in a row 🎸
+                            </div>
+                        </div>
 
-                <ul className="mb-1" role="list">
-                    <li
-                        className="flex justify-between items-center text-sm"
-                        role="listitem"
-                    >
-                        <span className="text-gray-600 dark:text-gray-400">
-                            Repeat average
-                        </span>
-                        <span className="font-bold">
-                            {avg_repeat_length.toFixed(1)} times
-                        </span>
-                    </li>
-                </ul>
-            </div>
+                        <ul className="mb-1" role="list">
+                            <li
+                                className="flex justify-between items-center text-sm"
+                                role="listitem"
+                            >
+                                <span className="text-gray-600 dark:text-gray-400">
+                                    Repeat average
+                                </span>
+                                <span className="font-bold">
+                                    {avg_repeat_length.toFixed(1)} times
+                                </span>
+                            </li>
+                        </ul>
+                    </div>
+                </>
+            )}
         </ChartCard>
     )
 }

--- a/app/src/components/Charts/SimpleCharts/RepeatBehavior/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/RepeatBehavior/index.tsx
@@ -3,11 +3,11 @@ import { queryRepeatBehavior, type RepeatResult } from './query'
 import { RepeatBehavior as RepeatBehaviorView } from './RepeatBehavior'
 
 export function RepeatBehavior({ year }: { year: number | undefined }) {
-    const { data } = useDBQueryFirst<RepeatResult>({
+    const { data, isLoading } = useDBQueryFirst<RepeatResult>({
         query: queryRepeatBehavior(year),
         year,
     })
 
-    if (!data) return null
-    return <RepeatBehaviorView data={data} />
+    if (!isLoading && (!data || data.total_repeat_sequences === 0)) return null
+    return <RepeatBehaviorView data={data} isLoading={isLoading} />
 }

--- a/app/src/components/Charts/SimpleCharts/SeasonalPatterns/SeasonalPatterns.tsx
+++ b/app/src/components/Charts/SimpleCharts/SeasonalPatterns/SeasonalPatterns.tsx
@@ -4,11 +4,18 @@ import { ChartCard } from '../shared/ChartCard'
 import { ChartHero, LabeledProgressBar } from '../shared'
 
 type Props = {
-    data: SeasonalResult
+    data: SeasonalResult | undefined
+    isLoading?: boolean
 }
 
-export const SeasonalPatterns: FC<Props> = ({ data }) => {
-    const { winter, spring, summer, fall, total } = data
+export const SeasonalPatterns: FC<Props> = ({ data, isLoading }) => {
+    const {
+        winter = 0,
+        spring = 0,
+        summer = 0,
+        fall = 0,
+        total = 0,
+    } = data ?? {}
     const percent = (count: number) => (total ? (count / total) * 100 : 0)
 
     const seasons = [
@@ -23,7 +30,7 @@ export const SeasonalPatterns: FC<Props> = ({ data }) => {
     )
 
     return (
-        <ChartCard title="Seasonal Mood" emoji="🌺">
+        <ChartCard title="Seasonal Mood" emoji="🌺" isLoading={isLoading}>
             <ChartHero
                 label={favorite.name}
                 sublabel={`${favorite.value?.toLocaleString()} streams`}

--- a/app/src/components/Charts/SimpleCharts/SeasonalPatterns/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/SeasonalPatterns/index.tsx
@@ -3,11 +3,11 @@ import { querySeasonalPatterns, type SeasonalResult } from './query'
 import { SeasonalPatterns as SeasonalPatternsView } from './SeasonalPatterns'
 
 export function SeasonalPatterns({ year }: { year: number | undefined }) {
-    const { data } = useDBQueryFirst<SeasonalResult>({
+    const { data, isLoading } = useDBQueryFirst<SeasonalResult>({
         query: querySeasonalPatterns(year),
         year,
     })
 
-    if (!data) return null
-    return <SeasonalPatternsView data={data} />
+    if (!isLoading && !data) return null
+    return <SeasonalPatternsView data={data} isLoading={isLoading} />
 }

--- a/app/src/components/Charts/SimpleCharts/SkipRate/SkipRate.tsx
+++ b/app/src/components/Charts/SimpleCharts/SkipRate/SkipRate.tsx
@@ -4,18 +4,20 @@ import { classifySkipRate } from './classifySkipRate'
 import { ChartCard, ChartHero, ProgressBar, InsightCard } from '../shared'
 
 type Props = {
-    data: SkipRateResult
+    data: SkipRateResult | undefined
+    isLoading?: boolean
 }
 
-export const SkipRate: FC<Props> = ({ data }) => {
-    const { complete_listens, skipped_listens } = data
+export const SkipRate: FC<Props> = ({ data, isLoading }) => {
+    const { complete_listens = 0, skipped_listens = 0 } = data ?? {}
 
-    const complete_pct =
-        (complete_listens / (complete_listens + skipped_listens)) * 100
+    const complete_pct = data
+        ? (complete_listens / (complete_listens + skipped_listens)) * 100
+        : 0
     const { classification, emoji, message } = classifySkipRate(complete_pct)
 
     return (
-        <ChartCard title="Skip Mood" emoji="⏭️">
+        <ChartCard title="Skip Mood" emoji="⏭️" isLoading={isLoading}>
             <ChartHero
                 label={classification}
                 sublabel={`${complete_pct.toFixed(1)}% are full listens`}

--- a/app/src/components/Charts/SimpleCharts/SkipRate/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/SkipRate/index.tsx
@@ -3,11 +3,11 @@ import { querySkipRate, type SkipRateResult } from './query'
 import { SkipRate as SkipRateView } from './SkipRate'
 
 export function SkipRate({ year }: { year: number | undefined }) {
-    const { data } = useDBQueryFirst<SkipRateResult>({
+    const { data, isLoading } = useDBQueryFirst<SkipRateResult>({
         query: querySkipRate(year),
         year,
     })
 
-    if (!data) return null
-    return <SkipRateView data={data} />
+    if (!isLoading && !data) return null
+    return <SkipRateView data={data} isLoading={isLoading} />
 }

--- a/app/src/components/Charts/SimpleCharts/TopAlbums/TopAlbums.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopAlbums/TopAlbums.tsx
@@ -4,18 +4,22 @@ import { memo } from 'react'
 import { ChartCard, RankedList } from '../shared'
 
 type Props = {
-    data: TopAlbumsResult[]
+    data: TopAlbumsResult[] | undefined
+    isLoading?: boolean
 }
 
-export const TopAlbums: FC<Props> = memo(function TopAlbums({ data }) {
-    const items = data.map((album) => ({
+export const TopAlbums: FC<Props> = memo(function TopAlbums({
+    data,
+    isLoading,
+}) {
+    const items = (data ?? []).map((album) => ({
         primary: album.album_name,
         secondary: album.artist_name,
         score: album.count_streams.toLocaleString(),
     }))
 
     return (
-        <ChartCard title="Top Albums" emoji="💿">
+        <ChartCard title="Top Albums" emoji="💿" isLoading={isLoading}>
             <RankedList items={items} />
         </ChartCard>
     )

--- a/app/src/components/Charts/SimpleCharts/TopAlbums/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopAlbums/index.tsx
@@ -3,11 +3,11 @@ import { queryTopAlbums, type TopAlbumsResult } from './query'
 import { TopAlbums as TopAlbumsView } from './TopAlbums'
 
 export function TopAlbums({ year }: { year: number | undefined }) {
-    const { data } = useDBQueryMany<TopAlbumsResult>({
+    const { data, isLoading } = useDBQueryMany<TopAlbumsResult>({
         query: queryTopAlbums(year),
         year,
     })
 
-    if (!data?.length) return null
-    return <TopAlbumsView data={data} />
+    if (!isLoading && !data?.length) return null
+    return <TopAlbumsView data={data} isLoading={isLoading} />
 }

--- a/app/src/components/Charts/SimpleCharts/TopArtists/TopArtists.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopArtists/TopArtists.tsx
@@ -5,18 +5,22 @@ import { formatDuration } from '../../../../utils/formatDuration'
 import { ChartCard, RankedList } from '../shared'
 
 type Props = {
-    data: TopArtistsResult[]
+    data: TopArtistsResult[] | undefined
+    isLoading?: boolean
 }
 
-export const TopArtists: FC<Props> = memo(function TopArtists({ data }) {
-    const items = data.map((artist) => ({
+export const TopArtists: FC<Props> = memo(function TopArtists({
+    data,
+    isLoading,
+}) {
+    const items = (data ?? []).map((artist) => ({
         primary: artist.artist_name,
         secondary: formatDuration(artist.ms_played).split(' ')[0],
         score: artist.count_streams.toLocaleString(),
     }))
 
     return (
-        <ChartCard title="Top Artists" emoji="🎤">
+        <ChartCard title="Top Artists" emoji="🎤" isLoading={isLoading}>
             <RankedList items={items} />
         </ChartCard>
     )

--- a/app/src/components/Charts/SimpleCharts/TopArtists/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopArtists/index.tsx
@@ -3,11 +3,11 @@ import { queryTopArtists, type TopArtistsResult } from './query'
 import { TopArtists as TopArtistsView } from './TopArtists'
 
 export function TopArtists({ year }: { year: number | undefined }) {
-    const { data } = useDBQueryMany<TopArtistsResult>({
+    const { data, isLoading } = useDBQueryMany<TopArtistsResult>({
         query: queryTopArtists(year),
         year,
     })
 
-    if (!data?.length) return null
-    return <TopArtistsView data={data} />
+    if (!isLoading && !data?.length) return null
+    return <TopArtistsView data={data} isLoading={isLoading} />
 }

--- a/app/src/components/Charts/SimpleCharts/TopTracks/TopTracks.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopTracks/TopTracks.tsx
@@ -4,18 +4,22 @@ import { memo } from 'react'
 import { ChartCard, RankedList } from '../shared'
 
 type Props = {
-    data: TopTracksResult[]
+    data: TopTracksResult[] | undefined
+    isLoading?: boolean
 }
 
-export const TopTracks: FC<Props> = memo(function TopTracks({ data }) {
-    const items = data.map((track) => ({
+export const TopTracks: FC<Props> = memo(function TopTracks({
+    data,
+    isLoading,
+}) {
+    const items = (data ?? []).map((track) => ({
         primary: track.track_name,
         secondary: track.artist_name,
         score: track.count_streams.toLocaleString(),
     }))
 
     return (
-        <ChartCard title="Top Tracks" emoji="🎵">
+        <ChartCard title="Top Tracks" emoji="🎵" isLoading={isLoading}>
             <RankedList items={items} />
         </ChartCard>
     )

--- a/app/src/components/Charts/SimpleCharts/TopTracks/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/TopTracks/index.tsx
@@ -3,11 +3,11 @@ import { queryTopTracks, type TopTracksResult } from './query'
 import { TopTracks as TopTracksView } from './TopTracks'
 
 export function TopTracks({ year }: { year: number | undefined }) {
-    const { data } = useDBQueryMany<TopTracksResult>({
+    const { data, isLoading } = useDBQueryMany<TopTracksResult>({
         query: queryTopTracks(year),
         year,
     })
 
-    if (!data?.length) return null
-    return <TopTracksView data={data} />
+    if (!isLoading && !data?.length) return null
+    return <TopTracksView data={data} isLoading={isLoading} />
 }

--- a/app/src/components/Charts/SimpleCharts/shared/ChartCard.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/shared/ChartCard.test.tsx
@@ -24,11 +24,11 @@ describe('ChartCard', () => {
     it('should render children', () => {
         render(
             <ChartCard title="Test">
-                <div data-testid="children">Child content</div>
+                <div>Child content</div>
             </ChartCard>
         )
 
-        expect(screen.getByTestId('children')).toBeDefined()
+        expect(screen.getByText('Child content')).toBeDefined()
     })
 
     it('should apply custom className', () => {
@@ -53,5 +53,53 @@ describe('ChartCard', () => {
         expect(classes).toContain('backdrop-blur-md')
         expect(classes).toContain('rounded-2xl')
         expect(classes).toContain('animate-fade-in')
+    })
+
+    it('should render question when provided', () => {
+        render(
+            <ChartCard title="Test" question="What is my top artist?">
+                Content
+            </ChartCard>
+        )
+
+        expect(screen.getByText('What is my top artist?')).toBeDefined()
+    })
+
+    it('should not render question element when not provided', () => {
+        render(<ChartCard title="Test">Content</ChartCard>)
+
+        expect(screen.queryByText(/\?/)).toBeNull()
+    })
+
+    it('should render skeleton and hide children when isLoading is true', () => {
+        render(
+            <ChartCard title="Test" isLoading>
+                <div>Content</div>
+            </ChartCard>
+        )
+
+        expect(screen.queryByText('Content')).toBeNull()
+        expect(document.querySelector('.animate-pulse')).not.toBeNull()
+    })
+
+    it('should render children and no skeleton when isLoading is false', () => {
+        render(
+            <ChartCard title="Test" isLoading={false}>
+                <div>Content</div>
+            </ChartCard>
+        )
+
+        expect(screen.getByText('Content')).toBeDefined()
+        expect(document.querySelector('.animate-pulse')).toBeNull()
+    })
+
+    it('should render question even when isLoading is true', () => {
+        render(
+            <ChartCard title="Test" isLoading question="Loading question?">
+                Content
+            </ChartCard>
+        )
+
+        expect(screen.getByText('Loading question?')).toBeDefined()
     })
 })

--- a/app/src/components/Charts/SimpleCharts/shared/ChartCard.tsx
+++ b/app/src/components/Charts/SimpleCharts/shared/ChartCard.tsx
@@ -5,6 +5,8 @@ export type ChartCardProps = {
     emoji?: string
     children: ReactNode
     className?: string
+    isLoading?: boolean
+    question?: string
 }
 
 export const ChartCard: FC<ChartCardProps> = ({
@@ -12,6 +14,8 @@ export const ChartCard: FC<ChartCardProps> = ({
     emoji,
     children,
     className = '',
+    isLoading = false,
+    question,
 }) => {
     return (
         <div
@@ -21,7 +25,20 @@ export const ChartCard: FC<ChartCardProps> = ({
                 {emoji && <span>{emoji}</span>}
                 {title}
             </h3>
-            {children}
+            {question && (
+                <p className="text-xs italic text-gray-400 dark:text-gray-500 mb-3 -mt-1">
+                    {question}
+                </p>
+            )}
+            {isLoading ? (
+                <div className="space-y-2 animate-pulse">
+                    <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-3/4" />
+                    <div className="h-3 bg-gray-200 dark:bg-slate-700 rounded w-full" />
+                    <div className="h-3 bg-gray-200 dark:bg-slate-700 rounded w-5/6" />
+                </div>
+            ) : (
+                children
+            )}
         </div>
     )
 }

--- a/app/src/components/Charts/SimpleView.test.tsx
+++ b/app/src/components/Charts/SimpleView.test.tsx
@@ -203,8 +203,13 @@ const repeatBehaviorMock: RepeatResult[] = [
 const principalPlatformMock: PlatformResult[] = [
     {
         platform: 'platform',
+        stream_count: 10,
+        pct: 70,
+    },
+    {
+        platform: 'platform2',
         stream_count: 1,
-        pct: 10,
+        pct: 30,
     },
 ]
 

--- a/app/src/components/Charts/SimpleView.tsx
+++ b/app/src/components/Charts/SimpleView.tsx
@@ -20,25 +20,28 @@ import {
     summarizeQuery,
 } from './Summarize/summarizeQuery'
 import { useState, useEffect } from 'react'
+import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 
 export function SimpleView() {
-    const [year, setYear] = useState<number | undefined>(
-        new Date().getFullYear()
-    )
-    const [minYear, setMinYear] = useState(2006)
-    const [maxYear, setMaxYear] = useState(new Date().getFullYear())
+    const [year, setYear] = useState<number | undefined>(undefined)
+    const [summarize, setSummarize] = useState<
+        SummarizeDataQueryResult | undefined
+    >()
+    const debouncedYear = useDebouncedValue(year, 250)
 
     useEffect(() => {
         const initDataSummarize = async () => {
             const results =
                 await queryDBAsJSON<SummarizeDataQueryResult>(summarizeQuery)
-            if (results.length === 0) return
-            setMinYear(new Date(Number(results[0].min_datetime)).getFullYear())
-            setMaxYear(new Date(Number(results[0].max_datetime)).getFullYear())
-            setYear(new Date(Number(results[0].max_datetime)).getFullYear())
+            setSummarize(results[0] || undefined)
         }
         initDataSummarize()
     }, [])
+
+    useEffect(() => {
+        if (summarize)
+            setYear(new Date(Number(summarize.max_datetime)).getFullYear())
+    }, [summarize])
 
     return (
         <>
@@ -46,34 +49,42 @@ export function SimpleView() {
                 <FunFacts />
             </div>
 
-            <div className="sticky top-2 z-50">
-                <RangeSlider
-                    value={year}
-                    min={minYear}
-                    max={maxYear}
-                    step={1}
-                    onChange={setYear}
-                />
-            </div>
+            {summarize && (
+                <>
+                    <div className="sticky top-2 z-50">
+                        <RangeSlider
+                            value={year}
+                            min={new Date(
+                                Number(summarize.min_datetime)
+                            ).getFullYear()}
+                            max={new Date(
+                                Number(summarize.max_datetime)
+                            ).getFullYear()}
+                            step={1}
+                            onChange={setYear}
+                        />
+                    </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                <TopTracks year={year} />
-                <TopArtists year={year} />
-                <TopAlbums year={year} />
-                <ConcentrationScore year={year} />
-                <ListeningRhythm year={year} />
-                <Regularity year={year} />
-                <div className="md:col-span-2">
-                    <EvolutionOverTime year={year} />
-                </div>
-                <SeasonalPatterns year={year} />
-                <NewVsOld year={year} />
-                <ArtistLoyalty year={year} />
-                <SkipRate year={year} />
-                <RepeatBehavior year={year} />
-                <PrincipalPlatform year={year} />
-                <FavoriteWeekday year={year} />
-            </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                        <TopTracks year={debouncedYear} />
+                        <TopArtists year={debouncedYear} />
+                        <TopAlbums year={debouncedYear} />
+                        <ConcentrationScore year={debouncedYear} />
+                        <ListeningRhythm year={debouncedYear} />
+                        <Regularity year={debouncedYear} />
+                        <div className="md:col-span-2">
+                            <EvolutionOverTime year={debouncedYear} />
+                        </div>
+                        <SeasonalPatterns year={debouncedYear} />
+                        <NewVsOld year={debouncedYear} />
+                        <ArtistLoyalty year={debouncedYear} />
+                        <SkipRate year={debouncedYear} />
+                        <RepeatBehavior year={debouncedYear} />
+                        <PrincipalPlatform year={debouncedYear} />
+                        <FavoriteWeekday year={debouncedYear} />
+                    </div>
+                </>
+            )}
         </>
     )
 }

--- a/app/src/hooks/useDBQuery.test.ts
+++ b/app/src/hooks/useDBQuery.test.ts
@@ -175,4 +175,46 @@ describe('shared behavior', () => {
 
         expect(spy).toHaveBeenCalledTimes(2)
     })
+
+    it('should ignore stale query results when a newer query resolves first', async () => {
+        const staleMock: User[] = [{ id: 1, year: 2024 }]
+        const freshMock: User[] = [{ id: 2, year: 2025 }]
+
+        let resolveStale!: (v: User[]) => void
+        let resolveFresh!: (v: User[]) => void
+
+        const stalePromise = new Promise<User[]>((res) => {
+            resolveStale = res
+        })
+        const freshPromise = new Promise<User[]>((res) => {
+            resolveFresh = res
+        })
+
+        const spy = vi.spyOn(queryDB, 'queryDBAsJSON')
+        spy.mockReturnValueOnce(stalePromise).mockReturnValueOnce(freshPromise)
+
+        const { result, rerender } = renderHook(
+            ({ year }: { year: number }) =>
+                useDBQueryMany<User>({
+                    query: `SELECT * FROM test WHERE year = ${year}`,
+                    year,
+                }),
+            { initialProps: { year: 2024 } }
+        )
+
+        // Trigger second query before first resolves
+        rerender({ year: 2025 })
+
+        // Fresh query resolves first
+        resolveFresh(freshMock)
+        await waitFor(() => {
+            expect(result.current.data).toEqual(freshMock)
+        })
+
+        // Stale query resolves after — should be ignored
+        resolveStale(staleMock)
+        await waitFor(() => {
+            expect(result.current.data).toEqual(freshMock)
+        })
+    })
 })

--- a/app/src/hooks/useDBQuery.ts
+++ b/app/src/hooks/useDBQuery.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { queryDBAsJSON } from '../db/queries/queryDB'
 
 type DBPrimitive = string | number | null
@@ -22,19 +22,25 @@ export function useDBQueryMany<T extends DBRow>({
     const [data, setData] = useState<T[] | undefined>(undefined)
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState<Error | undefined>(undefined)
+    const requestIdRef = useRef(0)
 
     useEffect(() => {
+        const id = ++requestIdRef.current
+
         const fetchData = async () => {
             setIsLoading(true)
             setError(undefined)
 
             try {
                 const rows = await queryDBAsJSON<T>(query)
-                setData(rows)
+                if (id === requestIdRef.current) setData(rows)
             } catch (e) {
-                setError(e instanceof Error ? e : new Error('Unknown error'))
+                if (id === requestIdRef.current)
+                    setError(
+                        e instanceof Error ? e : new Error('Unknown error')
+                    )
             } finally {
-                setIsLoading(false)
+                if (id === requestIdRef.current) setIsLoading(false)
             }
         }
 
@@ -51,19 +57,25 @@ export function useDBQueryFirst<T extends DBRow>({
     const [data, setData] = useState<T | undefined>(undefined)
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState<Error | undefined>(undefined)
+    const requestIdRef = useRef(0)
 
     useEffect(() => {
+        const id = ++requestIdRef.current
+
         const fetchData = async () => {
             setIsLoading(true)
             setError(undefined)
 
             try {
                 const rows = await queryDBAsJSON<T>(query)
-                setData(rows[0])
+                if (id === requestIdRef.current) setData(rows[0])
             } catch (e) {
-                setError(e instanceof Error ? e : new Error('Unknown error'))
+                if (id === requestIdRef.current)
+                    setError(
+                        e instanceof Error ? e : new Error('Unknown error')
+                    )
             } finally {
-                setIsLoading(false)
+                if (id === requestIdRef.current) setIsLoading(false)
             }
         }
 

--- a/app/src/hooks/useDebouncedValue.test.ts
+++ b/app/src/hooks/useDebouncedValue.test.ts
@@ -1,0 +1,68 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useDebouncedValue } from './useDebouncedValue'
+
+describe('useDebouncedValue', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it('should return initial value immediately', () => {
+        const { result } = renderHook(() => useDebouncedValue(42, 250))
+        expect(result.current).toBe(42)
+    })
+
+    it('should not update before delay elapses', () => {
+        const { result, rerender } = renderHook(
+            ({ value }) => useDebouncedValue(value, 250),
+            { initialProps: { value: 1 } }
+        )
+
+        rerender({ value: 2 })
+        act(() => {
+            vi.advanceTimersByTime(100)
+        })
+
+        expect(result.current).toBe(1)
+    })
+
+    it('should update after delay elapses', () => {
+        const { result, rerender } = renderHook(
+            ({ value }) => useDebouncedValue(value, 250),
+            { initialProps: { value: 1 } }
+        )
+
+        rerender({ value: 2 })
+        act(() => {
+            vi.advanceTimersByTime(250)
+        })
+
+        expect(result.current).toBe(2)
+    })
+
+    it('should only emit the last value when updated rapidly', () => {
+        const { result, rerender } = renderHook(
+            ({ value }) => useDebouncedValue(value, 250),
+            { initialProps: { value: 1 } }
+        )
+
+        rerender({ value: 2 })
+        act(() => {
+            vi.advanceTimersByTime(100)
+        })
+        rerender({ value: 3 })
+        act(() => {
+            vi.advanceTimersByTime(100)
+        })
+        rerender({ value: 4 })
+        act(() => {
+            vi.advanceTimersByTime(250)
+        })
+
+        expect(result.current).toBe(4)
+    })
+})

--- a/app/src/hooks/useDebouncedValue.ts
+++ b/app/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react'
+
+export function useDebouncedValue<T>(value: T, delay: number): T {
+    const [debounced, setDebounced] = useState(value)
+
+    useEffect(() => {
+        const id = setTimeout(() => setDebounced(value), delay)
+        return () => clearTimeout(id)
+    }, [value, delay])
+
+    return debounced
+}


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Charts had no loading state, no debounce on the year slider, and stale query responses could overwrite fresher results when queries resolved out of order.

## 🎹 Proposal

- Add `useDebouncedValue` hook to delay year-slider queries by 250 ms
- Introduce a request-ID ref pattern in `useDBQuery` to discard out-of-order responses
- Show a skeleton shimmer on initial chart load

## 🎶 Comments

The request-ID pattern is a lightweight alternative to `AbortController` and avoids any DuckDB WASM cancellation complexity.

Closes #145.

## 🎤 Test

- Move the year slider quickly and verify charts don't flash intermediate states
- Load data and confirm the skeleton shimmer appears, then resolves to chart content
- Open DevTools and verify no "state update on unmounted component" warnings