### PR TITLE
feat(charts): taller cards for ArtistLoyalty and SessionAnalysis

### DIFF
--- a/app/src/components/Charts/SimpleCharts/ArtistLoyalty/ArtistLoyalty.tsx
+++ b/app/src/components/Charts/SimpleCharts/ArtistLoyalty/ArtistLoyalty.tsx
@@ -55,6 +55,7 @@ export const ArtistLoyalty: FC<Props> = ({ data, isLoading }) => {
             emoji="🤝"
             isLoading={isLoading}
             question="How are my streams distributed by how much I listen to each artist?"
+            className="h-full"
         >
             <ChartHero
                 label={classification.label}

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.tsx
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.tsx
@@ -27,6 +27,7 @@ export const SessionAnalysis: FC<Props> = ({ data, isLoading }) => {
             emoji="🎵"
             isLoading={isLoading}
             question="How are my listening sessions structured?"
+            className="h-full"
         >
             {profile && (
                 <ChartHero

--- a/app/src/components/Charts/SimpleView.tsx
+++ b/app/src/components/Charts/SimpleView.tsx
@@ -90,12 +90,16 @@ export function SimpleView() {
                         </div>
                         <SeasonalPatterns year={debouncedYear} />
                         <NewVsOld year={debouncedYear} />
-                        <ArtistLoyalty year={debouncedYear} />
+                        <div className="row-span-2">
+                            <ArtistLoyalty year={debouncedYear} />
+                        </div>
                         <SkipRate year={debouncedYear} />
+                        <div className="row-span-2">
+                            <SessionAnalysis year={debouncedYear} />
+                        </div>
                         <RepeatBehavior year={debouncedYear} />
                         <PrincipalPlatform year={debouncedYear} />
                         <FavoriteWeekday year={debouncedYear} />
-                        <SessionAnalysis year={debouncedYear} />
                     </div>
                 </>
             )}


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

## 🎹 Proposal
- ArtistLoyalty and SessionAnalysis now occupy twice the vertical space of other cards in the bento grid

## 🎤 Test
- Confirm ArtistLoyalty and SessionAnalysis are taller than adjacent cards in the bento grid