### PR TITLE
chore(e2e): disable E2E tests for the preview deployment

### DIFF
--- a/.github/workflows/app-deploy-preview.yml
+++ b/.github/workflows/app-deploy-preview.yml
@@ -67,11 +67,16 @@ jobs:
           deploy-commit-message: "chore(): deploy Tracksy App Preview for PR #${{ github.event.number }}"
           remove-commit-message: "chore(): remove Tracksy App Preview for PR #${{ github.event.number }}"
 
-  e2e-tests:
-    needs: deploy-preview
-    if: github.event.action != 'closed'
-    uses: ./.github/workflows/e2e.yml
-    with:
-      baseUrl: ${{ needs.deploy-preview.outputs.preview-url}}
-      testPath: /tracksy/pr-preview/pr-${{ github.event.pull_request.number }}
-    secrets: inherit
+  # Temporarily disabled:
+  # - E2E tests are currently broken
+  # - tracked in issue #347
+  # - re-enable once the issue is fixed
+  #
+  # e2e-tests:
+  #   needs: deploy-preview
+  #   if: github.event.action != 'closed'
+  #   uses: ./.github/workflows/e2e.yml
+  #   with:
+  #     baseUrl: ${{ needs.deploy-preview.outputs.preview-url}}
+  #     testPath: /tracksy/pr-preview/pr-${{ github.event.pull_request.number }}
+  #   secrets: inherit


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

E2E tests are broken (#347), all CI/CD runs for PRs are failing.

## 🎹 Proposal

Temporarily disable E2E tests for the preview deployment.

Continue to failed for the "live" deployment. 

## 🎶 Comments

I don't yet know how to fix the real problem with E2E tests.

## 🎤 Test

<!-- Instructions for reproducing the problem and how you tested the fix. -->
