### PR TITLE
fix(demo): correct JSON filename used for the demo

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,2 +1,2 @@
 # Tracksy Configuration
-PUBLIC_DEMO_JSON_URL=https://huggingface.co/datasets/tracksy/synthetic-datasets/resolve/main/datasets/spotify/streamings_25000.json
+PUBLIC_DEMO_JSON_URL=https://huggingface.co/datasets/tracksy/synthetic-datasets/resolve/main/datasets/spotify/Streaming_History_Audio_2006_25000.json


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The JSON filename used for the demo has changed #357 

## 🎹 Proposal

Update the JSON filename in the env.

## 🎶 Comments

This is a hotfix, not the actual fix. We should align the workflows to prevent this kind of drift between the drag-and-drop feature and the demo.

## 🎤 Test

<!-- Instructions for reproducing the problem and how you tested the fix. -->
