### PR TITLE
fix(synthetic-datasets): correct JSON filename pattern for direct ingestion

### DIFF
--- a/synthetic-datasets/synthetic_datasets/writers/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/writers/spotify.py
@@ -15,7 +15,7 @@ class SpotifyWriter:
 
     def __init__(self, output_dir: Path, reference_date: datetime) -> None:
         folder = output_dir / "spotify"
-        self.json_path_template: str = str(folder) + "/streamings_{num_records}.json"
+        self.json_path_template: str = str(folder) + "/Streaming_History_Audio_2006_{num_records}.json"
         self.zip_path_template: str = str(folder) + "/streamings_{num_records}.zip"
         self.reference_date = reference_date
 

--- a/synthetic-datasets/tests/writers/test_spotify.py
+++ b/synthetic-datasets/tests/writers/test_spotify.py
@@ -81,7 +81,7 @@ def test_spotify_writer_write_calls_helpers(mock_write_zip, mock_write_json, str
     # then
     assert mock_write_json.called
     assert mock_write_json.call_args.args == (
-        Path(f"tmp_path/spotify/streamings_{size}.json"),
+        Path(f"tmp_path/spotify/Streaming_History_Audio_2006_{size}.json"),
         streaming_records,
     )
     assert mock_write_zip.called


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

`moon run synthetic-datasets:generate -- 100 --provider spotify` produced JSON files named `streamings_100.json`, which don't match the `Streaming_History_Audio_*.json` pattern expected by the app's `SpotifyStreamProvider`.

<img width="3038" height="2208" alt="No valid sream records found error from the console" src="https://github.com/user-attachments/assets/41dbec9d-f828-4c0a-8738-2d033f3cd247" />


## 🎹 Proposal

Changed `json_path_template` in `SpotifyWriter` from `streamings_{num_records}.json` to `Streaming_History_Audio_2006_{num_records}.json`.

## 🎶 Comments

The ZIP output already used the correct naming, only the raw JSON path was wrong, which is the demo stills work.

## 🎤 Test

Produce a `json` file and drop it to tracksy
```bash
moon run synthetic-datasets:generate -- 100 --provider spotify
```