### PR TITLE
fix(charts): fix SQL conditions, rendering guards, and chart refactors

### DIFF
--- a/app/src/components/Charts/DetailedCharts/StreamPerDayOfWeek/plot.tsx
+++ b/app/src/components/Charts/DetailedCharts/StreamPerDayOfWeek/plot.tsx
@@ -37,7 +37,7 @@ export function buildPlot(
                 tip: {
                     format: {
                         x: (d) => `${d}h`,
-                        y: (d) => days[d - 1],
+                        y: (d) => days[d],
                         fill: (d) => `${d} streams`,
                     },
                 },

--- a/app/src/components/Charts/DetailedCharts/Top10AlbumsEvolution/Top10AlbumsEvolution.sql
+++ b/app/src/components/Charts/DetailedCharts/Top10AlbumsEvolution/Top10AlbumsEvolution.sql
@@ -12,6 +12,8 @@ album_listening as (
         count(*) as playing_days_count
     from ${table}, max_date
     group by album_name, artist_name, ts::date
+    -- arbitrary threshold: an album listen is counted from 7 distinct tracks
+    -- conservative lower bound of average album length
     having count(distinct track_name) >= 7
 ),
 

--- a/app/src/components/Charts/DetailedCharts/TotalStreams/index.tsx
+++ b/app/src/components/Charts/DetailedCharts/TotalStreams/index.tsx
@@ -15,7 +15,7 @@ export function TotalStreams() {
             setData(result)
         }
         getData()
-    }, [queryTotalStreams])
+    }, [])
 
     if (!data) return <></>
 

--- a/app/src/components/Charts/SimpleCharts/FunFacts/NightFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/NightFavorite.sql
@@ -6,7 +6,7 @@ select
     'between 0am and 6am' as context
 from ${table}
 where
-    (hour(ts::datetime) >= 24 or hour(ts::datetime) < 6)
+    hour(ts::datetime) < 6
     and artist_name is not null
 group by artist_name
 order by value desc

--- a/app/src/components/Charts/SimpleCharts/FunFacts/WeekendFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/WeekendFavorite.sql
@@ -8,7 +8,7 @@ from ${table}
 where
     (
         dayofweek(ts::date) in (0, 6)
-        or (dayofweek(ts::date) in (5, 6) and hour(ts::datetime) >= 18)
+        or (dayofweek(ts::date) = 5 and hour(ts::datetime) >= 18)
     )
     and artist_name is not null
 group by artist_name

--- a/app/src/components/Charts/SimpleCharts/PrincipalPlatform/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/PrincipalPlatform/index.tsx
@@ -9,5 +9,6 @@ export function PrincipalPlatform({ year }: { year: number | undefined }) {
     })
 
     if (!isLoading && !data?.length) return null
+    if (!data || data.length <= 1) return null
     return <PrincipalPlatformView data={data} isLoading={isLoading} />
 }

--- a/app/src/components/Charts/SimpleCharts/RepeatBehavior/RepeatBehavior.sql
+++ b/app/src/components/Charts/SimpleCharts/RepeatBehavior/RepeatBehavior.sql
@@ -41,7 +41,12 @@ select
     count(*)::double as total_repeat_sequences,
     coalesce(max(repeat_count)::double, 0) as max_consecutive,
     coalesce(
-        (select track_name from group_sizes order by repeat_count desc limit 1),
+        (
+            select track_name
+            from group_sizes
+            order by repeat_count desc, track_name asc
+            limit 1
+        ),
         ''
     ) as most_repeated_track,
     coalesce(avg(repeat_count)::double, 0) as avg_repeat_length

--- a/app/src/components/Charts/SimpleView.tsx
+++ b/app/src/components/Charts/SimpleView.tsx
@@ -33,15 +33,12 @@ export function SimpleView() {
         const initDataSummarize = async () => {
             const results =
                 await queryDBAsJSON<SummarizeDataQueryResult>(summarizeQuery)
-            setSummarize(results[0] || undefined)
+            const s = results[0]
+            setSummarize(s)
+            if (s) setYear(new Date(Number(s.max_datetime)).getFullYear())
         }
         initDataSummarize()
     }, [])
-
-    useEffect(() => {
-        if (summarize)
-            setYear(new Date(Number(summarize.max_datetime)).getFullYear())
-    }, [summarize])
 
     return (
         <>


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Several SQL queries had redundant or incorrect conditions. Some charts rendered in edge cases where they shouldn't. The SimpleView derived the year in a separate reactive effect.

## 🎹 Proposal
- remove redundant conditions from NightFavorite and WeekendFavorite SQL (`hour >= 24` is unreachable; Saturday was already covered by the first predicate)
- document the album listen threshold in Top10AlbumsEvolution (arbitrary: 7 distinct tracks, conservative lower bound of average album length)
- show correct day name in StreamPerDayOfWeek tooltips (off-by-one in array index)
- prevent TotalStreams from re-fetching on every render (stale dep in effect array)
- hide the platform chart when all streams come from a single platform
- avoid a redundant render when loading the view (merge summarize + year derivation into one effect)

## 🎤 Test

- Load data and verify affected charts display correct values
- Verify PrincipalPlatform is hidden when only one platform is present
- Verify StreamPerDayOfWeek tooltips show the right day name