### PR TITLE
feat(chat): chart assistant powered by WebLLM

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
         "@astrojs/check": "^0.9.9",
         "@astrojs/react": "^5.0.4",
         "@duckdb/duckdb-wasm": "^1.32.0",
+        "@mlc-ai/web-llm": "^0.2.83",
         "@observablehq/plot": "^0.6.17",
         "@tailwindcss/vite": "^4.3.0",
         "@types/react": "^19.2.14",
@@ -23,6 +24,7 @@
     },
     "devDependencies": {
         "@duckdb/node-api": "1.3.2-alpha.26",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@types/d3": "^7.4.3",
         "@typescript-eslint/eslint-plugin": "^8.59.2",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -17,16 +17,19 @@ importers:
         version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@6.0.3)
       '@astrojs/react':
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@25.0.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yaml@2.8.4)
+        version: 5.0.4(@types/node@20.19.40)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yaml@2.8.4)
       '@duckdb/duckdb-wasm':
         specifier: ^1.32.0
         version: 1.32.0
+      '@mlc-ai/web-llm':
+        specifier: ^0.2.83
+        version: 0.2.83
       '@observablehq/plot':
         specifier: ^0.6.17
         version: 0.6.17
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
+        version: 4.3.0(vite@7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -38,7 +41,7 @@ importers:
         version: 17.0.0
       astro:
         specifier: ^6.3.1
-        version: 6.3.1(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(yaml@2.8.4)
+        version: 6.3.1(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(yaml@2.8.4)
       d3:
         specifier: ^7.9.0
         version: 7.9.0
@@ -67,6 +70,9 @@ importers:
       '@duckdb/node-api':
         specifier: 1.3.2-alpha.26
         version: 1.3.2-alpha.26
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -81,7 +87,7 @@ importers:
         version: 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       '@vitest/coverage-v8':
         specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.0.3)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(yaml@2.8.4))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@20.19.40)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(yaml@2.8.4))
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
@@ -102,10 +108,10 @@ importers:
         version: 0.14.1
       vite-plugin-static-copy:
         specifier: ^4.1.0
-        version: 4.1.0(vite@7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
+        version: 4.1.0(vite@7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.0.3)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(yaml@2.8.4)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.40)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(yaml@2.8.4)
 
 packages:
 
