### PR TITLE
feat(charts): add SessionAnalysis cards

### DIFF
--- a/app/src/components/Charts/DetailedCharts/Common/index.tsx
+++ b/app/src/components/Charts/DetailedCharts/Common/index.tsx
@@ -2,12 +2,11 @@
 
 import { useState, useEffect, useRef, useContext } from 'react'
 import { queryDBAsJSON } from '../../../../db/queries/queryDB'
-import { plot } from '@observablehq/plot'
 import { ThemeContext } from '../../../../hooks/ThemeContext'
 
 export interface CommonProps<T> {
     query: string
-    buildPlot: (data: T[], isDark?: boolean) => ReturnType<typeof plot>
+    buildPlot: (data: T[], isDark?: boolean) => Element
 }
 
 export function Common<T extends Record<string, string | number | null>>({

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/SessionAnalysis.test.tsx
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/SessionAnalysis.test.tsx
@@ -15,6 +15,7 @@ const queryResult: SessionAnalysisDetailedResult[] = [
         session_start: '2025-01-10T20:00:00',
         session_end: '2025-01-10T20:30:00',
         day_of_week: 5,
+        start_hour: 20,
     },
     {
         session_id: 2,
@@ -23,6 +24,7 @@ const queryResult: SessionAnalysisDetailedResult[] = [
         session_start: '2025-01-15T21:00:00',
         session_end: '2025-01-15T22:00:00',
         day_of_week: 3,
+        start_hour: 21,
     },
 ]
 

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/SessionAnalysis.test.tsx
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/SessionAnalysis.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+
+import * as query from '../../../../db/queries/queryDB'
+import * as db from '../../../../db/getDB'
+import type { SessionAnalysisDetailedResult } from './query'
+
+import { SessionAnalysis } from '.'
+
+const queryResult: SessionAnalysisDetailedResult[] = [
+    {
+        session_id: 1,
+        track_count: 5,
+        duration_ms: 1800000,
+        session_start: '2025-01-10T20:00:00',
+        session_end: '2025-01-10T20:30:00',
+        day_of_week: 5,
+    },
+    {
+        session_id: 2,
+        track_count: 8,
+        duration_ms: 3600000,
+        session_start: '2025-01-15T21:00:00',
+        session_end: '2025-01-15T22:00:00',
+        day_of_week: 3,
+    },
+]
+
+describe('SessionAnalysis Detailed Component', () => {
+    beforeEach(() => {
+        vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue(queryResult)
+
+        vi.spyOn(db, 'getDB').mockResolvedValue({
+            db: vi.fn(),
+            conn: vi.fn(),
+        } as unknown as Awaited<ReturnType<typeof db.getDB>>)
+    })
+
+    it('should render three sub-charts as SVGs', async () => {
+        const { container } = render(<SessionAnalysis year={2025} />)
+
+        await waitFor(() => {
+            expect(container.querySelectorAll('svg')).toHaveLength(3)
+        })
+    })
+
+    it('should render all sessions when year is undefined', async () => {
+        const { container } = render(<SessionAnalysis year={undefined} />)
+
+        await waitFor(() => {
+            expect(container.querySelectorAll('svg').length).toBeGreaterThan(0)
+        })
+    })
+})

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/index.tsx
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/index.tsx
@@ -1,0 +1,29 @@
+import { useCallback } from 'react'
+import type { SessionAnalysisDetailedResult } from './query'
+import { buildSessionAnalysisDetailedQuery } from './query'
+import { buildPlot } from './plot'
+import { Common } from '../Common'
+
+interface SessionAnalysisProps {
+    year: number | undefined
+}
+
+export function SessionAnalysis({ year }: SessionAnalysisProps) {
+    const plotBuilder = useCallback(
+        (data: SessionAnalysisDetailedResult[], isDark: boolean | undefined) =>
+            buildPlot(data, isDark),
+        []
+    )
+
+    return (
+        <div>
+            <p className="text-xs italic text-gray-400 dark:text-gray-500 px-6 pt-4 -mb-2">
+                How have my listening sessions evolved over time?
+            </p>
+            <Common<SessionAnalysisDetailedResult>
+                query={buildSessionAnalysisDetailedQuery(year)}
+                buildPlot={plotBuilder}
+            />
+        </div>
+    )
+}

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/plot.tsx
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/plot.tsx
@@ -6,7 +6,7 @@ const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 export function buildPlot(
     data: SessionAnalysisDetailedResult[],
     isDark = false
-): ReturnType<typeof Plot.plot> {
+): HTMLDivElement {
     const brandPurple = '#7c3aed'
     const style = {
         background: 'transparent',
@@ -93,5 +93,5 @@ export function buildPlot(
     const container = document.createElement('div')
     container.className = 'space-y-4 p-4'
     container.append(hist, scatter, dayBar)
-    return container as unknown as ReturnType<typeof Plot.plot>
+    return container
 }

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/plot.tsx
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/plot.tsx
@@ -1,0 +1,97 @@
+import * as Plot from '@observablehq/plot'
+import type { SessionAnalysisDetailedResult } from './query'
+
+const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+export function buildPlot(
+    data: SessionAnalysisDetailedResult[],
+    isDark = false
+): ReturnType<typeof Plot.plot> {
+    const brandPurple = '#7c3aed'
+    const style = {
+        background: 'transparent',
+        color: isDark ? '#e5e7eb' : '#1f2937',
+    }
+
+    const hist = Plot.plot({
+        title: 'Session duration distribution',
+        width: 600,
+        height: 220,
+        style,
+        x: { label: 'Duration (min)', nice: true },
+        y: { label: 'Sessions', grid: true },
+        color: { range: ['#ede9fe', brandPurple] },
+        marks: [
+            Plot.rectY(data, {
+                ...Plot.binX(
+                    { y: 'count', fill: 'count' },
+                    {
+                        x: (d: SessionAnalysisDetailedResult) =>
+                            d.duration_ms / 60000,
+                        thresholds: [0, 10, 20, 40, 60, 90, 120],
+                    }
+                ),
+                tip: true,
+            }),
+            Plot.ruleY([0]),
+        ],
+    })
+
+    const scatter = Plot.plot({
+        title: 'Sessions over time',
+        width: 600,
+        height: 260,
+        style,
+        x: { label: 'Date', type: 'time', nice: true },
+        y: {
+            label: 'Start hour',
+            domain: [0, 23],
+            tickFormat: (d: number) => `${d}h`,
+        },
+        r: { range: [2, 20] },
+        marks: [
+            Plot.dot(data, {
+                x: (d: SessionAnalysisDetailedResult) =>
+                    new Date(d.session_start),
+                y: (d: SessionAnalysisDetailedResult) =>
+                    new Date(d.session_start).getHours(),
+                r: (d: SessionAnalysisDetailedResult) => d.duration_ms / 60000,
+                fill: brandPurple,
+                fillOpacity: 0.6,
+                tip: true,
+            }),
+        ],
+    })
+
+    const countByDay = data.reduce<number[]>(
+        (acc, d) => {
+            acc[new Date(d.session_start).getDay()]++
+            return acc
+        },
+        [0, 0, 0, 0, 0, 0, 0]
+    )
+    const dayCounts = DAYS.map((day, i) => ({ day, count: countByDay[i] }))
+
+    const dayBar = Plot.plot({
+        title: 'Sessions by day of week',
+        width: 400,
+        height: 200,
+        style,
+        x: { label: 'Day', domain: DAYS },
+        y: { label: 'Sessions', grid: true },
+        marks: [
+            Plot.barY(dayCounts, {
+                x: 'day',
+                y: 'count',
+                fill: brandPurple,
+                tip: true,
+            }),
+            Plot.ruleY([0]),
+        ],
+    })
+
+    const container = document.createElement('div')
+    container.className = 'space-y-4 p-4'
+    container.append(hist, scatter, dayBar)
+    return container as unknown as ReturnType<typeof Plot.plot>
+}

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/plot.tsx
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/plot.tsx
@@ -53,8 +53,7 @@ export function buildPlot(
             Plot.dot(data, {
                 x: (d: SessionAnalysisDetailedResult) =>
                     new Date(d.session_start),
-                y: (d: SessionAnalysisDetailedResult) =>
-                    new Date(d.session_start).getHours(),
+                y: (d: SessionAnalysisDetailedResult) => d.start_hour,
                 r: (d: SessionAnalysisDetailedResult) => d.duration_ms / 60000,
                 fill: brandPurple,
                 fillOpacity: 0.6,

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/plot.tsx
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/plot.tsx
@@ -65,7 +65,7 @@ export function buildPlot(
 
     const countByDay = data.reduce<number[]>(
         (acc, d) => {
-            acc[new Date(d.session_start).getDay()]++
+            acc[d.day_of_week]++
             return acc
         },
         [0, 0, 0, 0, 0, 0, 0]

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.test.ts
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.test.ts
@@ -78,4 +78,13 @@ describe('SessionAnalysis Detailed Query', () => {
         expect(rows[0].day_of_week).toBe(5)
         expect(rows[1].day_of_week).toBe(3)
     })
+
+    it('should return start_hour computed by DuckDB', async () => {
+        const result = await conn.runAndReadAll(
+            buildSessionAnalysisDetailedQuery(2025)
+        )
+        const rows = result.getRowObjectsJson()
+        expect(rows[0].start_hour).toBe(20)
+        expect(rows[1].start_hour).toBe(21)
+    })
 })

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.test.ts
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
+import { buildSessionAnalysisDetailedQuery } from './query'
+import { DuckDBConnection } from '@duckdb/node-api'
+
+let conn: DuckDBConnection
+
+describe('SessionAnalysis Detailed Query', () => {
+    beforeAll(async () => {
+        conn = await DuckDBConnection.create()
+    })
+
+    afterAll(() => {
+        conn.closeSync()
+    })
+
+    beforeEach(async () => {
+        await conn.run(`
+            CREATE OR REPLACE TABLE stream_sessions (
+                session_id BIGINT,
+                track_count BIGINT,
+                duration_ms BIGINT,
+                session_start VARCHAR,
+                session_end VARCHAR
+            )
+        `)
+        await conn.run(`
+            INSERT INTO stream_sessions VALUES
+            (1, 5, 1800000, '2025-01-10T20:00:00', '2025-01-10T20:30:00'),
+            (2, 8, 3600000, '2025-01-15T21:00:00', '2025-01-15T22:00:00'),
+            (3, 3,  900000, '2024-06-01T10:00:00', '2024-06-01T10:15:00')
+        `)
+    })
+
+    it('should filter to the specified year', async () => {
+        const result = await conn.runAndReadAll(
+            buildSessionAnalysisDetailedQuery(2025)
+        )
+        const rows = result.getRowObjectsJson()
+        expect(rows).toHaveLength(2)
+    })
+
+    it('should return all sessions when year is undefined', async () => {
+        const result = await conn.runAndReadAll(
+            buildSessionAnalysisDetailedQuery(undefined)
+        )
+        const rows = result.getRowObjectsJson()
+        expect(rows).toHaveLength(3)
+    })
+
+    it('should return correct session fields', async () => {
+        const result = await conn.runAndReadAll(
+            buildSessionAnalysisDetailedQuery(2025)
+        )
+        const rows = result.getRowObjectsJson()
+        expect(rows[0]).toMatchObject({
+            session_id: 1,
+            track_count: 5,
+            duration_ms: 1800000,
+        })
+    })
+
+    it('should order results by session_start ascending', async () => {
+        const result = await conn.runAndReadAll(
+            buildSessionAnalysisDetailedQuery(2025)
+        )
+        const rows = result.getRowObjectsJson()
+        const starts = rows.map((r) => r.session_start as string)
+        expect(starts[0] < starts[1]).toBe(true)
+    })
+})

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.test.ts
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
 import { buildSessionAnalysisDetailedQuery } from './query'
 import { DuckDBConnection } from '@duckdb/node-api'
+import { STREAM_SESSIONS_TABLE } from '../../../../db/queries/constants'
 
 let conn: DuckDBConnection
 
@@ -15,7 +16,7 @@ describe('SessionAnalysis Detailed Query', () => {
 
     beforeEach(async () => {
         await conn.run(`
-            CREATE OR REPLACE TABLE stream_sessions (
+            CREATE OR REPLACE TABLE ${STREAM_SESSIONS_TABLE} (
                 session_id BIGINT,
                 track_count BIGINT,
                 duration_ms BIGINT,
@@ -24,7 +25,7 @@ describe('SessionAnalysis Detailed Query', () => {
             )
         `)
         await conn.run(`
-            INSERT INTO stream_sessions VALUES
+            INSERT INTO ${STREAM_SESSIONS_TABLE} VALUES
             (1, 5, 1800000, '2025-01-10T20:00:00', '2025-01-10T20:30:00'),
             (2, 8, 3600000, '2025-01-15T21:00:00', '2025-01-15T22:00:00'),
             (3, 3,  900000, '2024-06-01T10:00:00', '2024-06-01T10:15:00')

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.test.ts
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.test.ts
@@ -67,4 +67,14 @@ describe('SessionAnalysis Detailed Query', () => {
         const starts = rows.map((r) => r.session_start as string)
         expect(starts[0] < starts[1]).toBe(true)
     })
+
+    it('should return day_of_week computed by DuckDB', async () => {
+        const result = await conn.runAndReadAll(
+            buildSessionAnalysisDetailedQuery(2025)
+        )
+        const rows = result.getRowObjectsJson()
+        // 2025-01-10 is a Friday (5), 2025-01-15 is a Wednesday (3)
+        expect(rows[0].day_of_week).toBe(5)
+        expect(rows[1].day_of_week).toBe(3)
+    })
 })

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.ts
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.ts
@@ -1,4 +1,5 @@
 import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
+import { STREAM_SESSIONS_TABLE } from '../../../../db/queries/constants'
 
 export type SessionAnalysisDetailedResult = {
     session_id: number
@@ -21,7 +22,7 @@ export function buildSessionAnalysisDetailedQuery(
             session_start::VARCHAR                          AS session_start,
             session_end::VARCHAR                            AS session_end,
             dayofweek(session_start::timestamp)::INTEGER    AS day_of_week
-        FROM stream_sessions
+        FROM ${STREAM_SESSIONS_TABLE}
         WHERE ${yearCondition}
         ORDER BY session_start
     `

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.ts
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.ts
@@ -6,6 +6,7 @@ export type SessionAnalysisDetailedResult = {
     duration_ms: number
     session_start: string
     session_end: string
+    day_of_week: number
 }
 
 export function buildSessionAnalysisDetailedQuery(
@@ -14,11 +15,12 @@ export function buildSessionAnalysisDetailedQuery(
     const yearCondition = buildYearCondition(year, 'year(session_start::date)')
     return `
         SELECT
-            session_id::DOUBLE     AS session_id,
-            track_count::DOUBLE    AS track_count,
-            duration_ms::DOUBLE    AS duration_ms,
-            session_start::VARCHAR AS session_start,
-            session_end::VARCHAR   AS session_end
+            session_id::DOUBLE                              AS session_id,
+            track_count::DOUBLE                             AS track_count,
+            duration_ms::DOUBLE                             AS duration_ms,
+            session_start::VARCHAR                          AS session_start,
+            session_end::VARCHAR                            AS session_end,
+            dayofweek(session_start::timestamp)::INTEGER    AS day_of_week
         FROM stream_sessions
         WHERE ${yearCondition}
         ORDER BY session_start

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.ts
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.ts
@@ -1,0 +1,26 @@
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
+
+export type SessionAnalysisDetailedResult = {
+    session_id: number
+    track_count: number
+    duration_ms: number
+    session_start: string
+    session_end: string
+}
+
+export function buildSessionAnalysisDetailedQuery(
+    year: number | undefined
+): string {
+    const yearCondition = buildYearCondition(year, 'year(session_start::date)')
+    return `
+        SELECT
+            session_id::DOUBLE     AS session_id,
+            track_count::DOUBLE    AS track_count,
+            duration_ms::DOUBLE    AS duration_ms,
+            session_start::VARCHAR AS session_start,
+            session_end::VARCHAR   AS session_end
+        FROM stream_sessions
+        WHERE ${yearCondition}
+        ORDER BY session_start
+    `
+}

--- a/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.ts
+++ b/app/src/components/Charts/DetailedCharts/SessionAnalysis/query.ts
@@ -8,6 +8,7 @@ export type SessionAnalysisDetailedResult = {
     session_start: string
     session_end: string
     day_of_week: number
+    start_hour: number
 }
 
 export function buildSessionAnalysisDetailedQuery(
@@ -21,7 +22,8 @@ export function buildSessionAnalysisDetailedQuery(
             duration_ms::DOUBLE                             AS duration_ms,
             session_start::VARCHAR                          AS session_start,
             session_end::VARCHAR                            AS session_end,
-            dayofweek(session_start::timestamp)::INTEGER    AS day_of_week
+            dayofweek(session_start::timestamp)::INTEGER    AS day_of_week,
+            hour(session_start::timestamp)::INTEGER          AS start_hour
         FROM ${STREAM_SESSIONS_TABLE}
         WHERE ${yearCondition}
         ORDER BY session_start

--- a/app/src/components/Charts/DetailedView.tsx
+++ b/app/src/components/Charts/DetailedView.tsx
@@ -21,6 +21,7 @@ import { Top10AlbumsEvolution } from './DetailedCharts/Top10AlbumsEvolution'
 import { Top10TracksEvolution } from './DetailedCharts/Top10TracksEvolution'
 import { StreamPerDayOfWeek } from './DetailedCharts/StreamPerDayOfWeek'
 import { ArtistDiscovery } from './DetailedCharts/ArtistDiscovery'
+import { SessionAnalysis as SessionAnalysisDetailed } from './DetailedCharts/SessionAnalysis'
 import { DuckDBShell } from '../DuckDBShell/DuckDBShell'
 
 export function DetailedView() {
@@ -99,6 +100,7 @@ export function DetailedView() {
                 <Streaks />
                 <Top10Evolution />
                 <Top10TracksEvolution />
+                <SessionAnalysisDetailed year={debouncedYear} />
             </section>
             <DuckDBShell />
         </>

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.sql
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.sql
@@ -6,5 +6,5 @@ select
     avg(duration_ms) as avg_duration_ms,
     median(track_count) as median_tracks,
     max_by(session_start, duration_ms) as longest_session_date
-from stream_sessions
+from ${table}
 where ${year_condition}

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.sql
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.sql
@@ -1,0 +1,10 @@
+select
+    count(*)::double as session_count,
+    max(duration_ms)::double as longest_session_ms,
+    max(track_count)::double as longest_session_track_count,
+    mode(hour(session_start::timestamp))::integer as peak_start_hour,
+    avg(duration_ms) as avg_duration_ms,
+    median(track_count) as median_tracks,
+    max_by(session_start, duration_ms) as longest_session_date
+from stream_sessions
+where ${year_condition}

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SessionAnalysis } from './SessionAnalysis'
+
+const baseData = {
+    session_count: 42,
+    avg_duration_ms: 600000,
+    median_tracks: 6,
+    longest_session_ms: 1800000,
+    longest_session_track_count: 15,
+    longest_session_date: '2025-01-10T20:00:00',
+    peak_start_hour: 20,
+}
+
+describe('SessionAnalysis Component', () => {
+    it('renders Express profile for short average sessions', () => {
+        render(<SessionAnalysis data={baseData} />)
+        expect(screen.getByText('Express')).toBeTruthy()
+        expect(screen.getByText('42 sessions')).toBeTruthy()
+    })
+
+    it('renders Balanced profile for medium average sessions', () => {
+        render(
+            <SessionAnalysis data={{ ...baseData, avg_duration_ms: 2400000 }} />
+        )
+        expect(screen.getByText('Balanced')).toBeTruthy()
+    })
+
+    it('renders Marathon profile for long average sessions', () => {
+        render(
+            <SessionAnalysis data={{ ...baseData, avg_duration_ms: 7200000 }} />
+        )
+        expect(screen.getByText('Marathon')).toBeTruthy()
+    })
+
+    it('renders Balanced at exactly the Express upper boundary (1 200 000 ms)', () => {
+        render(
+            <SessionAnalysis data={{ ...baseData, avg_duration_ms: 1200000 }} />
+        )
+        expect(screen.getByText('Balanced')).toBeTruthy()
+    })
+
+    it('renders Marathon at exactly the Balanced upper boundary (3 600 000 ms)', () => {
+        render(
+            <SessionAnalysis data={{ ...baseData, avg_duration_ms: 3600000 }} />
+        )
+        expect(screen.getByText('Marathon')).toBeTruthy()
+    })
+
+    it('renders peak start hour', () => {
+        render(<SessionAnalysis data={baseData} />)
+        expect(screen.getByText(/20h/)).toBeTruthy()
+    })
+
+    it('renders skeleton and title when loading', () => {
+        render(<SessionAnalysis data={undefined} isLoading />)
+        expect(screen.getByText('Listening sessions')).toBeTruthy()
+    })
+})

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.test.tsx
@@ -52,6 +52,14 @@ describe('SessionAnalysis Component', () => {
         expect(screen.getByText(/20h/)).toBeTruthy()
     })
 
+    it('renders the longest session date', () => {
+        render(<SessionAnalysis data={baseData} />)
+        const expectedDate = new Date(
+            baseData.longest_session_date
+        ).toLocaleDateString()
+        expect(screen.getByText(new RegExp(expectedDate))).toBeTruthy()
+    })
+
     it('renders skeleton and title when loading', () => {
         render(<SessionAnalysis data={undefined} isLoading />)
         expect(screen.getByText('Listening sessions')).toBeTruthy()

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.tsx
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.tsx
@@ -1,0 +1,77 @@
+import type { FC } from 'react'
+import type { SessionAnalysisResult } from './query'
+import { ChartCard, ChartHero, InsightCard } from '../shared'
+import { formatDuration } from '../../../../utils/formatDuration'
+
+type Props = {
+    data: SessionAnalysisResult | undefined
+    isLoading?: boolean
+}
+
+type Profile = { label: string; emoji: string; color: string }
+
+function classify(avgMs: number): Profile {
+    if (avgMs < 1200000)
+        return { label: 'Express', emoji: '🏃', color: 'text-green-400' }
+    if (avgMs < 3600000)
+        return { label: 'Balanced', emoji: '🎧', color: 'text-blue-400' }
+    return { label: 'Marathon', emoji: '🏔️', color: 'text-purple-400' }
+}
+
+export const SessionAnalysis: FC<Props> = ({ data, isLoading }) => {
+    const profile = data ? classify(data.avg_duration_ms) : null
+
+    return (
+        <ChartCard
+            title="Listening sessions"
+            emoji="🎵"
+            isLoading={isLoading}
+            question="How are my listening sessions structured?"
+        >
+            {profile && (
+                <ChartHero
+                    label={profile.label}
+                    sublabel={`${(data?.session_count ?? 0).toLocaleString()} sessions`}
+                    emoji={profile.emoji}
+                    labelColor={profile.color}
+                />
+            )}
+
+            {data && (
+                <div className="space-y-3">
+                    <div className="grid grid-cols-2 gap-2 text-sm">
+                        <div className="text-center p-2 bg-gray-100 dark:bg-slate-700/50 rounded-lg">
+                            <div className="font-semibold text-gray-800 dark:text-gray-200">
+                                {formatDuration(
+                                    Math.round(data.avg_duration_ms)
+                                )}
+                            </div>
+                            <div className="text-xs text-gray-500 dark:text-gray-400">
+                                average duration
+                            </div>
+                        </div>
+                        <div className="text-center p-2 bg-gray-100 dark:bg-slate-700/50 rounded-lg">
+                            <div className="font-semibold text-gray-800 dark:text-gray-200">
+                                {Math.round(data.median_tracks)} tracks
+                            </div>
+                            <div className="text-xs text-gray-500 dark:text-gray-400">
+                                median per session
+                            </div>
+                        </div>
+                    </div>
+
+                    <InsightCard>
+                        Longest:{' '}
+                        {formatDuration(Math.round(data.longest_session_ms))} —{' '}
+                        {data.longest_session_track_count} tracks
+                    </InsightCard>
+
+                    <InsightCard>
+                        Favorite start time:{' '}
+                        {String(data.peak_start_hour).padStart(2, '0')}h
+                    </InsightCard>
+                </div>
+            )}
+        </ChartCard>
+    )
+}

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.tsx
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.tsx
@@ -31,7 +31,7 @@ export const SessionAnalysis: FC<Props> = ({ data, isLoading }) => {
             {profile && (
                 <ChartHero
                     label={profile.label}
-                    sublabel={`${(data?.session_count ?? 0).toLocaleString()} sessions`}
+                    sublabel={`${data!.session_count.toLocaleString()} sessions`}
                     emoji={profile.emoji}
                     labelColor={profile.color}
                 />

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.tsx
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.tsx
@@ -73,6 +73,9 @@ export const SessionAnalysis: FC<Props> = ({ data, isLoading }) => {
                         Favorite start time:{' '}
                         {String(data.peak_start_hour).padStart(2, '0')}h
                     </InsightCard>
+                    <p className="text-[10px] text-gray-400 dark:text-gray-600 text-center">
+                        A session = consecutive streams with gaps ≤ 15 min
+                    </p>
                 </div>
             )}
         </ChartCard>

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.tsx
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.tsx
@@ -63,7 +63,10 @@ export const SessionAnalysis: FC<Props> = ({ data, isLoading }) => {
                     <InsightCard>
                         Longest:{' '}
                         {formatDuration(Math.round(data.longest_session_ms))} —{' '}
-                        {data.longest_session_track_count} tracks
+                        {data.longest_session_track_count} tracks on{' '}
+                        {new Date(
+                            data.longest_session_date
+                        ).toLocaleDateString()}
                     </InsightCard>
 
                     <InsightCard>

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/index.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/index.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import * as useDBQueryModule from '../../../../hooks/useDBQuery'
+import { SessionAnalysis } from './index'
+
+describe('SessionAnalysis container', () => {
+    it('renders nothing when data is undefined and not loading', () => {
+        vi.spyOn(useDBQueryModule, 'useDBQueryFirst').mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            error: undefined,
+        })
+        const { container } = render(<SessionAnalysis year={2025} />)
+        expect(container.firstChild).toBeNull()
+    })
+})

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/index.tsx
@@ -1,0 +1,13 @@
+import { useDBQueryFirst } from '../../../../hooks/useDBQuery'
+import { querySessionAnalysis, type SessionAnalysisResult } from './query'
+import { SessionAnalysis as SessionAnalysisView } from './SessionAnalysis'
+
+export function SessionAnalysis({ year }: { year: number | undefined }) {
+    const { data, isLoading } = useDBQueryFirst<SessionAnalysisResult>({
+        query: querySessionAnalysis(year),
+        year,
+    })
+
+    if (!isLoading && !data) return null
+    return <SessionAnalysisView data={data} isLoading={isLoading} />
+}

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/query.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
+import { querySessionAnalysis } from './query'
+import { DuckDBConnection } from '@duckdb/node-api'
+
+let conn: DuckDBConnection
+
+describe('SessionAnalysis Query', () => {
+    beforeAll(async () => {
+        conn = await DuckDBConnection.create()
+    })
+
+    afterAll(() => {
+        conn.closeSync()
+    })
+
+    beforeEach(async () => {
+        await conn.run(`
+            CREATE OR REPLACE TABLE stream_sessions (
+                session_id BIGINT,
+                track_count BIGINT,
+                duration_ms BIGINT,
+                session_start VARCHAR,
+                session_end VARCHAR
+            )
+        `)
+        await conn.run(`
+            INSERT INTO stream_sessions VALUES
+            (1, 5, 1800000, '2025-01-10T20:00:00', '2025-01-10T20:30:00'),
+            (2, 8, 3600000, '2025-01-15T21:00:00', '2025-01-15T22:00:00'),
+            (3, 3,  900000, '2024-06-01T10:00:00', '2024-06-01T10:15:00')
+        `)
+    })
+
+    it('should return one aggregate row per year filter', async () => {
+        const result = await conn.runAndReadAll(querySessionAnalysis(2025))
+        const rows = result.getRowObjectsJson()
+        expect(rows).toHaveLength(1)
+        expect(rows[0].session_count).toBe(2)
+    })
+
+    it('should include all sessions when year is undefined', async () => {
+        const result = await conn.runAndReadAll(querySessionAnalysis(undefined))
+        const rows = result.getRowObjectsJson()
+        expect(rows[0].session_count).toBe(3)
+    })
+
+    it('should compute avg_duration_ms correctly', async () => {
+        const result = await conn.runAndReadAll(querySessionAnalysis(2025))
+        const rows = result.getRowObjectsJson()
+        expect(rows[0].avg_duration_ms).toBe(2700000)
+    })
+
+    it('should identify the longest session', async () => {
+        const result = await conn.runAndReadAll(querySessionAnalysis(2025))
+        const rows = result.getRowObjectsJson()
+        expect(rows[0].longest_session_ms).toBe(3600000)
+        expect(rows[0].longest_session_track_count).toBe(8)
+    })
+
+    it('should return the start time of the longest session as longest_session_date', async () => {
+        const result = await conn.runAndReadAll(querySessionAnalysis(2025))
+        const rows = result.getRowObjectsJson()
+        expect(rows[0].longest_session_date).toBe('2025-01-15T21:00:00')
+    })
+
+    it('should return the most frequent start hour as peak_start_hour', async () => {
+        const result = await conn.runAndReadAll(querySessionAnalysis(undefined))
+        const rows = result.getRowObjectsJson()
+        // two sessions start at 20h and 21h, one at 10h — no single mode,
+        // but the value must be a valid hour integer
+        expect(rows[0].peak_start_hour).toBeGreaterThanOrEqual(0)
+        expect(rows[0].peak_start_hour).toBeLessThanOrEqual(23)
+    })
+
+    it('should return peak_start_hour matching the unique start hour when unambiguous', async () => {
+        await conn.run(`
+            INSERT INTO stream_sessions VALUES
+            (4, 2, 600000, '2025-02-01T20:00:00', '2025-02-01T20:10:00')
+        `)
+        const result = await conn.runAndReadAll(querySessionAnalysis(2025))
+        const rows = result.getRowObjectsJson()
+        // 2025 now has two 20h sessions (ids 1 and 4) vs one 21h — peak must be 20
+        expect(rows[0].peak_start_hour).toBe(20)
+    })
+})

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/query.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
 import { querySessionAnalysis } from './query'
 import { DuckDBConnection } from '@duckdb/node-api'
+import { STREAM_SESSIONS_TABLE } from '../../../../db/queries/constants'
 
 let conn: DuckDBConnection
 
@@ -15,7 +16,7 @@ describe('SessionAnalysis Query', () => {
 
     beforeEach(async () => {
         await conn.run(`
-            CREATE OR REPLACE TABLE stream_sessions (
+            CREATE OR REPLACE TABLE ${STREAM_SESSIONS_TABLE} (
                 session_id BIGINT,
                 track_count BIGINT,
                 duration_ms BIGINT,
@@ -24,7 +25,7 @@ describe('SessionAnalysis Query', () => {
             )
         `)
         await conn.run(`
-            INSERT INTO stream_sessions VALUES
+            INSERT INTO ${STREAM_SESSIONS_TABLE} VALUES
             (1, 5, 1800000, '2025-01-10T20:00:00', '2025-01-10T20:30:00'),
             (2, 8, 3600000, '2025-01-15T21:00:00', '2025-01-15T22:00:00'),
             (3, 3,  900000, '2024-06-01T10:00:00', '2024-06-01T10:15:00')
@@ -74,7 +75,7 @@ describe('SessionAnalysis Query', () => {
 
     it('should return peak_start_hour matching the unique start hour when unambiguous', async () => {
         await conn.run(`
-            INSERT INTO stream_sessions VALUES
+            INSERT INTO ${STREAM_SESSIONS_TABLE} VALUES
             (4, 2, 600000, '2025-02-01T20:00:00', '2025-02-01T20:10:00')
         `)
         const result = await conn.runAndReadAll(querySessionAnalysis(2025))

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/query.ts
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/query.ts
@@ -1,0 +1,17 @@
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
+import sqlQuery from './SessionAnalysis.sql?raw'
+
+export type SessionAnalysisResult = {
+    session_count: number
+    avg_duration_ms: number
+    median_tracks: number
+    longest_session_ms: number
+    longest_session_track_count: number
+    longest_session_date: string
+    peak_start_hour: number
+}
+
+export function querySessionAnalysis(year: number | undefined): string {
+    const yearCondition = buildYearCondition(year, 'year(session_start::date)')
+    return sqlQuery.replaceAll('${year_condition}', yearCondition)
+}

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/query.ts
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/query.ts
@@ -1,5 +1,6 @@
 import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQuery from './SessionAnalysis.sql?raw'
+import { STREAM_SESSIONS_TABLE } from '../../../../db/queries/constants'
 
 export type SessionAnalysisResult = {
     session_count: number
@@ -13,5 +14,7 @@ export type SessionAnalysisResult = {
 
 export function querySessionAnalysis(year: number | undefined): string {
     const yearCondition = buildYearCondition(year, 'year(session_start::date)')
-    return sqlQuery.replaceAll('${year_condition}', yearCondition)
+    return sqlQuery
+        .replaceAll('${table}', STREAM_SESSIONS_TABLE)
+        .replaceAll('${year_condition}', yearCondition)
 }

--- a/app/src/components/Charts/SimpleView.tsx
+++ b/app/src/components/Charts/SimpleView.tsx
@@ -11,6 +11,7 @@ import { PrincipalPlatform } from './SimpleCharts/PrincipalPlatform'
 import { ArtistLoyalty } from './SimpleCharts/ArtistLoyalty'
 import { FavoriteWeekday } from './SimpleCharts/FavoriteWeekday'
 import { CalendarHeatmap } from './SimpleCharts/CalendarHeatmap'
+import { SessionAnalysis } from './SimpleCharts/SessionAnalysis'
 import { TopArtists } from './SimpleCharts/TopArtists'
 import { TopAlbums } from './SimpleCharts/TopAlbums'
 import { TopTracks } from './SimpleCharts/TopTracks'
@@ -83,6 +84,7 @@ export function SimpleView() {
                         <RepeatBehavior year={debouncedYear} />
                         <PrincipalPlatform year={debouncedYear} />
                         <FavoriteWeekday year={debouncedYear} />
+                        <SessionAnalysis year={debouncedYear} />
                     </div>
                 </>
             )}

--- a/app/src/db/stream_sessions.sql
+++ b/app/src/db/stream_sessions.sql
@@ -14,7 +14,7 @@ session_starts as (
         case
             when
                 prev_ts is null
-                or date_diff('minute', prev_ts::timestamp, ts::timestamp) > 30
+                or date_diff('minute', prev_ts::timestamp, ts::timestamp) > 15
                 then 1
             else 0
         end as is_new_session


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

No chart showed how listening sessions were structured.

## 🎹 Proposal

- Add `SessionAnalysis` SimpleChart: session count, avg duration, median tracks, longest session (duration, track count, date), peak start hour, and a listener profile classification (Express / Balanced / Marathon)
- Add `SessionAnalysis` DetailedChart: duration histogram, scatter plot (date vs hour, sized by duration), and day-of-week bar chart (aggregation computed in SQL via `dayofweek()`)

## 🎶 Comments



## 🎤 Test

- Load data and verify the SessionAnalysis card shows correct session count, duration, peak hour, and the date of the longest session
- Check the profile label (Express / Balanced / Marathon) matches the average session duration
- Verify the SessionAnalysis Detailed view shows all three sub-charts