### PR TITLE
fix(charts): anti-flicker on year change and auto-refresh on data reload

### DIFF
--- a/app/src/components/Charts/DetailedView.tsx
+++ b/app/src/components/Charts/DetailedView.tsx
@@ -5,13 +5,14 @@ import { SummaryPerYear } from './DetailedCharts/SummaryPerYear'
 import { TotalStreams } from './DetailedCharts/TotalStreams'
 import { TopArtist } from './DetailedCharts/TopArtist'
 import { RangeSlider } from '../RangeSlider/RangeSlider'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import {
     summarizeQuery,
     type SummarizeDataQueryResult,
 } from './Summarize/summarizeQuery'
 import { queryDBAsJSON } from '../../db/queries/queryDB'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
+import { DATA_LOADED_EVENT } from '../../db/dataSignal'
 import { TopTracks } from './DetailedCharts/TopTracks'
 import { TopArtists } from './DetailedCharts/TopArtists'
 import { TopAlbums } from './DetailedCharts/TopAlbums'
@@ -31,14 +32,21 @@ export function DetailedView() {
     >()
     const debouncedYear = useDebouncedValue(year, 250)
 
-    useEffect(() => {
-        const initDataSummarize = async () => {
-            const results =
-                await queryDBAsJSON<SummarizeDataQueryResult>(summarizeQuery)
-            setSummarize(results[0] || undefined)
-        }
-        initDataSummarize()
+    const initDataSummarize = useCallback(async () => {
+        const results =
+            await queryDBAsJSON<SummarizeDataQueryResult>(summarizeQuery)
+        setSummarize(results[0] || undefined)
     }, [])
+
+    useEffect(() => {
+        initDataSummarize()
+    }, [initDataSummarize])
+
+    useEffect(() => {
+        window.addEventListener(DATA_LOADED_EVENT, initDataSummarize)
+        return () =>
+            window.removeEventListener(DATA_LOADED_EVENT, initDataSummarize)
+    }, [initDataSummarize])
 
     useEffect(() => {
         if (summarize)

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, vi, expect, beforeEach } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
 import { FunFacts } from '.'
 
 import * as query from '../../../../db/queries/queryDB'
 import * as db from '../../../../db/getDB'
 import { FunFactResult } from './queries'
+import { DATA_LOADED_EVENT } from '../../../../db/dataSignal'
 
 const allFactTitles = [
     '🌅 Musical Breakfast',
@@ -82,6 +83,30 @@ describe('FunFacts Component', () => {
             const button = screen.getByTitle('New fact')
             expect(button).toBeDefined()
         })
+    })
+
+    it('should refresh fact on DATA_LOADED_EVENT', async () => {
+        const querySpy = vi.spyOn(query, 'queryDBAsJSON')
+        const { container } = render(<FunFacts />)
+
+        await waitFor(() => {
+            expect(container.textContent).toBeTruthy()
+        })
+
+        const firstFact = container.textContent
+        const callCountAfterMount = querySpy.mock.calls.length
+
+        act(() => {
+            window.dispatchEvent(new CustomEvent(DATA_LOADED_EVENT))
+        })
+
+        await waitFor(() => {
+            expect(querySpy.mock.calls.length).toBeGreaterThan(
+                callCountAfterMount
+            )
+        })
+
+        expect(container.textContent).not.toBe(firstFact)
     })
 
     it('should refresh to a different fact when clicking refresh', async () => {

--- a/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { QUERY_FUNCTIONS, type FunFactResult } from './queries'
 import { queryDBAsJSON } from '../../../../db/queries/queryDB'
+import { DATA_LOADED_EVENT } from '../../../../db/dataSignal'
 import { FunFacts as FunFactsView } from './FunFacts'
 
 export function FunFacts() {
@@ -49,6 +50,16 @@ export function FunFacts() {
     useEffect(() => {
         loadRandomFact()
     }, [])
+
+    useEffect(() => {
+        const handleDataLoaded = () => {
+            seenFactsRef.current.clear()
+            loadRandomFact()
+        }
+        window.addEventListener(DATA_LOADED_EVENT, handleDataLoaded)
+        return () =>
+            window.removeEventListener(DATA_LOADED_EVENT, handleDataLoaded)
+    }, [loadRandomFact])
 
     if (!fact) return null
 

--- a/app/src/components/Charts/SimpleView.tsx
+++ b/app/src/components/Charts/SimpleView.tsx
@@ -21,8 +21,9 @@ import {
     type SummarizeDataQueryResult,
     summarizeQuery,
 } from './Summarize/summarizeQuery'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
+import { DATA_LOADED_EVENT } from '../../db/dataSignal'
 
 export function SimpleView() {
     const [year, setYear] = useState<number | undefined>(undefined)
@@ -31,16 +32,26 @@ export function SimpleView() {
     >()
     const debouncedYear = useDebouncedValue(year, 250)
 
-    useEffect(() => {
-        const initDataSummarize = async () => {
-            const results =
-                await queryDBAsJSON<SummarizeDataQueryResult>(summarizeQuery)
-            const s = results[0]
-            setSummarize(s)
-            if (s) setYear(new Date(Number(s.max_datetime)).getFullYear())
-        }
-        initDataSummarize()
+    const initDataSummarize = useCallback(async () => {
+        const results =
+            await queryDBAsJSON<SummarizeDataQueryResult>(summarizeQuery)
+        setSummarize(results[0] || undefined)
     }, [])
+
+    useEffect(() => {
+        initDataSummarize()
+    }, [initDataSummarize])
+
+    useEffect(() => {
+        window.addEventListener(DATA_LOADED_EVENT, initDataSummarize)
+        return () =>
+            window.removeEventListener(DATA_LOADED_EVENT, initDataSummarize)
+    }, [initDataSummarize])
+
+    useEffect(() => {
+        if (summarize)
+            setYear(new Date(Number(summarize.max_datetime)).getFullYear())
+    }, [summarize])
 
     return (
         <>

--- a/app/src/db/dataSignal.ts
+++ b/app/src/db/dataSignal.ts
@@ -1,0 +1,7 @@
+export const DATA_LOADED_EVENT = 'tracksy:data-loaded'
+
+export function dispatchDataLoaded(): void {
+    if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent(DATA_LOADED_EVENT))
+    }
+}

--- a/app/src/db/queries/insertFilesInDatabase.test.ts
+++ b/app/src/db/queries/insertFilesInDatabase.test.ts
@@ -6,6 +6,7 @@ import { convertArrayToFileList } from '../../utils/convertArrayToFileList'
 import { AsyncDuckDB, AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
 import * as adapters from '../../streamProvider'
 import * as precompute from '../precompute'
+import * as dataSignal from '../dataSignal'
 
 import type { StreamRecord } from '../../streamProvider/types'
 import { TABLE } from './constants'
@@ -71,6 +72,7 @@ describe('insertFilesInDatabase', () => {
         vi.spyOn(precompute, 'precomputeDerivedTables').mockResolvedValue(
             undefined
         )
+        vi.spyOn(dataSignal, 'dispatchDataLoaded').mockImplementation(() => {})
     })
 
     afterEach(() => {

--- a/app/src/db/queries/insertFilesInDatabase.ts
+++ b/app/src/db/queries/insertFilesInDatabase.ts
@@ -4,6 +4,7 @@ import { tableFromJSON } from 'apache-arrow'
 import { detectProvider } from '../../streamProvider'
 import type { StreamRecord } from '../../streamProvider/types'
 import { precomputeDerivedTables } from '../precompute'
+import { dispatchDataLoaded } from '../dataSignal'
 
 export async function insertFilesInDatabase(files: FileList) {
     if (files.length < 1) {
@@ -56,4 +57,5 @@ export async function insertFilesInDatabase(files: FileList) {
     )
 
     await precomputeDerivedTables(conn)
+    dispatchDataLoaded()
 }

--- a/app/src/db/queries/insertUrlInDatabase.ts
+++ b/app/src/db/queries/insertUrlInDatabase.ts
@@ -1,6 +1,7 @@
 import { getDB } from '../getDB'
 import { TABLE, DROP_TABLE_QUERY } from './constants'
 import { precomputeDerivedTables } from '../precompute'
+import { dispatchDataLoaded } from '../dataSignal'
 
 export async function insertUrlInDatabase(jsonUrl: URL) {
     const { conn } = await getDB()
@@ -25,4 +26,5 @@ export async function insertUrlInDatabase(jsonUrl: URL) {
     )
 
     await precomputeDerivedTables(conn)
+    dispatchDataLoaded()
 }

--- a/app/src/hooks/useDBQuery.test.ts
+++ b/app/src/hooks/useDBQuery.test.ts
@@ -1,7 +1,8 @@
-import { renderHook, waitFor } from '@testing-library/react'
+import { renderHook, waitFor, act } from '@testing-library/react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useDBQueryFirst, useDBQueryMany } from './useDBQuery'
 import * as queryDB from '../db/queries/queryDB'
+import { DATA_LOADED_EVENT } from '../db/dataSignal'
 
 type User = { id: number; name?: string; year?: number }
 
@@ -139,6 +140,146 @@ describe('useDBQueryFirst', () => {
         expect(result.current.data).toBeUndefined()
         expect(result.current.error).toBeInstanceOf(Error)
         expect(result.current.error?.message).toBe('DB error')
+    })
+})
+
+describe('stale-while-revalidate', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('keeps isLoading false during refetch after initial load', async () => {
+        let resolveRefetch!: (v: User[]) => void
+        const refetchPromise = new Promise<User[]>((res) => {
+            resolveRefetch = res
+        })
+
+        const spy = vi.spyOn(queryDB, 'queryDBAsJSON')
+        spy.mockResolvedValueOnce([{ id: 1 }])
+        spy.mockReturnValueOnce(refetchPromise)
+
+        const { result, rerender } = renderHook(
+            ({ year }: { year: number }) =>
+                useDBQueryMany<User>({ query: `SELECT ${year}`, year }),
+            { initialProps: { year: 2024 } }
+        )
+
+        await waitFor(() => expect(result.current.data).toEqual([{ id: 1 }]))
+        expect(result.current.isLoading).toBe(false)
+
+        rerender({ year: 2025 })
+
+        // stale data still visible, no skeleton
+        expect(result.current.isLoading).toBe(false)
+        expect(result.current.data).toEqual([{ id: 1 }])
+
+        resolveRefetch([{ id: 2 }])
+        await waitFor(() => expect(result.current.data).toEqual([{ id: 2 }]))
+        expect(result.current.isLoading).toBe(false)
+    })
+
+    it('shows skeleton on DATA_LOADED_EVENT after initial load', async () => {
+        let resolveReload!: (v: User[]) => void
+        const reloadPromise = new Promise<User[]>((res) => {
+            resolveReload = res
+        })
+
+        const spy = vi.spyOn(queryDB, 'queryDBAsJSON')
+        spy.mockResolvedValueOnce([{ id: 1 }])
+        spy.mockReturnValueOnce(reloadPromise)
+
+        const { result } = renderHook(() =>
+            useDBQueryMany<User>({ query: 'SELECT 1' })
+        )
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+        act(() => {
+            window.dispatchEvent(new CustomEvent(DATA_LOADED_EVENT))
+        })
+
+        await waitFor(() => expect(result.current.isLoading).toBe(true))
+
+        resolveReload([{ id: 99 }])
+        await waitFor(() => expect(result.current.data).toEqual([{ id: 99 }]))
+        expect(result.current.isLoading).toBe(false)
+    })
+
+    it('refetches data after DATA_LOADED_EVENT', async () => {
+        const spy = vi.spyOn(queryDB, 'queryDBAsJSON')
+        spy.mockResolvedValueOnce([{ id: 1 }])
+        spy.mockResolvedValueOnce([{ id: 99 }])
+
+        const { result } = renderHook(() =>
+            useDBQueryMany<User>({ query: 'SELECT 1' })
+        )
+
+        await waitFor(() => expect(result.current.data).toEqual([{ id: 1 }]))
+
+        act(() => {
+            window.dispatchEvent(new CustomEvent(DATA_LOADED_EVENT))
+        })
+
+        await waitFor(() => expect(result.current.data).toEqual([{ id: 99 }]))
+    })
+})
+
+describe('useDBQueryFirst — stale-while-revalidate', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('keeps isLoading false during refetch after initial load', async () => {
+        let resolveRefetch!: (v: User[]) => void
+        const refetchPromise = new Promise<User[]>((res) => {
+            resolveRefetch = res
+        })
+
+        const spy = vi.spyOn(queryDB, 'queryDBAsJSON')
+        spy.mockResolvedValueOnce([{ id: 1 }])
+        spy.mockReturnValueOnce(refetchPromise)
+
+        const { result, rerender } = renderHook(
+            ({ year }: { year: number }) =>
+                useDBQueryFirst<User>({ query: `SELECT ${year}`, year }),
+            { initialProps: { year: 2024 } }
+        )
+
+        await waitFor(() => expect(result.current.data).toEqual({ id: 1 }))
+        expect(result.current.isLoading).toBe(false)
+
+        rerender({ year: 2025 })
+
+        expect(result.current.isLoading).toBe(false)
+
+        resolveRefetch([{ id: 2 }])
+        await waitFor(() => expect(result.current.data).toEqual({ id: 2 }))
+    })
+
+    it('shows skeleton on DATA_LOADED_EVENT, then refetches', async () => {
+        let resolveReload!: (v: User[]) => void
+        const reloadPromise = new Promise<User[]>((res) => {
+            resolveReload = res
+        })
+
+        const spy = vi.spyOn(queryDB, 'queryDBAsJSON')
+        spy.mockResolvedValueOnce([{ id: 1 }])
+        spy.mockReturnValueOnce(reloadPromise)
+
+        const { result } = renderHook(() =>
+            useDBQueryFirst<User>({ query: 'SELECT 1' })
+        )
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+        act(() => {
+            window.dispatchEvent(new CustomEvent(DATA_LOADED_EVENT))
+        })
+
+        await waitFor(() => expect(result.current.isLoading).toBe(true))
+
+        resolveReload([{ id: 99 }])
+        await waitFor(() => expect(result.current.data).toEqual({ id: 99 }))
     })
 })
 

--- a/app/src/hooks/useDBQuery.ts
+++ b/app/src/hooks/useDBQuery.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { queryDBAsJSON } from '../db/queries/queryDB'
+import { DATA_LOADED_EVENT } from '../db/dataSignal'
 
 type DBPrimitive = string | number | null
 type DBRow = Record<string, DBPrimitive>
@@ -23,17 +24,32 @@ export function useDBQueryMany<T extends DBRow>({
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState<Error | undefined>(undefined)
     const requestIdRef = useRef(0)
+    const hasLoadedRef = useRef(false)
+    const [triggerRefetch, setTriggerRefetch] = useState(0)
+
+    useEffect(() => {
+        const handleDataLoaded = () => {
+            hasLoadedRef.current = false
+            setTriggerRefetch((t) => t + 1)
+        }
+        window.addEventListener(DATA_LOADED_EVENT, handleDataLoaded)
+        return () =>
+            window.removeEventListener(DATA_LOADED_EVENT, handleDataLoaded)
+    }, [])
 
     useEffect(() => {
         const id = ++requestIdRef.current
 
         const fetchData = async () => {
-            setIsLoading(true)
+            setIsLoading(!hasLoadedRef.current)
             setError(undefined)
 
             try {
                 const rows = await queryDBAsJSON<T>(query)
-                if (id === requestIdRef.current) setData(rows)
+                if (id === requestIdRef.current) {
+                    setData(rows)
+                    hasLoadedRef.current = true
+                }
             } catch (e) {
                 if (id === requestIdRef.current)
                     setError(
@@ -45,7 +61,7 @@ export function useDBQueryMany<T extends DBRow>({
         }
 
         fetchData()
-    }, [query, year])
+    }, [query, year, triggerRefetch])
 
     return { data, isLoading, error }
 }
@@ -58,17 +74,32 @@ export function useDBQueryFirst<T extends DBRow>({
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState<Error | undefined>(undefined)
     const requestIdRef = useRef(0)
+    const hasLoadedRef = useRef(false)
+    const [triggerRefetch, setTriggerRefetch] = useState(0)
+
+    useEffect(() => {
+        const handleDataLoaded = () => {
+            hasLoadedRef.current = false
+            setTriggerRefetch((t) => t + 1)
+        }
+        window.addEventListener(DATA_LOADED_EVENT, handleDataLoaded)
+        return () =>
+            window.removeEventListener(DATA_LOADED_EVENT, handleDataLoaded)
+    }, [])
 
     useEffect(() => {
         const id = ++requestIdRef.current
 
         const fetchData = async () => {
-            setIsLoading(true)
+            setIsLoading(!hasLoadedRef.current)
             setError(undefined)
 
             try {
                 const rows = await queryDBAsJSON<T>(query)
-                if (id === requestIdRef.current) setData(rows[0])
+                if (id === requestIdRef.current) {
+                    setData(rows[0])
+                    hasLoadedRef.current = true
+                }
             } catch (e) {
                 if (id === requestIdRef.current)
                     setError(
@@ -80,7 +111,7 @@ export function useDBQueryFirst<T extends DBRow>({
         }
 
         fetchData()
-    }, [query, year])
+    }, [query, year, triggerRefetch])
 
     return { data, isLoading, error }
 }


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Changing the year caused all charts to flash the skeleton shimmer before re-rendering. Loading new data (via the demo button or dropzone) left stale values on screen until the user manually changed the year or switched view. FunFacts also stayed frozen after a reload.

Two root causes:
- `insertUrlInDatabase` (demo button path) never dispatched `DATA_LOADED_EVENT`, so the demo button didn't trigger any refresh
- `FunFacts` fetched on mount only and had no `DATA_LOADED_EVENT` listener

## 🎹 Proposal

**Anti-flicker (year change)**
- Stale-while-revalidate in `useDBQuery`: `hasLoadedRef` tracks whether data has ever loaded; skeleton only shown on first load, subsequent fetches keep old data visible

**Auto-refresh on new data**
- New `dataSignal.ts` module exports `DATA_LOADED_EVENT` and `dispatchDataLoaded()`
- `insertFilesInDatabase` and `insertUrlInDatabase` both dispatch `DATA_LOADED_EVENT` after tables are ready
- `SimpleView` and `DetailedView` subscribe to re-run the summarize query, which cascades a year update to all year-dependent charts
- `useDBQuery` subscribes directly so non-year-dependent charts also refetch
- `FunFacts` subscribes and resets its seen-facts rotation so the new dataset gets a fresh pick

## 🎶 Comments

`hasLoadedRef` resets to `false` on `DATA_LOADED_EVENT` so the next fetch after a new upload still shows the skeleton (intentional: new data, fresh load).

## 🎤 Test

- Move the year slider and confirm charts update without any skeleton flash
- Click the demo button and verify all charts refresh automatically without user interaction
- Upload a new file and verify the same auto-refresh behavior
- Verify FunFacts updates after both demo load and file upload