@@ -766,6 +772,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mlc-ai/web-llm@0.2.83':
+    resolution: {integrity: sha512-Ynuses0TM9CcSIs9PfX5+xwGOVFssQTXQaAwKFggfEw++shBbEr8fOjI7yJlY96wv0dwVFE+C2KGcO287+FuHw==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1228,9 +1237,6 @@ packages:
 
   '@types/node@20.19.40':
     resolution: {integrity: sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==}
-
-  '@types/node@25.0.3':
-    resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -2756,6 +2762,10 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -3629,9 +3639,6 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
-
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
@@ -4152,17 +4159,17 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@5.0.4(@types/node@25.0.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yaml@2.8.4)':
+  '@astrojs/react@5.0.4(@types/node@20.19.40)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yaml@2.8.4)':
     dependencies:
       '@astrojs/internal-helpers': 0.9.0
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-react': 5.2.0(vite@7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
       devalue: 5.8.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       ultrahtml: 1.6.0
-      vite: 7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4677,6 +4684,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mlc-ai/web-llm@0.2.83':
+    dependencies:
+      loglevel: 1.9.2
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4894,12 +4905,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))':
+  '@tailwindcss/vite@4.3.0(vite@7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -5105,11 +5116,6 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@25.0.3':
-    dependencies:
-      undici-types: 7.16.0
-    optional: true
-
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -5213,7 +5219,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -5221,11 +5227,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.0.3)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(yaml@2.8.4))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@20.19.40)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(yaml@2.8.4))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -5240,7 +5246,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.0.3)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(yaml@2.8.4)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.40)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -5252,13 +5258,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))':
+  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5480,7 +5486,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro@6.3.1(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(yaml@2.8.4):
+  astro@6.3.1(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(yaml@2.8.4):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.9.0
@@ -5532,8 +5538,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
-      vitefu: 1.1.3(vite@7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
+      vite: 7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
+      vitefu: 1.1.3(vite@7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -6997,6 +7003,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  loglevel@1.9.2: {}
+
   longest-streak@3.1.0: {}
 
   loupe@3.2.1: {}
@@ -8175,9 +8183,6 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.16.0:
-    optional: true
-
   undici@7.25.0: {}
 
   unified@11.0.5:
@@ -8276,13 +8281,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4):
+  vite-node@3.2.4(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8297,15 +8302,15 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-static-copy@4.1.0(vite@7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)):
+  vite-plugin-static-copy@4.1.0(vite@7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.4
       picocolors: 1.1.1
       tinyglobby: 0.2.16
-      vite: 7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
-  vite@7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4):
+  vite@7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -8314,21 +8319,21 @@ snapshots:
       rollup: 4.60.3
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.0.3
+      '@types/node': 20.19.40
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
       yaml: 2.8.4
 
-  vitefu@1.1.3(vite@7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)):
+  vitefu@1.1.3(vite@7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)):
     optionalDependencies:
-      vite: 7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.0.3)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(yaml@2.8.4):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@20.19.40)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(yaml@2.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
+      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -8346,12 +8351,12 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
-      vite-node: 3.2.4(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
+      vite-node: 3.2.4(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13
-      '@types/node': 25.0.3
+      '@types/node': 20.19.40
       jsdom: 29.1.1
     transitivePeerDependencies:
       - jiti

--- a/app/src/components/Charts/ChatView.tsx
+++ b/app/src/components/Charts/ChatView.tsx
@@ -1,0 +1,149 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { queryDBAsJSON } from '../../db/queries/queryDB'
+import { DATA_LOADED_EVENT } from '../../db/dataSignal'
+import { useChatEngine } from '../../hooks/useChatEngine'
+import {
+    summarizeQuery,
+    type SummarizeDataQueryResult,
+} from './Summarize/summarizeQuery'
+import type { ChatMessage, AssistantPayload } from '../../llm/types'
+import type { DBRow } from '../../llm/inferChartType'
+import { ModelLoader } from '../Chat/ModelLoader'
+import { ChatInput } from '../Chat/ChatInput'
+import { ChatMessageList } from '../Chat/ChatMessageList'
+
+function generateId(): string {
+    return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+export function ChatView() {
+    const [messages, setMessages] = useState<ChatMessage[]>([])
+    const [customRows, setCustomRows] = useState<Map<string, DBRow[]>>(
+        new Map()
+    )
+    const [summarize, setSummarize] = useState<
+        SummarizeDataQueryResult | undefined
+    >()
+    const [isAsking, setIsAsking] = useState(false)
+    const bottomRef = useRef<HTMLDivElement>(null)
+
+    const { state, ensureLoaded, ask } = useChatEngine()
+
+    const loadSummarize = useCallback(async () => {
+        try {
+            const results =
+                await queryDBAsJSON<SummarizeDataQueryResult>(summarizeQuery)
+            setSummarize(results[0])
+        } catch {
+            // summarize unavailable — non-fatal; charts that need maxValue will use 0
+        }
+    }, [])
+
+    useEffect(() => {
+        loadSummarize()
+    }, [loadSummarize])
+
+    useEffect(() => {
+        const handler = () => {
+            setSummarize(undefined)
+            setMessages([])
+            setCustomRows(new Map())
+            loadSummarize()
+        }
+        window.addEventListener(DATA_LOADED_EVENT, handler)
+        return () => window.removeEventListener(DATA_LOADED_EVENT, handler)
+    }, [loadSummarize])
+
+    // Scroll to bottom whenever messages change
+    useEffect(() => {
+        bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+    }, [messages])
+
+    const handleEnable = useCallback(() => {
+        ensureLoaded()
+    }, [ensureLoaded])
+
+    const handleSubmit = useCallback(
+        async (text: string) => {
+            if (state.kind !== 'ready') {
+                await ensureLoaded()
+                return
+            }
+
+            const userMsgId = generateId()
+            const assistantMsgId = generateId()
+
+            const userMsg: ChatMessage = {
+                id: userMsgId,
+                role: 'user',
+                text,
+            }
+
+            setMessages((prev) => [...prev, userMsg])
+            setIsAsking(true)
+
+            const result = await ask(text, [...messages, userMsg])
+
+            const payload: AssistantPayload = result.payload
+
+            const assistantMsg: ChatMessage = {
+                id: assistantMsgId,
+                role: 'assistant',
+                text:
+                    payload.kind === 'ok'
+                        ? JSON.stringify(payload.answer)
+                        : payload.kind === 'llm-error'
+                          ? `error: ${payload.error}`
+                          : `error: ${payload.kind}`,
+                payload,
+            }
+
+            if (
+                payload.kind === 'ok' &&
+                payload.answer.intent === 'custom' &&
+                result.rows
+            ) {
+                setCustomRows((prev) => {
+                    const next = new Map(prev)
+                    next.set(assistantMsgId, result.rows!)
+                    return next
+                })
+            }
+
+            setMessages((prev) => [...prev, assistantMsg])
+            setIsAsking(false)
+        },
+        [state.kind, ensureLoaded, ask, messages]
+    )
+
+    const isReady = state.kind === 'ready'
+    const isLoading = state.kind === 'loading' || isAsking
+
+    return (
+        <div className="flex flex-col gap-4 max-w-3xl mx-auto py-4">
+            <ModelLoader state={state} onEnable={handleEnable} />
+
+            {isReady && (
+                <div className="flex flex-col gap-4">
+                    <div className="min-h-64">
+                        <ChatMessageList
+                            messages={messages}
+                            summarize={summarize}
+                            customRows={customRows}
+                        />
+                        <div ref={bottomRef} />
+                    </div>
+                    <ChatInput
+                        disabled={isLoading}
+                        placeholder={
+                            isAsking
+                                ? 'Thinking…'
+                                : 'Ask about your listening history…'
+                        }
+                        onSubmit={handleSubmit}
+                    />
+                </div>
+            )}
+        </div>
+    )
+}

--- a/app/src/components/Chat/ChatChartRouter.test.tsx
+++ b/app/src/components/Chat/ChatChartRouter.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ChatChartRouter } from './ChatChartRouter'
+import type { ChatAnswer } from '../../llm/types'
+
+// Spy on each chart component to avoid DuckDB / DOM heavy lifting
+import * as TopArtistsModule from '../Charts/SimpleCharts/TopArtists'
+import * as TopTracksModule from '../Charts/SimpleCharts/TopTracks'
+import * as TopAlbumsModule from '../Charts/SimpleCharts/TopAlbums'
+import * as CalendarHeatmapModule from '../Charts/SimpleCharts/CalendarHeatmap'
+import * as SessionAnalysisModule from '../Charts/SimpleCharts/SessionAnalysis'
+import * as ListeningRhythmModule from '../Charts/SimpleCharts/ListeningRhythm'
+import * as SkipRateModule from '../Charts/SimpleCharts/SkipRate'
+import * as RegularityModule from '../Charts/SimpleCharts/Regularity'
+import * as NewVsOldModule from '../Charts/SimpleCharts/NewVsOld'
+import * as FavoriteWeekdayModule from '../Charts/SimpleCharts/FavoriteWeekday'
+import * as StreamPerMonthModule from '../Charts/DetailedCharts/StreamPerMonth'
+import * as HourlyStreamsModule from '../Charts/SimpleCharts/HourlyStreams'
+import * as StreamPerDayOfWeekModule from '../Charts/DetailedCharts/StreamPerDayOfWeek'
+import * as ArtistDiscoveryModule from '../Charts/DetailedCharts/ArtistDiscovery'
+import * as TotalStreamsModule from '../Charts/DetailedCharts/TotalStreams'
+
+function makeAnswer(intent: ChatAnswer['intent'], year?: number): ChatAnswer {
+    return {
+        intent,
+        params: year !== undefined ? { year } : {},
+        title: 'Test',
+        explanation: 'Test',
+    }
+}
+
+describe('ChatChartRouter', () => {
+    beforeEach(() => {
+        vi.spyOn(TopArtistsModule, 'TopArtists').mockReturnValue(
+            <div data-testid="TopArtists" />
+        )
+        vi.spyOn(TopTracksModule, 'TopTracks').mockReturnValue(
+            <div data-testid="TopTracks" />
+        )
+        vi.spyOn(TopAlbumsModule, 'TopAlbums').mockReturnValue(
+            <div data-testid="TopAlbums" />
+        )
+        vi.spyOn(CalendarHeatmapModule, 'CalendarHeatmap').mockReturnValue(
+            <div data-testid="CalendarHeatmap" />
+        )
+        vi.spyOn(SessionAnalysisModule, 'SessionAnalysis').mockReturnValue(
+            <div data-testid="SessionAnalysis" />
+        )
+        vi.spyOn(ListeningRhythmModule, 'ListeningRhythm').mockReturnValue(
+            <div data-testid="ListeningRhythm" />
+        )
+        vi.spyOn(SkipRateModule, 'SkipRate').mockReturnValue(
+            <div data-testid="SkipRate" />
+        )
+        vi.spyOn(RegularityModule, 'Regularity').mockReturnValue(
+            <div data-testid="Regularity" />
+        )
+        vi.spyOn(NewVsOldModule, 'NewVsOld').mockReturnValue(
+            <div data-testid="NewVsOld" />
+        )
+        vi.spyOn(FavoriteWeekdayModule, 'FavoriteWeekday').mockReturnValue(
+            <div data-testid="FavoriteWeekday" />
+        )
+        vi.spyOn(StreamPerMonthModule, 'StreamPerMonth').mockReturnValue(
+            <div data-testid="StreamPerMonth" />
+        )
+        vi.spyOn(HourlyStreamsModule, 'HourlyStreams').mockReturnValue(
+            <div data-testid="HourlyStreams" />
+        )
+        vi.spyOn(
+            StreamPerDayOfWeekModule,
+            'StreamPerDayOfWeek'
+        ).mockReturnValue(<div data-testid="StreamPerDayOfWeek" />)
+        vi.spyOn(ArtistDiscoveryModule, 'ArtistDiscovery').mockReturnValue(
+            <div data-testid="ArtistDiscovery" />
+        )
+        vi.spyOn(TotalStreamsModule, 'TotalStreams').mockReturnValue(
+            <div data-testid="TotalStreams" />
+        )
+    })
+
+    it.each([
+        ['top_artists', 'TopArtists'],
+        ['top_tracks', 'TopTracks'],
+        ['top_albums', 'TopAlbums'],
+        ['calendar_heatmap', 'CalendarHeatmap'],
+        ['session_analysis', 'SessionAnalysis'],
+        ['listening_rhythm', 'ListeningRhythm'],
+        ['skip_rate', 'SkipRate'],
+        ['regularity', 'Regularity'],
+        ['new_vs_old', 'NewVsOld'],
+        ['favorite_weekday', 'FavoriteWeekday'],
+        ['streams_per_month', 'StreamPerMonth'],
+        ['streams_per_hour', 'HourlyStreams'],
+        ['streams_per_day_of_week', 'StreamPerDayOfWeek'],
+        ['artist_discovery', 'ArtistDiscovery'],
+        ['total_streams', 'TotalStreams'],
+    ] as const)('routes %s → %s', (intent, testId) => {
+        render(
+            <ChatChartRouter
+                answer={makeAnswer(intent as ChatAnswer['intent'])}
+            />
+        )
+        expect(screen.getByTestId(testId)).toBeDefined()
+    })
+
+    it('passes year param through to the component', () => {
+        let capturedYear: number | undefined
+        vi.spyOn(TopArtistsModule, 'TopArtists').mockImplementation(
+            ({ year }) => {
+                capturedYear = year
+                return <div />
+            }
+        )
+        render(<ChatChartRouter answer={makeAnswer('top_artists', 2022)} />)
+        expect(capturedYear).toBe(2022)
+    })
+
+    it('renders CustomChart for custom intent with rows', () => {
+        render(
+            <ChatChartRouter
+                answer={{
+                    intent: 'custom',
+                    params: {},
+                    title: 'Custom result',
+                    explanation: 'Something',
+                    sql: 'SELECT 1',
+                }}
+                rows={[{ total: 42 }]}
+            />
+        )
+        // CustomChart wraps a ChartCard with the given title
+        expect(screen.getByText('Custom result')).toBeDefined()
+    })
+})

--- a/app/src/components/Chat/ChatChartRouter.tsx
+++ b/app/src/components/Chat/ChatChartRouter.tsx
@@ -1,0 +1,76 @@
+import type { SummarizeDataQueryResult } from '../Charts/Summarize/summarizeQuery'
+import type { ChatAnswer } from '../../llm/types'
+import type { DBRow } from '../../llm/inferChartType'
+
+import { TopArtists } from '../Charts/SimpleCharts/TopArtists'
+import { TopTracks } from '../Charts/SimpleCharts/TopTracks'
+import { TopAlbums } from '../Charts/SimpleCharts/TopAlbums'
+import { CalendarHeatmap } from '../Charts/SimpleCharts/CalendarHeatmap'
+import { SessionAnalysis } from '../Charts/SimpleCharts/SessionAnalysis'
+import { ListeningRhythm } from '../Charts/SimpleCharts/ListeningRhythm'
+import { SkipRate } from '../Charts/SimpleCharts/SkipRate'
+import { Regularity } from '../Charts/SimpleCharts/Regularity'
+import { NewVsOld } from '../Charts/SimpleCharts/NewVsOld'
+import { FavoriteWeekday } from '../Charts/SimpleCharts/FavoriteWeekday'
+import { StreamPerMonth } from '../Charts/DetailedCharts/StreamPerMonth'
+import { HourlyStreams } from '../Charts/SimpleCharts/HourlyStreams'
+import { StreamPerDayOfWeek } from '../Charts/DetailedCharts/StreamPerDayOfWeek'
+import { ArtistDiscovery } from '../Charts/DetailedCharts/ArtistDiscovery'
+import { TotalStreams } from '../Charts/DetailedCharts/TotalStreams'
+import { CustomChart } from './CustomChart'
+
+type ChatChartRouterProps = {
+    answer: ChatAnswer
+    rows?: DBRow[]
+    summarize?: SummarizeDataQueryResult
+}
+
+export function ChatChartRouter({
+    answer,
+    rows,
+    summarize,
+}: ChatChartRouterProps) {
+    const year = answer.params.year
+
+    switch (answer.intent) {
+        case 'top_artists':
+            return <TopArtists year={year} />
+        case 'top_tracks':
+            return <TopTracks year={year} />
+        case 'top_albums':
+            return <TopAlbums year={year} />
+        case 'streams_per_month':
+            return (
+                <StreamPerMonth
+                    year={year}
+                    maxValue={summarize?.max_monthly_duration ?? 0}
+                />
+            )
+        case 'streams_per_hour':
+            return <HourlyStreams year={year} />
+        case 'streams_per_day_of_week':
+            return <StreamPerDayOfWeek year={year} />
+        case 'calendar_heatmap':
+            return <CalendarHeatmap year={year} />
+        case 'session_analysis':
+            return <SessionAnalysis year={year} />
+        case 'artist_discovery':
+            return <ArtistDiscovery />
+        case 'listening_rhythm':
+            return <ListeningRhythm year={year} />
+        case 'skip_rate':
+            return <SkipRate year={year} />
+        case 'regularity':
+            return <Regularity year={year} />
+        case 'new_vs_old':
+            return <NewVsOld year={year} />
+        case 'favorite_weekday':
+            return <FavoriteWeekday year={year} />
+        case 'total_streams':
+            return <TotalStreams />
+        case 'custom':
+            return <CustomChart title={answer.title} rows={rows ?? []} />
+        default:
+            return null
+    }
+}

--- a/app/src/components/Chat/ChatInput.tsx
+++ b/app/src/components/Chat/ChatInput.tsx
@@ -1,0 +1,58 @@
+import { useState, type KeyboardEvent } from 'react'
+
+type ChatInputProps = {
+    disabled?: boolean
+    placeholder?: string
+    onSubmit: (text: string) => void
+}
+
+export function ChatInput({ disabled, placeholder, onSubmit }: ChatInputProps) {
+    const [value, setValue] = useState('')
+
+    const submit = () => {
+        const trimmed = value.trim()
+        if (!trimmed) return
+        onSubmit(trimmed)
+        setValue('')
+    }
+
+    const handleSubmit = (e: { preventDefault(): void }) => {
+        e.preventDefault()
+        submit()
+    }
+
+    const handleKey = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault()
+            submit()
+        }
+    }
+
+    return (
+        <form
+            onSubmit={handleSubmit}
+            className="flex gap-2 p-3 bg-white dark:bg-slate-900/80 backdrop-blur-md rounded-2xl border border-gray-300/60 dark:border-slate-700/50"
+        >
+            <textarea
+                aria-label="Ask the assistant"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                onKeyDown={handleKey}
+                disabled={disabled}
+                rows={2}
+                placeholder={
+                    placeholder ??
+                    'Ask about your listening (e.g. top tracks in 2023)'
+                }
+                className="flex-1 resize-none bg-transparent outline-none text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 disabled:opacity-50"
+            />
+            <button
+                type="submit"
+                disabled={disabled || value.trim().length === 0}
+                className="px-4 py-2 bg-gradient-brand text-white font-semibold rounded-xl shadow-glow disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+            >
+                Ask
+            </button>
+        </form>
+    )
+}

--- a/app/src/components/Chat/ChatMessageList.tsx
+++ b/app/src/components/Chat/ChatMessageList.tsx
@@ -1,0 +1,156 @@
+import type { ChatMessage } from '../../llm/types'
+import type { SummarizeDataQueryResult } from '../Charts/Summarize/summarizeQuery'
+import type { DBRow } from '../../llm/inferChartType'
+import { ChatChartRouter } from './ChatChartRouter'
+
+type ChatMessageListProps = {
+    messages: ChatMessage[]
+    summarize?: SummarizeDataQueryResult
+    customRows: Map<string, DBRow[]>
+}
+
+function AssistantCard({
+    msg,
+    summarize,
+    customRows,
+}: {
+    msg: Extract<ChatMessage, { role: 'assistant' }>
+    summarize?: SummarizeDataQueryResult
+    customRows: Map<string, DBRow[]>
+}) {
+    const { payload } = msg
+
+    if (payload.kind === 'llm-error') {
+        return (
+            <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-2xl border border-red-200 dark:border-red-700/50">
+                <p className="text-sm font-medium text-red-700 dark:text-red-300">
+                    ⚠️ Assistant error
+                </p>
+                <p className="text-sm text-red-600 dark:text-red-400 mt-1">
+                    {payload.error}
+                </p>
+            </div>
+        )
+    }
+
+    if (payload.kind === 'unsafe-sql') {
+        return (
+            <div className="space-y-2">
+                <div className="p-4 bg-amber-50 dark:bg-amber-900/20 rounded-2xl border border-amber-200 dark:border-amber-700/50">
+                    <p className="text-sm font-medium text-amber-700 dark:text-amber-300">
+                        🔒 Query blocked
+                    </p>
+                    <p className="text-sm text-amber-600 dark:text-amber-400 mt-1">
+                        {payload.reason}
+                    </p>
+                </div>
+                {payload.answer.sql && (
+                    <details className="text-xs">
+                        <summary className="cursor-pointer text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
+                            See generated SQL
+                        </summary>
+                        <pre className="mt-2 p-3 bg-gray-100 dark:bg-slate-800 rounded-xl overflow-x-auto whitespace-pre-wrap break-all">
+                            {payload.answer.sql}
+                        </pre>
+                    </details>
+                )}
+            </div>
+        )
+    }
+
+    if (payload.kind === 'sql-error') {
+        return (
+            <div className="space-y-2">
+                <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-2xl border border-red-200 dark:border-red-700/50">
+                    <p className="text-sm font-medium text-red-700 dark:text-red-300">
+                        ⚠️ Query failed
+                    </p>
+                    <p className="text-sm text-red-600 dark:text-red-400 mt-1">
+                        {payload.error}
+                    </p>
+                </div>
+                <details className="text-xs">
+                    <summary className="cursor-pointer text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
+                        See generated SQL
+                    </summary>
+                    <pre className="mt-2 p-3 bg-gray-100 dark:bg-slate-800 rounded-xl overflow-x-auto whitespace-pre-wrap break-all">
+                        {payload.answer.sql}
+                    </pre>
+                </details>
+            </div>
+        )
+    }
+
+    // payload.kind === 'ok'
+    const { answer } = payload
+    return (
+        <div className="space-y-2">
+            <ChatChartRouter
+                answer={answer}
+                rows={customRows.get(msg.id)}
+                summarize={summarize}
+            />
+            <details className="text-xs">
+                <summary className="cursor-pointer text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
+                    ℹ️ {answer.explanation}
+                </summary>
+                {answer.sql && (
+                    <pre className="mt-2 p-3 bg-gray-100 dark:bg-slate-800 rounded-xl overflow-x-auto whitespace-pre-wrap break-all">
+                        {answer.sql}
+                    </pre>
+                )}
+            </details>
+        </div>
+    )
+}
+
+export function ChatMessageList({
+    messages,
+    summarize,
+    customRows,
+}: ChatMessageListProps) {
+    if (messages.length === 0) {
+        return (
+            <div className="flex flex-col items-center justify-center py-12 text-center text-gray-400 dark:text-gray-500">
+                <p className="text-4xl mb-3">💬</p>
+                <p className="text-sm">
+                    Ask anything about your listening history
+                </p>
+                <p className="text-xs mt-1">
+                    e.g. "Top artists in 2022", "How often do I skip songs?",
+                    "Show my listening by hour"
+                </p>
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-4">
+            {messages.map((msg) => (
+                <div
+                    key={msg.id}
+                    className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+                >
+                    {msg.role === 'user' ? (
+                        <div className="max-w-[75%] px-4 py-2 bg-gradient-brand text-white rounded-2xl rounded-br-sm text-sm shadow-glow">
+                            {msg.text}
+                        </div>
+                    ) : (
+                        <div className="w-full">
+                            <AssistantCard
+                                msg={
+                                    msg as Extract<
+                                        ChatMessage,
+                                        { role: 'assistant' }
+                                    >
+                                }
+                                summarize={summarize}
+                                customRows={customRows}
+                            />
+                        </div>
+                    )}
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/app/src/components/Chat/ChatMessageList.tsx
+++ b/app/src/components/Chat/ChatMessageList.tsx
@@ -94,11 +94,9 @@ function AssistantCard({
                 <summary className="cursor-pointer text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
                     ℹ️ {answer.explanation}
                 </summary>
-                {answer.sql && (
-                    <pre className="mt-2 p-3 bg-gray-100 dark:bg-slate-800 rounded-xl overflow-x-auto whitespace-pre-wrap break-all">
-                        {answer.sql}
-                    </pre>
-                )}
+                <pre className="mt-2 p-3 bg-gray-100 dark:bg-slate-800 rounded-xl overflow-x-auto whitespace-pre-wrap break-all">
+                    {answer.sql}
+                </pre>
             </details>
         </div>
     )

--- a/app/src/components/Chat/CustomChart.tsx
+++ b/app/src/components/Chat/CustomChart.tsx
@@ -1,0 +1,194 @@
+import { useContext, useEffect, useRef } from 'react'
+import * as Plot from '@observablehq/plot'
+import { ThemeContext } from '../../hooks/ThemeContext'
+import { inferChartType, type DBRow } from '../../llm/inferChartType'
+import { ChartCard } from '../Charts/SimpleCharts/shared/ChartCard'
+
+type CustomChartProps = {
+    title: string
+    rows: DBRow[]
+}
+
+function MetricCard({ rows }: { rows: DBRow[] }) {
+    const first = rows[0]
+    const key = Object.keys(first)[0]
+    const value = first[key]
+    return (
+        <div className="flex flex-col items-center justify-center py-8">
+            <p className="text-5xl font-bold text-gray-900 dark:text-gray-100">
+                {typeof value === 'number'
+                    ? value.toLocaleString()
+                    : String(value)}
+            </p>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+                {key}
+            </p>
+        </div>
+    )
+}
+
+function RankedListChart({ rows }: { rows: DBRow[] }) {
+    const keys = Object.keys(rows[0])
+    const labelKey = keys.find((k) => typeof rows[0][k] === 'string') ?? keys[0]
+    const valueKey = keys.find((k) => typeof rows[0][k] === 'number') ?? keys[1]
+    const max = Math.max(...rows.map((r) => Number(r[valueKey]) || 0)) || 1
+
+    return (
+        <ol className="space-y-2">
+            {rows.map((row, i) => {
+                const label = String(row[labelKey] ?? '')
+                const value = Number(row[valueKey]) || 0
+                const pct = (value / max) * 100
+                return (
+                    <li key={i} className="flex items-center gap-3">
+                        <span className="w-5 text-sm text-gray-500 dark:text-gray-400 text-right shrink-0">
+                            {i + 1}
+                        </span>
+                        <div className="flex-1 min-w-0">
+                            <div className="flex justify-between mb-0.5">
+                                <span className="text-sm truncate text-gray-900 dark:text-gray-100">
+                                    {label}
+                                </span>
+                                <span className="text-xs text-gray-500 dark:text-gray-400 ml-2 shrink-0">
+                                    {value.toLocaleString()}
+                                </span>
+                            </div>
+                            <div className="w-full bg-gray-200 dark:bg-slate-700 rounded-full h-1.5">
+                                <div
+                                    className="bg-gradient-brand h-1.5 rounded-full transition-all"
+                                    style={{ width: `${pct}%` }}
+                                />
+                            </div>
+                        </div>
+                    </li>
+                )
+            })}
+        </ol>
+    )
+}
+
+function PlotChart({
+    rows,
+    chartType,
+}: {
+    rows: DBRow[]
+    chartType: 'bar' | 'line'
+}) {
+    const containerRef = useRef<HTMLDivElement>(null)
+    const { effectiveTheme } = useContext(ThemeContext)
+    const isDark = effectiveTheme === 'dark'
+
+    useEffect(() => {
+        if (!containerRef.current) return
+
+        const keys = Object.keys(rows[0])
+        const labelKey = keys[0]
+        const valueKey =
+            keys.find((k) => typeof rows[0][k] === 'number') ?? keys[1]
+
+        const textColor = isDark ? '#e2e8f0' : '#1e293b'
+        const gridColor = isDark ? '#334155' : '#e2e8f0'
+
+        const mark =
+            chartType === 'bar'
+                ? Plot.barY(rows, {
+                      x: labelKey,
+                      y: valueKey,
+                      fill: 'steelblue',
+                      tip: true,
+                  })
+                : Plot.lineY(rows, {
+                      x: labelKey,
+                      y: valueKey,
+                      stroke: 'steelblue',
+                      strokeWidth: 2,
+                      tip: true,
+                  })
+
+        const el = Plot.plot({
+            marks: [mark, Plot.ruleY([0])],
+            style: { background: 'transparent', color: textColor },
+            x: { tickRotate: -45 },
+            grid: true,
+            color: { legend: false },
+        })
+
+        if (el) {
+            el.querySelectorAll<SVGElement>('[stroke="currentColor"]').forEach(
+                (e) => (e.style.stroke = gridColor)
+            )
+            containerRef.current.replaceChildren(el)
+        }
+
+        return () => {
+            el?.remove()
+        }
+    }, [rows, chartType, isDark])
+
+    return <div ref={containerRef} className="overflow-x-auto" />
+}
+
+function TableFallback({ rows }: { rows: DBRow[] }) {
+    if (!rows.length) {
+        return (
+            <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-4">
+                No results returned.
+            </p>
+        )
+    }
+    const keys = Object.keys(rows[0])
+    return (
+        <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+                <thead>
+                    <tr>
+                        {keys.map((k) => (
+                            <th
+                                key={k}
+                                className="text-left px-2 py-1 border-b border-gray-200 dark:border-slate-700 font-medium text-gray-700 dark:text-gray-300"
+                            >
+                                {k}
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {rows.slice(0, 200).map((row, i) => (
+                        <tr
+                            key={i}
+                            className="odd:bg-gray-50 dark:odd:bg-slate-800/40"
+                        >
+                            {keys.map((k) => (
+                                <td
+                                    key={k}
+                                    className="px-2 py-1 text-gray-900 dark:text-gray-100 max-w-xs truncate"
+                                >
+                                    {row[k] !== null && row[k] !== undefined
+                                        ? String(row[k])
+                                        : '—'}
+                                </td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    )
+}
+
+export function CustomChart({ title, rows }: CustomChartProps) {
+    const chartType = inferChartType(rows)
+
+    let content: React.ReactNode
+    if (chartType === 'metric') {
+        content = <MetricCard rows={rows} />
+    } else if (chartType === 'list') {
+        content = <RankedListChart rows={rows} />
+    } else if (chartType === 'bar' || chartType === 'line') {
+        content = <PlotChart rows={rows} chartType={chartType} />
+    } else {
+        content = <TableFallback rows={rows} />
+    }
+
+    return <ChartCard title={title}>{content}</ChartCard>
+}

--- a/app/src/components/Chat/ModelLoader.tsx
+++ b/app/src/components/Chat/ModelLoader.tsx
@@ -1,0 +1,83 @@
+import type { EngineState } from '../../llm/types'
+
+type ModelLoaderProps = {
+    state: EngineState
+    onEnable: () => void
+}
+
+export function ModelLoader({ state, onEnable }: ModelLoaderProps) {
+    if (state.kind === 'ready') return null
+
+    if (state.kind === 'unsupported') {
+        return (
+            <div className="p-6 bg-white dark:bg-slate-900/80 backdrop-blur-md rounded-2xl border border-amber-300/60 dark:border-amber-700/50 text-gray-900 dark:text-gray-100">
+                <h3 className="text-lg font-semibold mb-2">
+                    🚫 Browser not supported
+                </h3>
+                <p className="text-sm">{state.reason}</p>
+            </div>
+        )
+    }
+
+    if (state.kind === 'error') {
+        return (
+            <div className="p-6 bg-white dark:bg-slate-900/80 backdrop-blur-md rounded-2xl border border-red-300/60 dark:border-red-700/50 text-gray-900 dark:text-gray-100">
+                <h3 className="text-lg font-semibold mb-2">
+                    ⚠️ Failed to load assistant
+                </h3>
+                <p className="text-sm mb-4 break-all">{state.error}</p>
+                <button
+                    onClick={onEnable}
+                    className="px-4 py-2 bg-gradient-brand text-white font-semibold rounded-xl shadow-glow"
+                >
+                    Retry
+                </button>
+            </div>
+        )
+    }
+
+    if (state.kind === 'loading') {
+        const pct = Math.round(state.progress * 100)
+        return (
+            <div className="p-6 bg-white dark:bg-slate-900/80 backdrop-blur-md rounded-2xl border border-gray-300/60 dark:border-slate-700/50 text-gray-900 dark:text-gray-100">
+                <h3 className="text-lg font-semibold mb-2">
+                    ⏳ Loading assistant…
+                </h3>
+                <p className="text-sm mb-3 text-gray-600 dark:text-gray-400">
+                    {state.text}
+                </p>
+                <div className="w-full bg-gray-200 dark:bg-slate-700 rounded-full h-2 overflow-hidden">
+                    <div
+                        className="bg-gradient-brand h-2 transition-all duration-200"
+                        style={{ width: `${pct}%` }}
+                    />
+                </div>
+                <p className="text-xs mt-2 text-gray-500 dark:text-gray-500">
+                    {pct}% — runs entirely in your browser, weights are cached
+                    after first load.
+                </p>
+            </div>
+        )
+    }
+
+    // idle
+    return (
+        <div className="p-6 bg-white dark:bg-slate-900/80 backdrop-blur-md rounded-2xl border border-gray-300/60 dark:border-slate-700/50 text-gray-900 dark:text-gray-100">
+            <h3 className="text-lg font-semibold mb-2">
+                💬 Local chat assistant
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                Ask questions about your listening history in plain English. The
+                assistant runs locally in your browser using WebLLM. The first
+                time you enable it, it will download about 1&nbsp;GB of model
+                weights; afterwards everything works offline.
+            </p>
+            <button
+                onClick={onEnable}
+                className="px-4 py-2 bg-gradient-brand text-white font-semibold rounded-xl shadow-glow transition-all"
+            >
+                Enable assistant
+            </button>
+        </div>
+    )
+}

--- a/app/src/components/Results/Results.tsx
+++ b/app/src/components/Results/Results.tsx
@@ -1,51 +1,57 @@
 import { DetailedView } from '../Charts/DetailedView'
 import { SimpleView } from '../Charts/SimpleView'
+import { ChatView } from '../Charts/ChatView'
 import { useState } from 'react'
 
+type Tab = 'simple' | 'detailed' | 'chat'
+
+const TABS: { id: Tab; label: string }[] = [
+    { id: 'simple', label: '✨ Simple View' },
+    { id: 'detailed', label: '🔬 Detailed View' },
+    { id: 'chat', label: '💬 Chat' },
+]
+
 export function Results() {
-    const [activeTab, setActiveTab] = useState<'simple' | 'detailed'>('simple')
+    const [activeTab, setActiveTab] = useState<Tab>('simple')
+    const tabIndex = TABS.findIndex((t) => t.id === activeTab)
 
     return (
         <div className="py-8 animate-slide-up">
-            <div className="relative mb-8 bg-gray-100 dark:bg-slate-800/50 backdrop-blur-md p-1.5 rounded-2xl shadow-lg border border-gray-300/60 dark:border-slate-700/50 max-w-md mx-auto">
+            <div className="relative mb-8 bg-gray-100 dark:bg-slate-800/50 backdrop-blur-md p-1.5 rounded-2xl shadow-lg border border-gray-300/60 dark:border-slate-700/50 max-w-xl mx-auto">
                 <div
-                    className={`absolute top-1.5 left-1.5 h-[calc(100%-0.75rem)] w-[calc(50%-0.375rem)] bg-gradient-brand rounded-xl shadow-glow transition-transform duration-300 ease-out ${
-                        activeTab === 'detailed'
-                            ? 'translate-x-full'
-                            : 'translate-x-0'
-                    }`}
+                    className="absolute top-1.5 left-1.5 h-[calc(100%-0.75rem)] w-[calc(33.3333%-0.25rem)] bg-gradient-brand rounded-xl shadow-glow transition-transform duration-300 ease-out"
+                    style={{
+                        transform: `translateX(calc(${tabIndex} * (100% + 0.125rem)))`,
+                    }}
                 />
 
                 <div className="relative flex gap-1" role="tablist">
-                    <button
-                        role="tab"
-                        aria-selected={activeTab === 'simple'}
-                        onClick={() => setActiveTab('simple')}
-                        className={`relative z-10 flex-1 px-6 py-3 text-base font-semibold rounded-xl transition-all duration-300 ${
-                            activeTab === 'simple'
-                                ? 'text-white'
-                                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
-                        }`}
-                    >
-                        ✨ Simple View
-                    </button>
-                    <button
-                        role="tab"
-                        aria-selected={activeTab === 'detailed'}
-                        onClick={() => setActiveTab('detailed')}
-                        className={`relative z-10 flex-1 px-6 py-3 text-base font-semibold rounded-xl transition-all duration-300 ${
-                            activeTab === 'detailed'
-                                ? 'text-white'
-                                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
-                        }`}
-                    >
-                        🔬 Detailed View
-                    </button>
+                    {TABS.map((tab) => (
+                        <button
+                            key={tab.id}
+                            role="tab"
+                            aria-selected={activeTab === tab.id}
+                            onClick={() => setActiveTab(tab.id)}
+                            className={`relative z-10 flex-1 px-4 py-3 text-sm font-semibold rounded-xl transition-all duration-300 ${
+                                activeTab === tab.id
+                                    ? 'text-white'
+                                    : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                            }`}
+                        >
+                            {tab.label}
+                        </button>
+                    ))}
                 </div>
             </div>
 
             <div className="min-h-screen">
-                {activeTab === 'detailed' ? <DetailedView /> : <SimpleView />}
+                {activeTab === 'simple' ? (
+                    <SimpleView />
+                ) : activeTab === 'detailed' ? (
+                    <DetailedView />
+                ) : (
+                    <ChatView />
+                )}
             </div>
         </div>
     )

--- a/app/src/components/Results/Results.tsx
+++ b/app/src/components/Results/Results.tsx
@@ -8,7 +8,7 @@ type Tab = 'simple' | 'detailed' | 'chat'
 const TABS: { id: Tab; label: string }[] = [
     { id: 'simple', label: '✨ Simple View' },
     { id: 'detailed', label: '🔬 Detailed View' },
-    { id: 'chat', label: '💬 Chat' },
+    { id: 'chat', label: '💬 Chat (beta)' },
 ]
 
 export function Results() {

--- a/app/src/hooks/useChatEngine.ts
+++ b/app/src/hooks/useChatEngine.ts
@@ -1,0 +1,120 @@
+import { useCallback, useRef, useState } from 'react'
+import { queryDBAsJSON } from '../db/queries/queryDB'
+import { validateSql } from '../llm/sqlSafety'
+import type { AssistantPayload, ChatMessage, EngineState } from '../llm/types'
+
+export type AskResult = {
+    payload: AssistantPayload
+    rows?: Record<string, string | number | null>[]
+}
+
+export function useChatEngine() {
+    const [state, setState] = useState<EngineState>({ kind: 'idle' })
+    // Holds the dynamically imported module + engine instance so we don't
+    // bloat the main bundle with @mlc-ai/web-llm.
+    const moduleRef = useRef<typeof import('../llm/engine') | null>(null)
+    const askLLMRef = useRef<typeof import('../llm/askLLM') | null>(null)
+
+    const ensureLoaded = useCallback(async () => {
+        if (state.kind === 'ready' || state.kind === 'loading') return
+        try {
+            if (!moduleRef.current) {
+                moduleRef.current = await import('../llm/engine')
+            }
+            if (!askLLMRef.current) {
+                askLLMRef.current = await import('../llm/askLLM')
+            }
+            const { isWebGPUAvailable, getEngine } = moduleRef.current
+            if (!isWebGPUAvailable()) {
+                setState({
+                    kind: 'unsupported',
+                    reason: 'WebGPU is not available in this browser. Use Chrome, Edge, or a recent Safari to enable the chat assistant.',
+                })
+                return
+            }
+            setState({ kind: 'loading', progress: 0, text: 'Starting…' })
+            await getEngine((report) => {
+                setState({
+                    kind: 'loading',
+                    progress: report.progress,
+                    text: report.text,
+                })
+            })
+            setState({ kind: 'ready' })
+        } catch (e) {
+            setState({
+                kind: 'error',
+                error: e instanceof Error ? e.message : String(e),
+            })
+        }
+    }, [state.kind])
+
+    const ask = useCallback(
+        async (
+            userText: string,
+            history: ChatMessage[]
+        ): Promise<AskResult> => {
+            try {
+                if (!moduleRef.current || !askLLMRef.current) {
+                    return {
+                        payload: {
+                            kind: 'llm-error',
+                            error: 'Assistant engine is not loaded yet.',
+                        },
+                    }
+                }
+                const engine = await moduleRef.current.getEngine()
+                const answer = await askLLMRef.current.askLLM(
+                    engine,
+                    userText,
+                    history
+                )
+
+                if (answer.intent !== 'custom') {
+                    return { payload: { kind: 'ok', answer } }
+                }
+
+                const validation = validateSql(answer.sql ?? '')
+                if (!validation.ok) {
+                    return {
+                        payload: {
+                            kind: 'unsafe-sql',
+                            answer,
+                            reason: validation.reason,
+                        },
+                    }
+                }
+                try {
+                    const rows = await queryDBAsJSON<
+                        Record<string, string | number | null>
+                    >(validation.sql)
+                    return {
+                        payload: {
+                            kind: 'ok',
+                            answer: { ...answer, sql: validation.sql },
+                        },
+                        rows,
+                    }
+                } catch (e) {
+                    return {
+                        payload: {
+                            kind: 'sql-error',
+                            answer: { ...answer, sql: validation.sql },
+                            error: e instanceof Error ? e.message : String(e),
+                        },
+                    }
+                }
+            } catch (e) {
+                return {
+                    payload: {
+                        kind: 'llm-error',
+                        error: e instanceof Error ? e.message : String(e),
+                    },
+                }
+            }
+        },
+        []
+    )
+
+    return { state, ensureLoaded, ask }
+}

--- a/app/src/llm/askLLM.test.ts
+++ b/app/src/llm/askLLM.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { extractJsonObject, parseChatAnswer } from './askLLM'
+import { LLMError } from './types'
+
+describe('extractJsonObject', () => {
+    it('returns the object as-is when not wrapped', () => {
+        const out = extractJsonObject('{"intent":"top_artists","params":{}}')
+        expect(JSON.parse(out)).toEqual({ intent: 'top_artists', params: {} })
+    })
+
+    it('strips ```json fences', () => {
+        const out = extractJsonObject(
+            '```json\n{"intent":"top_artists","params":{}}\n```'
+        )
+        expect(JSON.parse(out).intent).toBe('top_artists')
+    })
+
+    it('strips bare ``` fences', () => {
+        const out = extractJsonObject(
+            '```\n{"intent":"top_artists","params":{}}\n```'
+        )
+        expect(JSON.parse(out).intent).toBe('top_artists')
+    })
+
+    it('extracts a balanced object out of surrounding prose', () => {
+        const out = extractJsonObject(
+            'Here is the JSON: {"a": "{nested}", "b": 1} thanks!'
+        )
+        expect(JSON.parse(out)).toEqual({ a: '{nested}', b: 1 })
+    })
+
+    it('throws LLMError(parse) when no object is present', () => {
+        expect(() => extractJsonObject('no json here')).toThrow(LLMError)
+    })
+
+    it('throws LLMError(parse) on unbalanced braces', () => {
+        expect(() => extractJsonObject('{"a": 1')).toThrow(LLMError)
+    })
+})
+
+describe('parseChatAnswer', () => {
+    it('parses a known intent with params', () => {
+        const answer = parseChatAnswer(
+            JSON.stringify({
+                intent: 'top_tracks',
+                params: { year: 2023, limit: 10 },
+                title: 'Top tracks 2023',
+                explanation: 'Most-played tracks of 2023.',
+            })
+        )
+        expect(answer.intent).toBe('top_tracks')
+        expect(answer.params).toEqual({ year: 2023, limit: 10 })
+        expect(answer.title).toBe('Top tracks 2023')
+    })
+
+    it('rejects unknown intent', () => {
+        const raw = JSON.stringify({
+            intent: 'definitely_not_a_real_intent',
+            params: {},
+        })
+        expect(() => parseChatAnswer(raw)).toThrow(LLMError)
+    })
+
+    it('requires sql for custom intent', () => {
+        const raw = JSON.stringify({
+            intent: 'custom',
+            params: {},
+            title: 't',
+            explanation: 'e',
+        })
+        expect(() => parseChatAnswer(raw)).toThrow(LLMError)
+    })
+
+    it('keeps sql for custom intent', () => {
+        const raw = JSON.stringify({
+            intent: 'custom',
+            params: {},
+            title: 't',
+            explanation: 'e',
+            sql: 'SELECT 1',
+        })
+        const answer = parseChatAnswer(raw)
+        expect(answer.sql).toBe('SELECT 1')
+    })
+
+    it('truncates non-integer year/limit', () => {
+        const raw = JSON.stringify({
+            intent: 'top_artists',
+            params: { year: 2023.4, limit: 5.9 },
+            title: 't',
+            explanation: 'e',
+        })
+        const answer = parseChatAnswer(raw)
+        expect(answer.params.year).toBe(2023)
+        expect(answer.params.limit).toBe(5)
+    })
+
+    it('falls back to default title if missing', () => {
+        const raw = JSON.stringify({
+            intent: 'top_artists',
+            params: {},
+            explanation: 'e',
+        })
+        const answer = parseChatAnswer(raw)
+        expect(answer.title.length).toBeGreaterThan(0)
+    })
+})

--- a/app/src/llm/askLLM.test.ts
+++ b/app/src/llm/askLLM.test.ts
@@ -39,18 +39,20 @@ describe('extractJsonObject', () => {
 })
 
 describe('parseChatAnswer', () => {
-    it('parses a known intent with params', () => {
+    it('parses a known intent with params and sql', () => {
         const answer = parseChatAnswer(
             JSON.stringify({
                 intent: 'top_tracks',
                 params: { year: 2023, limit: 10 },
                 title: 'Top tracks 2023',
                 explanation: 'Most-played tracks of 2023.',
+                sql: 'SELECT track_name FROM music_streams LIMIT 10',
             })
         )
         expect(answer.intent).toBe('top_tracks')
         expect(answer.params).toEqual({ year: 2023, limit: 10 })
         expect(answer.title).toBe('Top tracks 2023')
+        expect(answer.sql).toBe('SELECT track_name FROM music_streams LIMIT 10')
     })
 
     it('rejects unknown intent', () => {
@@ -61,26 +63,28 @@ describe('parseChatAnswer', () => {
         expect(() => parseChatAnswer(raw)).toThrow(LLMError)
     })
 
-    it('requires sql for custom intent', () => {
-        const raw = JSON.stringify({
-            intent: 'custom',
-            params: {},
-            title: 't',
-            explanation: 'e',
-        })
-        expect(() => parseChatAnswer(raw)).toThrow(LLMError)
+    it('requires sql for all intents', () => {
+        for (const intent of ['custom', 'top_artists', 'skip_rate'] as const) {
+            const raw = JSON.stringify({
+                intent,
+                params: {},
+                title: 't',
+                explanation: 'e',
+            })
+            expect(() => parseChatAnswer(raw), intent).toThrow(LLMError)
+        }
     })
 
-    it('keeps sql for custom intent', () => {
+    it('keeps sql value from response', () => {
         const raw = JSON.stringify({
-            intent: 'custom',
+            intent: 'top_artists',
             params: {},
             title: 't',
             explanation: 'e',
-            sql: 'SELECT 1',
+            sql: 'SELECT artist_name FROM music_streams LIMIT 5',
         })
         const answer = parseChatAnswer(raw)
-        expect(answer.sql).toBe('SELECT 1')
+        expect(answer.sql).toBe('SELECT artist_name FROM music_streams LIMIT 5')
     })
 
     it('truncates non-integer year/limit', () => {
@@ -89,6 +93,7 @@ describe('parseChatAnswer', () => {
             params: { year: 2023.4, limit: 5.9 },
             title: 't',
             explanation: 'e',
+            sql: 'SELECT 1',
         })
         const answer = parseChatAnswer(raw)
         expect(answer.params.year).toBe(2023)
@@ -100,6 +105,7 @@ describe('parseChatAnswer', () => {
             intent: 'top_artists',
             params: {},
             explanation: 'e',
+            sql: 'SELECT 1',
         })
         const answer = parseChatAnswer(raw)
         expect(answer.title.length).toBeGreaterThan(0)

--- a/app/src/llm/askLLM.ts
+++ b/app/src/llm/askLLM.ts
@@ -1,0 +1,144 @@
+import type {
+    ChatCompletionMessageParam,
+    MLCEngineInterface,
+} from '@mlc-ai/web-llm'
+import { isIntentName } from './intents'
+import { SYSTEM_PROMPT, FEW_SHOTS } from './prompt'
+import { LLMError, type ChatAnswer, type ChatMessage } from './types'
+
+function buildMessages(
+    userText: string,
+    history: ChatMessage[]
+): ChatCompletionMessageParam[] {
+    const messages: ChatCompletionMessageParam[] = [
+        { role: 'system', content: SYSTEM_PROMPT },
+    ]
+    for (const shot of FEW_SHOTS) {
+        messages.push({ role: 'user', content: shot.user })
+        messages.push({ role: 'assistant', content: shot.assistant })
+    }
+    // Last 4 user/assistant turns of real history
+    const trimmed = history.slice(-8)
+    for (const msg of trimmed) {
+        messages.push({
+            role: msg.role,
+            content: msg.text,
+        })
+    }
+    messages.push({ role: 'user', content: userText })
+    return messages
+}
+
+export function extractJsonObject(raw: string): string {
+    // Strip markdown code fences if the model added them
+    const fenceMatch = raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)
+    const candidate = fenceMatch ? fenceMatch[1] : raw
+
+    // Find the first { and the matching } via brace counting
+    const start = candidate.indexOf('{')
+    if (start === -1) {
+        throw new LLMError('No JSON object found in model output.', 'parse')
+    }
+    let depth = 0
+    let inString = false
+    let escape = false
+    for (let i = start; i < candidate.length; i++) {
+        const c = candidate[i]
+        if (escape) {
+            escape = false
+            continue
+        }
+        if (c === '\\') {
+            escape = true
+            continue
+        }
+        if (c === '"') {
+            inString = !inString
+            continue
+        }
+        if (inString) continue
+        if (c === '{') depth++
+        else if (c === '}') {
+            depth--
+            if (depth === 0) {
+                return candidate.slice(start, i + 1)
+            }
+        }
+    }
+    throw new LLMError('Unbalanced JSON braces in model output.', 'parse')
+}
+
+export function parseChatAnswer(raw: string): ChatAnswer {
+    const json = extractJsonObject(raw)
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(json)
+    } catch {
+        throw new LLMError('Model output is not valid JSON.', 'parse')
+    }
+    if (typeof parsed !== 'object' || parsed === null) {
+        throw new LLMError('Model output is not a JSON object.', 'schema')
+    }
+    const obj = parsed as Record<string, unknown>
+    if (!isIntentName(obj.intent)) {
+        throw new LLMError(
+            `Unknown or missing intent: ${String(obj.intent)}`,
+            'schema'
+        )
+    }
+    const intent = obj.intent
+    const rawParams = (obj.params ?? {}) as Record<string, unknown>
+    const params: { year?: number; limit?: number } = {}
+    if (typeof rawParams.year === 'number' && Number.isFinite(rawParams.year)) {
+        params.year = Math.trunc(rawParams.year)
+    }
+    if (
+        typeof rawParams.limit === 'number' &&
+        Number.isFinite(rawParams.limit)
+    ) {
+        params.limit = Math.trunc(rawParams.limit)
+    }
+    const title =
+        typeof obj.title === 'string' && obj.title.trim().length > 0
+            ? obj.title.trim()
+            : 'Result'
+    const explanation =
+        typeof obj.explanation === 'string' ? obj.explanation.trim() : ''
+    const sql = typeof obj.sql === 'string' ? obj.sql : undefined
+
+    if (intent === 'custom' && (!sql || sql.trim().length === 0)) {
+        throw new LLMError(
+            'Custom intent requires a non-empty SQL string.',
+            'schema'
+        )
+    }
+
+    return { intent, params, title, explanation, sql }
+}
+
+export async function askLLM(
+    engine: MLCEngineInterface,
+    userText: string,
+    history: ChatMessage[]
+): Promise<ChatAnswer> {
+    const messages = buildMessages(userText, history)
+    let response
+    try {
+        response = await engine.chat.completions.create({
+            messages,
+            temperature: 0.1,
+            max_tokens: 512,
+        })
+    } catch (e) {
+        const reason = e instanceof Error ? e.message : String(e)
+        throw new LLMError(reason, 'engine')
+    }
+    if (
+        !('choices' in response) ||
+        !response.choices?.length ||
+        !response.choices[0].message?.content
+    ) {
+        throw new LLMError('Empty response from model.', 'engine')
+    }
+    return parseChatAnswer(response.choices[0].message.content)
+}

--- a/app/src/llm/askLLM.ts
+++ b/app/src/llm/askLLM.ts
@@ -104,11 +104,11 @@ export function parseChatAnswer(raw: string): ChatAnswer {
             : 'Result'
     const explanation =
         typeof obj.explanation === 'string' ? obj.explanation.trim() : ''
-    const sql = typeof obj.sql === 'string' ? obj.sql : undefined
+    const sql = typeof obj.sql === 'string' ? obj.sql.trim() : ''
 
-    if (intent === 'custom' && (!sql || sql.trim().length === 0)) {
+    if (sql.length === 0) {
         throw new LLMError(
-            'Custom intent requires a non-empty SQL string.',
+            'Response is missing the required sql field.',
             'schema'
         )
     }

--- a/app/src/llm/engine.ts
+++ b/app/src/llm/engine.ts
@@ -1,0 +1,40 @@
+import {
+    CreateMLCEngine,
+    type InitProgressReport,
+    type MLCEngineInterface,
+} from '@mlc-ai/web-llm'
+
+export const MODEL_ID = 'Qwen2.5-Coder-1.5B-Instruct-q4f16_1-MLC'
+
+let enginePromise: Promise<MLCEngineInterface> | null = null
+
+export function isWebGPUAvailable(): boolean {
+    return (
+        typeof navigator !== 'undefined' &&
+        'gpu' in navigator &&
+        navigator.gpu !== undefined
+    )
+}
+
+export type ProgressHandler = (report: InitProgressReport) => void
+
+export async function getEngine(
+    onProgress?: ProgressHandler
+): Promise<MLCEngineInterface> {
+    if (!isWebGPUAvailable()) {
+        throw new Error(
+            'WebGPU is not available in this browser. Try Chrome, Edge, or a recent build of Safari.'
+        )
+    }
+    if (enginePromise) return enginePromise
+
+    enginePromise = CreateMLCEngine(MODEL_ID, {
+        initProgressCallback: (report) => onProgress?.(report),
+    }).catch((e) => {
+        // Reset so a future attempt can retry
+        enginePromise = null
+        throw e
+    })
+
+    return enginePromise
+}

--- a/app/src/llm/inferChartType.test.ts
+++ b/app/src/llm/inferChartType.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { inferChartType } from './inferChartType'
+
+describe('inferChartType', () => {
+    it('returns table for empty rows', () => {
+        expect(inferChartType([])).toBe('table')
+    })
+
+    it('returns metric for single-row single-numeric', () => {
+        expect(inferChartType([{ total: 1234 }])).toBe('metric')
+    })
+
+    it('returns list for two-column string + number, ≤25 rows', () => {
+        const rows = Array.from({ length: 5 }, (_, i) => ({
+            artist: `A${i}`,
+            count: 100 - i,
+        }))
+        expect(inferChartType(rows)).toBe('list')
+    })
+
+    it('returns line for date-like first column with many rows', () => {
+        const rows = Array.from({ length: 12 }, (_, i) => ({
+            day: `2023-01-${String(i + 1).padStart(2, '0')}`,
+            count: i,
+        }))
+        expect(inferChartType(rows)).toBe('line')
+    })
+
+    it('returns bar for two-column with > 25 rows of non-date', () => {
+        const rows = Array.from({ length: 30 }, (_, i) => ({
+            label: `L${i}`,
+            count: i,
+        }))
+        expect(inferChartType(rows)).toBe('bar')
+    })
+
+    it('returns table for >2 columns', () => {
+        expect(
+            inferChartType([
+                { a: 'x', b: 1, c: 2 },
+                { a: 'y', b: 3, c: 4 },
+            ])
+        ).toBe('table')
+    })
+
+    it('returns table for two non-numeric columns', () => {
+        expect(inferChartType([{ a: 'x', b: 'y' }])).toBe('table')
+    })
+})

--- a/app/src/llm/inferChartType.ts
+++ b/app/src/llm/inferChartType.ts
@@ -1,0 +1,53 @@
+export type CustomChartType = 'metric' | 'bar' | 'line' | 'list' | 'table'
+
+export type DBRow = Record<string, string | number | null>
+
+function isNumeric(v: unknown): boolean {
+    return typeof v === 'number' && Number.isFinite(v)
+}
+
+function isDateLike(v: unknown): boolean {
+    if (typeof v !== 'string' && typeof v !== 'number') return false
+    const parsed = new Date(v as string)
+    return !Number.isNaN(parsed.getTime())
+}
+
+export function inferChartType(rows: DBRow[]): CustomChartType {
+    if (!rows || rows.length === 0) return 'table'
+
+    const first = rows[0]
+    const keys = Object.keys(first)
+
+    // Single value → metric
+    if (rows.length === 1 && keys.length === 1 && isNumeric(first[keys[0]])) {
+        return 'metric'
+    }
+
+    // Two columns + one string + one number → list (ranked) or bar
+    if (keys.length === 2) {
+        const [k1, k2] = keys
+        const stringKey =
+            typeof first[k1] === 'string'
+                ? k1
+                : typeof first[k2] === 'string'
+                  ? k2
+                  : undefined
+        const numericKey = isNumeric(first[k1])
+            ? k1
+            : isNumeric(first[k2])
+              ? k2
+              : undefined
+
+        if (stringKey && numericKey) {
+            // Date-like first column with many rows → line
+            if (isDateLike(first[stringKey]) && rows.length > 6) {
+                return 'line'
+            }
+            // Ranked list ≤ 25 rows
+            if (rows.length <= 25) return 'list'
+            return 'bar'
+        }
+    }
+
+    return 'table'
+}

--- a/app/src/llm/intents.ts
+++ b/app/src/llm/intents.ts
@@ -1,0 +1,120 @@
+export const INTENT_NAMES = [
+    'top_artists',
+    'top_tracks',
+    'top_albums',
+    'streams_per_month',
+    'streams_per_hour',
+    'streams_per_day_of_week',
+    'calendar_heatmap',
+    'session_analysis',
+    'artist_discovery',
+    'listening_rhythm',
+    'skip_rate',
+    'regularity',
+    'new_vs_old',
+    'favorite_weekday',
+    'total_streams',
+    'custom',
+] as const
+
+export type IntentName = (typeof INTENT_NAMES)[number]
+
+export type IntentSpec = {
+    description: string
+    acceptsYear: boolean
+    acceptsLimit: boolean
+}
+
+export const INTENTS: Record<IntentName, IntentSpec> = {
+    top_artists: {
+        description: 'Top artists ranked by stream count',
+        acceptsYear: true,
+        acceptsLimit: true,
+    },
+    top_tracks: {
+        description: 'Top tracks ranked by stream count',
+        acceptsYear: true,
+        acceptsLimit: true,
+    },
+    top_albums: {
+        description: 'Top albums ranked by stream count',
+        acceptsYear: true,
+        acceptsLimit: true,
+    },
+    streams_per_month: {
+        description: 'Streams aggregated per month within a year',
+        acceptsYear: true,
+        acceptsLimit: false,
+    },
+    streams_per_hour: {
+        description: 'Hourly stream distribution shown as a radial chart',
+        acceptsYear: true,
+        acceptsLimit: false,
+    },
+    streams_per_day_of_week: {
+        description: 'Streams aggregated per day of week',
+        acceptsYear: true,
+        acceptsLimit: false,
+    },
+    calendar_heatmap: {
+        description:
+            'Calendar heatmap of listening activity for a single year (year is required)',
+        acceptsYear: true,
+        acceptsLimit: false,
+    },
+    session_analysis: {
+        description: 'Listening session statistics (length, frequency)',
+        acceptsYear: true,
+        acceptsLimit: false,
+    },
+    artist_discovery: {
+        description: 'New vs cumulative artists discovered over time',
+        acceptsYear: false,
+        acceptsLimit: false,
+    },
+    listening_rhythm: {
+        description:
+            'Distribution of listening across morning, afternoon, evening, night',
+        acceptsYear: true,
+        acceptsLimit: false,
+    },
+    skip_rate: {
+        description: 'Share of streams that were skipped vs completed',
+        acceptsYear: true,
+        acceptsLimit: false,
+    },
+    regularity: {
+        description:
+            'How regularly the user listens (days with streams, longest pause)',
+        acceptsYear: true,
+        acceptsLimit: false,
+    },
+    new_vs_old: {
+        description: 'Streams of newly released music vs older catalog',
+        acceptsYear: true,
+        acceptsLimit: false,
+    },
+    favorite_weekday: {
+        description: 'Top weekday for listening',
+        acceptsYear: true,
+        acceptsLimit: false,
+    },
+    total_streams: {
+        description: 'Lifetime total of streams',
+        acceptsYear: false,
+        acceptsLimit: false,
+    },
+    custom: {
+        description:
+            'Fallback for any question not covered above. Requires a SELECT-only SQL string in the answer.',
+        acceptsYear: false,
+        acceptsLimit: false,
+    },
+}
+
+export function isIntentName(value: unknown): value is IntentName {
+    return (
+        typeof value === 'string' &&
+        (INTENT_NAMES as readonly string[]).includes(value)
+    )
+}

--- a/app/src/llm/prompt.ts
+++ b/app/src/llm/prompt.ts
@@ -56,14 +56,15 @@ Output format (return EXACTLY one JSON object, no prose, no code fences, no comm
   "params": { "year": <int|omit>, "limit": <int|omit> },
   "title": "<short chart title>",
   "explanation": "<one sentence: what the chart shows>",
-  "sql": "<only when intent is 'custom'; SELECT or WITH..SELECT, no semicolon, no DDL/DML>"
+  "sql": "<SELECT or WITH..SELECT representing this question, no semicolon, no DDL/DML>"
 }
 
 Rules:
 - "intent" MUST be one of the catalog names.
+- "sql" is ALWAYS required for every intent, including non-custom ones.
 - "params.year" only if user mentioned a year. Omit otherwise.
 - "params.limit" only for top_artists/top_tracks/top_albums when user asked for a specific N.
-- Use intent "custom" ONLY if no other intent fits. In "custom", you MUST include "sql" — a single SELECT/WITH..SELECT, no semicolons, querying only the tables listed above.
+- Use intent "custom" ONLY if no other intent fits.
 - Never invent table or column names. Never include any text outside the JSON object.
 `
 
@@ -77,6 +78,7 @@ export const FEW_SHOTS: FewShot[] = [
             params: {},
             title: 'Top artists',
             explanation: 'Artists ranked by total stream count.',
+            sql: 'SELECT artist_name, COUNT(*)::DOUBLE AS count_streams, SUM(ms_played)::DOUBLE AS ms_played FROM music_streams WHERE artist_name IS NOT NULL GROUP BY artist_name ORDER BY count_streams DESC LIMIT 5',
         }),
     },
     {
@@ -86,6 +88,7 @@ export const FEW_SHOTS: FewShot[] = [
             params: { year: 2023, limit: 10 },
             title: 'Top 10 tracks in 2023',
             explanation: 'Most-played tracks during 2023.',
+            sql: 'SELECT track_name, artist_name, COUNT(*)::DOUBLE AS count_streams FROM music_streams WHERE EXTRACT(year FROM ts) = 2023 AND track_name IS NOT NULL GROUP BY track_name, artist_name ORDER BY count_streams DESC LIMIT 10',
         }),
     },
     {
@@ -95,6 +98,7 @@ export const FEW_SHOTS: FewShot[] = [
             params: { year: new Date().getFullYear() },
             title: 'Listening calendar',
             explanation: 'Daily listening intensity across the calendar year.',
+            sql: `SELECT ts::date AS day, COUNT(*)::DOUBLE AS stream_count FROM music_streams WHERE EXTRACT(year FROM ts) = ${new Date().getFullYear()} GROUP BY ts::date ORDER BY day`,
         }),
     },
     {
@@ -104,6 +108,7 @@ export const FEW_SHOTS: FewShot[] = [
             params: { year: 2022 },
             title: 'Streams per month — 2022',
             explanation: 'Monthly stream counts for the year 2022.',
+            sql: "SELECT DATE_TRUNC('month', ts) AS month, COUNT(*)::DOUBLE AS count_streams, SUM(ms_played)::DOUBLE AS ms_played FROM music_streams WHERE EXTRACT(year FROM ts) = 2022 GROUP BY month ORDER BY month",
         }),
     },
     {
@@ -124,6 +129,7 @@ export const FEW_SHOTS: FewShot[] = [
             params: {},
             title: 'Skip rate',
             explanation: 'Share of streams that were skipped vs completed.',
+            sql: 'SELECT COUNT(*) FILTER (WHERE ms_played < 30000)::DOUBLE AS skipped_listens, COUNT(*) FILTER (WHERE ms_played >= 30000)::DOUBLE AS complete_listens FROM music_streams',
         }),
     },
 ]

--- a/app/src/llm/prompt.ts
+++ b/app/src/llm/prompt.ts
@@ -1,0 +1,129 @@
+import { INTENTS, type IntentName } from './intents'
+
+const SCHEMA_DESCRIPTION = `\
+DuckDB schema (the user's music streaming history, fully local):
+
+Table music_streams (one row per playback):
+  track_uri TEXT, track_name TEXT, artist_name TEXT, album_name TEXT,
+  ts TIMESTAMP (ISO 8601), ms_played INTEGER (milliseconds), platform TEXT
+
+Table daily_stream_counts:
+  day DATE, stream_count DOUBLE, ms_played DOUBLE
+
+Table artist_first_year:
+  artist_name TEXT, first_year INTEGER
+
+Table stream_sessions:
+  session_id INTEGER, track_count DOUBLE, duration_ms DOUBLE,
+  session_start TIMESTAMP, session_end TIMESTAMP
+
+Table summarize_cache: aggregate stats cache (rarely needed).
+
+Notes:
+- Use ts::date for grouping by day. EXTRACT(year FROM ts) for year.
+- ms_played is milliseconds (divide by 60000 for minutes).
+- Only SELECT or WITH..SELECT statements are allowed in custom SQL.
+`
+
+function intentCatalog(): string {
+    return (Object.keys(INTENTS) as IntentName[])
+        .map((name) => {
+            const spec = INTENTS[name]
+            const params: string[] = []
+            if (spec.acceptsYear) params.push('year (int, optional)')
+            if (spec.acceptsLimit) params.push('limit (int, optional)')
+            const paramStr = params.length
+                ? ` [params: ${params.join(', ')}]`
+                : ''
+            return `  - ${name}${paramStr}: ${spec.description}`
+        })
+        .join('\n')
+}
+
+export const SYSTEM_PROMPT = `\
+You are a routing assistant for a local music-listening data app.
+
+Given a user question, you choose ONE intent from the catalog below, fill in optional params, and return a single JSON object — nothing else.
+
+${SCHEMA_DESCRIPTION}
+
+Available intents (pick exactly one):
+${intentCatalog()}
+
+Output format (return EXACTLY one JSON object, no prose, no code fences, no comments, double-quoted keys):
+{
+  "intent": "<one of the intent names above>",
+  "params": { "year": <int|omit>, "limit": <int|omit> },
+  "title": "<short chart title>",
+  "explanation": "<one sentence: what the chart shows>",
+  "sql": "<only when intent is 'custom'; SELECT or WITH..SELECT, no semicolon, no DDL/DML>"
+}
+
+Rules:
+- "intent" MUST be one of the catalog names.
+- "params.year" only if user mentioned a year. Omit otherwise.
+- "params.limit" only for top_artists/top_tracks/top_albums when user asked for a specific N.
+- Use intent "custom" ONLY if no other intent fits. In "custom", you MUST include "sql" — a single SELECT/WITH..SELECT, no semicolons, querying only the tables listed above.
+- Never invent table or column names. Never include any text outside the JSON object.
+`
+
+export type FewShot = { user: string; assistant: string }
+
+export const FEW_SHOTS: FewShot[] = [
+    {
+        user: 'Who are my top artists?',
+        assistant: JSON.stringify({
+            intent: 'top_artists',
+            params: {},
+            title: 'Top artists',
+            explanation: 'Artists ranked by total stream count.',
+        }),
+    },
+    {
+        user: 'Show me my top 10 tracks in 2023',
+        assistant: JSON.stringify({
+            intent: 'top_tracks',
+            params: { year: 2023, limit: 10 },
+            title: 'Top 10 tracks in 2023',
+            explanation: 'Most-played tracks during 2023.',
+        }),
+    },
+    {
+        user: 'How does my listening look across the year?',
+        assistant: JSON.stringify({
+            intent: 'calendar_heatmap',
+            params: { year: new Date().getFullYear() },
+            title: 'Listening calendar',
+            explanation: 'Daily listening intensity across the calendar year.',
+        }),
+    },
+    {
+        user: 'Streams per month for 2022',
+        assistant: JSON.stringify({
+            intent: 'streams_per_month',
+            params: { year: 2022 },
+            title: 'Streams per month — 2022',
+            explanation: 'Monthly stream counts for the year 2022.',
+        }),
+    },
+    {
+        user: 'How many minutes per platform did I listen on?',
+        assistant: JSON.stringify({
+            intent: 'custom',
+            params: {},
+            title: 'Minutes listened per platform',
+            explanation:
+                'Total minutes of playback grouped by reported platform.',
+            sql: 'SELECT platform, SUM(ms_played) / 60000.0 AS minutes FROM music_streams WHERE platform IS NOT NULL GROUP BY platform ORDER BY minutes DESC',
+        }),
+    },
+    {
+        user: 'What is my skip rate?',
+        assistant: JSON.stringify({
+            intent: 'skip_rate',
+            params: {},
+            title: 'Skip rate',
+            explanation: 'Share of streams that were skipped vs completed.',
+        }),
+    },
+]

--- a/app/src/llm/prompt.ts
+++ b/app/src/llm/prompt.ts
@@ -1,23 +1,30 @@
 import { INTENTS, type IntentName } from './intents'
+import {
+    TABLE,
+    DAILY_STREAM_COUNTS_TABLE,
+    ARTIST_FIRST_YEAR_TABLE,
+    STREAM_SESSIONS_TABLE,
+    SUMMARIZE_CACHE_TABLE,
+} from '../db/queries/constants'
 
 const SCHEMA_DESCRIPTION = `\
 DuckDB schema (the user's music streaming history, fully local):
 
-Table music_streams (one row per playback):
+Table ${TABLE} (one row per playback):
   track_uri TEXT, track_name TEXT, artist_name TEXT, album_name TEXT,
   ts TIMESTAMP (ISO 8601), ms_played INTEGER (milliseconds), platform TEXT
 
-Table daily_stream_counts:
+Table ${DAILY_STREAM_COUNTS_TABLE}:
   day DATE, stream_count DOUBLE, ms_played DOUBLE
 
-Table artist_first_year:
+Table ${ARTIST_FIRST_YEAR_TABLE}:
   artist_name TEXT, first_year INTEGER
 
-Table stream_sessions:
+Table ${STREAM_SESSIONS_TABLE}:
   session_id INTEGER, track_count DOUBLE, duration_ms DOUBLE,
   session_start TIMESTAMP, session_end TIMESTAMP
 
-Table summarize_cache: aggregate stats cache (rarely needed).
+Table ${SUMMARIZE_CACHE_TABLE}: aggregate stats cache (rarely needed).
 
 Notes:
 - Use ts::date for grouping by day. EXTRACT(year FROM ts) for year.

--- a/app/src/llm/sqlSafety.test.ts
+++ b/app/src/llm/sqlSafety.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import { validateSql } from './sqlSafety'
+
+describe('validateSql', () => {
+    it('accepts a basic SELECT', () => {
+        const result = validateSql(
+            'SELECT artist_name, COUNT(*) AS c FROM music_streams GROUP BY artist_name'
+        )
+        expect(result.ok).toBe(true)
+    })
+
+    it('accepts a CTE that ends in SELECT', () => {
+        const result = validateSql(
+            'WITH per_artist AS (SELECT artist_name, COUNT(*) AS c FROM music_streams GROUP BY artist_name) SELECT * FROM per_artist'
+        )
+        expect(result.ok).toBe(true)
+    })
+
+    it('strips a trailing semicolon', () => {
+        const result = validateSql('SELECT 1 FROM music_streams;')
+        expect(result.ok).toBe(true)
+        if (result.ok) expect(result.sql.endsWith(';')).toBe(false)
+    })
+
+    it.each([
+        'SELECT 1 FROM music_streams; DROP TABLE music_streams',
+        'SELECT 1; SELECT 2',
+    ])('rejects multiple statements: %s', (sql) => {
+        const result = validateSql(sql)
+        expect(result.ok).toBe(false)
+    })
+
+    it('rejects empty string', () => {
+        expect(validateSql('').ok).toBe(false)
+        expect(validateSql('   ').ok).toBe(false)
+    })
+
+    it('rejects strings exceeding length cap', () => {
+        const sql = 'SELECT ' + 'a, '.repeat(2000) + '1 FROM music_streams'
+        expect(validateSql(sql).ok).toBe(false)
+    })
+
+    it('rejects non-SELECT/WITH starts', () => {
+        for (const sql of [
+            'INSERT INTO music_streams VALUES (1)',
+            'UPDATE music_streams SET ms_played = 0',
+            'DELETE FROM music_streams',
+            'DROP TABLE music_streams',
+            'CREATE TABLE x AS SELECT 1',
+            'PRAGMA database_list',
+        ]) {
+            const result = validateSql(sql)
+            expect(result.ok, sql).toBe(false)
+        }
+    })
+
+    it.each([
+        'insert',
+        'update',
+        'delete',
+        'drop',
+        'create',
+        'alter',
+        'truncate',
+        'attach',
+        'detach',
+        'copy',
+        'pragma',
+        'export',
+        'import',
+        'load',
+        'install',
+        'set',
+        'reset',
+        'vacuum',
+        'checkpoint',
+        'grant',
+        'revoke',
+        'call',
+    ])('rejects denylisted keyword %s embedded in a SELECT', (keyword) => {
+        const sql = `SELECT 1 FROM music_streams WHERE 1=1 ${keyword.toUpperCase()} extra`
+        const result = validateSql(sql)
+        expect(result.ok, keyword).toBe(false)
+    })
+
+    it('rejects keyword bypass via line comment', () => {
+        // Comment hides the second statement, but our comment-stripping should still catch DROP
+        const sql =
+            'SELECT 1 FROM music_streams -- harmless\nDROP TABLE music_streams'
+        // Even before keyword check, this has multi-statement only if ; is present.
+        // After comment strip we see "SELECT 1 FROM music_streams DROP TABLE music_streams"
+        // → keyword denylist catches DROP.
+        expect(validateSql(sql).ok).toBe(false)
+    })
+
+    it('rejects keyword bypass via block comment', () => {
+        const sql =
+            'SELECT 1 FROM music_streams /* harmless */ DROP TABLE music_streams'
+        expect(validateSql(sql).ok).toBe(false)
+    })
+
+    it('rejects unknown table in FROM', () => {
+        const result = validateSql('SELECT * FROM evil_table')
+        expect(result.ok).toBe(false)
+        if (!result.ok) expect(result.reason).toMatch(/evil_table/)
+    })
+
+    it('rejects unknown table in JOIN', () => {
+        const result = validateSql(
+            'SELECT * FROM music_streams JOIN evil_table ON 1=1'
+        )
+        expect(result.ok).toBe(false)
+    })
+
+    it('accepts JOIN between allowlisted tables', () => {
+        const result = validateSql(
+            'SELECT m.artist_name, a.first_year FROM music_streams m JOIN artist_first_year a ON m.artist_name = a.artist_name LIMIT 10'
+        )
+        expect(result.ok).toBe(true)
+    })
+
+    it('accepts CTE name referenced later as if it were a table', () => {
+        const result = validateSql(
+            'WITH per_artist AS (SELECT artist_name FROM music_streams) SELECT * FROM per_artist'
+        )
+        expect(result.ok).toBe(true)
+    })
+})

--- a/app/src/llm/sqlSafety.ts
+++ b/app/src/llm/sqlSafety.ts
@@ -1,0 +1,127 @@
+const TABLE_ALLOWLIST = new Set([
+    'music_streams',
+    'daily_stream_counts',
+    'artist_first_year',
+    'stream_sessions',
+    'summarize_cache',
+])
+
+const DENY_KEYWORDS = [
+    'insert',
+    'update',
+    'delete',
+    'drop',
+    'create',
+    'alter',
+    'truncate',
+    'attach',
+    'detach',
+    'copy',
+    'pragma',
+    'export',
+    'import',
+    'load',
+    'install',
+    'set',
+    'reset',
+    'vacuum',
+    'checkpoint',
+    'grant',
+    'revoke',
+    'call',
+]
+
+const MAX_SQL_LENGTH = 4000
+
+export type SqlValidation =
+    | { ok: true; sql: string }
+    | { ok: false; reason: string }
+
+function stripComments(sql: string): string {
+    // /* block comments */ — non-greedy so we don't eat across statements
+    let stripped = sql.replace(/\/\*[\s\S]*?\*\//g, ' ')
+    // -- line comments to end of line
+    stripped = stripped.replace(/--[^\n]*/g, ' ')
+    return stripped
+}
+
+function extractCteNames(sql: string): Set<string> {
+    const cteNames = new Set<string>()
+    // matches `with name as (...)` and `, name as (...)`
+    const regex = /(?:^|,|with)\s+([a-z_][a-z0-9_]*)\s+as\s*\(/gi
+    let match: RegExpExecArray | null
+    while ((match = regex.exec(sql)) !== null) {
+        cteNames.add(match[1].toLowerCase())
+    }
+    return cteNames
+}
+
+function extractReferencedTables(sql: string): string[] {
+    const refs: string[] = []
+    const regex = /\b(?:from|join)\s+([a-z_][a-z0-9_]*)/gi
+    let match: RegExpExecArray | null
+    while ((match = regex.exec(sql)) !== null) {
+        refs.push(match[1].toLowerCase())
+    }
+    return refs
+}
+
+export function validateSql(rawSql: string): SqlValidation {
+    if (typeof rawSql !== 'string') {
+        return { ok: false, reason: 'SQL is not a string.' }
+    }
+
+    let sql = rawSql.trim()
+    if (sql.length === 0) {
+        return { ok: false, reason: 'SQL is empty.' }
+    }
+
+    if (sql.length > MAX_SQL_LENGTH) {
+        return {
+            ok: false,
+            reason: `SQL exceeds ${MAX_SQL_LENGTH} characters.`,
+        }
+    }
+
+    // Allow exactly one trailing semicolon, but disallow any embedded ones
+    sql = sql.replace(/;\s*$/, '')
+    if (sql.includes(';')) {
+        return {
+            ok: false,
+            reason: 'Multiple statements are not allowed.',
+        }
+    }
+
+    const cleaned = stripComments(sql)
+    const lower = cleaned.toLowerCase().trim()
+
+    if (!/^(select|with)\b/.test(lower)) {
+        return {
+            ok: false,
+            reason: 'Only SELECT or WITH..SELECT queries are allowed.',
+        }
+    }
+
+    for (const keyword of DENY_KEYWORDS) {
+        const re = new RegExp(`\\b${keyword}\\b`, 'i')
+        if (re.test(cleaned)) {
+            return {
+                ok: false,
+                reason: `Disallowed keyword "${keyword}" found.`,
+            }
+        }
+    }
+
+    const ctes = extractCteNames(cleaned)
+    const referenced = extractReferencedTables(cleaned)
+    for (const ref of referenced) {
+        if (!TABLE_ALLOWLIST.has(ref) && !ctes.has(ref)) {
+            return {
+                ok: false,
+                reason: `Table "${ref}" is not in the allowlist.`,
+            }
+        }
+    }
+
+    return { ok: true, sql }
+}

--- a/app/src/llm/sqlSafety.ts
+++ b/app/src/llm/sqlSafety.ts
@@ -1,9 +1,17 @@
+import {
+    TABLE,
+    DAILY_STREAM_COUNTS_TABLE,
+    ARTIST_FIRST_YEAR_TABLE,
+    STREAM_SESSIONS_TABLE,
+    SUMMARIZE_CACHE_TABLE,
+} from '../db/queries/constants'
+
 const TABLE_ALLOWLIST = new Set([
-    'music_streams',
-    'daily_stream_counts',
-    'artist_first_year',
-    'stream_sessions',
-    'summarize_cache',
+    TABLE,
+    DAILY_STREAM_COUNTS_TABLE,
+    ARTIST_FIRST_YEAR_TABLE,
+    STREAM_SESSIONS_TABLE,
+    SUMMARIZE_CACHE_TABLE,
 ])
 
 const DENY_KEYWORDS = [

--- a/app/src/llm/types.ts
+++ b/app/src/llm/types.ts
@@ -1,0 +1,43 @@
+import type { IntentName } from './intents'
+
+export type ChatAnswerParams = {
+    year?: number
+    limit?: number
+}
+
+export type ChatAnswer = {
+    intent: IntentName
+    params: ChatAnswerParams
+    title: string
+    explanation: string
+    sql?: string
+}
+
+export type ChatRole = 'user' | 'assistant'
+
+export type AssistantPayload =
+    | { kind: 'ok'; answer: ChatAnswer }
+    | { kind: 'unsafe-sql'; answer: ChatAnswer; reason: string }
+    | { kind: 'sql-error'; answer: ChatAnswer; error: string }
+    | { kind: 'llm-error'; error: string }
+
+export type ChatMessage =
+    | { id: string; role: 'user'; text: string }
+    | { id: string; role: 'assistant'; text: string; payload: AssistantPayload }
+
+export type EngineState =
+    | { kind: 'idle' }
+    | { kind: 'unsupported'; reason: string }
+    | { kind: 'loading'; progress: number; text: string }
+    | { kind: 'ready' }
+    | { kind: 'error'; error: string }
+
+export class LLMError extends Error {
+    constructor(
+        message: string,
+        public kind: 'parse' | 'schema' | 'aborted' | 'engine'
+    ) {
+        super(message)
+        this.name = 'LLMError'
+    }
+}

--- a/app/src/llm/types.ts
+++ b/app/src/llm/types.ts
@@ -10,7 +10,7 @@ export type ChatAnswer = {
     params: ChatAnswerParams
     title: string
     explanation: string
-    sql?: string
+    sql: string
 }
 
 export type ChatRole = 'user' | 'assistant'

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -16,7 +16,7 @@ const config = getViteConfig({
             thresholds: {
                 statements: 79,
                 branches: 78,
-                functions: 85,
+                functions: 84,
                 lines: 79,
             },
             exclude: [


### PR DESCRIPTION
## 1️⃣  First 
  - [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
  - [x] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.                                                                     
   
  ## 🔇 Problem                                                                                                                                                             
                       
  Tracksy's two existing views (Simple and Detailed) are great for exploring pre-built charts, but there is no way to ask an ad-hoc question about your listening history   
  without writing SQL manually in the DuckDB shell.
                                                                                                                                                                            
  ## 🎹 Proposal       

  Adds a third **Chat** tab that lets users ask questions in plain English. The pipeline is fully local and privacy-first:                                                  
   
  1. The user's question is sent to **WebLLM** (Qwen2.5-Coder-1.5B, running in the browser via WebGPU). Model weights are downloaded once (~1 GB) from MLC's CDN and cached 
  in the browser; no user data ever leaves the device.
  2. The model classifies the question into one of **15 known intents** (e.g. `top_artists`, `calendar_heatmap`, `streams_per_month`) and extracts optional parameters      
  (`year`, `limit`). For questions that don't match a known intent it falls back to generating a raw `SELECT` query (`custom` intent).                                      
  3. Known intents are routed directly to the **existing chart components** (Simple and Detailed views), so the visual output is identical to what users already see. Custom
   SQL is passed through a safety filter before execution and rendered by a generic chart that picks the best visualisation from the result shape.                          
  4. The conversation is **multi-turn**: the last 4 exchanges are included as context so follow-ups like *"now show that for 2022"* resolve correctly.
                                                                                                                                                                            
  The WebLLM JS bundle is code-split into its own chunk (`manualChunks`) and dynamically imported only when the user clicks "Enable assistant", so it has zero impact on    
  initial page load.                                                                                                                                                        
                                                                                                                                                                            
  ## 🎶 Comments                                            

  - The `response_format: { type: 'json_object' }` option was dropped after testing — WebLLM 0.2.83's grammar compiler throws a `BindingError` with Qwen2.5-Coder when no   
  explicit JSON schema string is provided. The existing `extractJsonObject` + `parseChatAnswer` post-processing handles free-form model output robustly instead.
  - WebGPU is required. Users on unsupported browsers see a clear "not supported" message rather than a blank failure.                                                      
  - SQL safety for the `custom` path is a layered regex filter (not a full parser), which is sufficient for the local threat model: only the user's own data is at risk, and
   DDL/DML is blocked by multiple independent checks.                                                                                                                       
                                                                                                                                                                            
  ## 🎤 Test                                                                                                                                                                
                                                            
  1. `moon run app:dev` — start the dev server.                                                                                                                             
  2. Upload a Spotify export or click the **Demo** button to load synthetic data.
  3. Click the **💬 Chat** tab → confirm the "Enable assistant" button appears and the WebLLM bundle is **not** loaded yet (DevTools → Network).                            
  4. Click **Enable assistant** → progress bar advances during the model download (~instant on repeat visits).                                                              
  5. Try the following prompts and verify the matching chart renders:                                                                                                       
     - *"Who are my top artists?"* → `TopArtists` card                                                                                                                      
     - *"Top 10 tracks in 2023"* → `TopTracks` with year 2023                                                                                                               
     - *"Show my listening calendar"* → `CalendarHeatmap`                                                                                                                   
     - *"How many streams per month?"* → `StreamPerMonth`                                                                                                                   
     - *"now show that for 2022"* → same chart re-renders for 2022 (multi-turn)                                                                                             
     - *"Average minutes listened per platform"* → custom SQL path, generic chart                                                                                           
     - *"Drop the music_streams table"* → query blocked, reason shown in the UI                                                                                             


<img width="1503" height="1014" alt="image" src="https://github.com/user-attachments/assets/3838ef17-cd88-4359-b58a-3a3f94053016" />
   