### PR TITLE
refactor(demo): unify insertUrl flow with StreamProvider pipeline

### DIFF
--- a/app/src/db/queries/__tests__/test-utils.ts
+++ b/app/src/db/queries/__tests__/test-utils.ts
@@ -1,0 +1,37 @@
+import { vi } from 'vitest'
+
+import * as db from '../../getDB'
+import { AsyncDuckDB, AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
+
+import type { StreamRecord } from '../../../streamProvider/types'
+import { StreamProvider } from '../../../streamProvider/StreamProvider'
+
+export function mockDB() {
+    const connectionMock = {
+        query: vi.fn().mockResolvedValue({}),
+        insertArrowTable: vi.fn().mockResolvedValue({}),
+    } as unknown as AsyncDuckDBConnection
+
+    vi.spyOn(db, 'getDB').mockResolvedValue({
+        conn: connectionMock,
+        db: {} as unknown as AsyncDuckDB,
+    })
+
+    return connectionMock
+}
+
+export function mockStreamProviderWithSpy(records: StreamRecord[]) {
+    const provider = new (class extends StreamProvider {
+        readonly name = 'test'
+        readonly displayName = 'Test Provider'
+        readonly filePattern = /test\.json$/
+        readonly fileContentType = 'application/json'
+
+        readFile = vi.fn(async () => records)
+        transform = vi.fn((raw) => raw as StreamRecord[])
+    })()
+
+    const processFileSpy = vi.spyOn(provider, 'processFile')
+
+    return { provider, processFileSpy }
+}

--- a/app/src/db/queries/insertFilesInDatabase.test.ts
+++ b/app/src/db/queries/insertFilesInDatabase.test.ts
@@ -1,16 +1,14 @@
 import { vi, describe, it, expect, afterEach, beforeEach } from 'vitest'
 
-import * as db from '../getDB'
 import { insertFilesInDatabase } from './insertFilesInDatabase'
 import { convertArrayToFileList } from '../../utils/convertArrayToFileList'
-import { AsyncDuckDB, AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
 import * as adapters from '../../streamProvider'
 import * as precompute from '../precompute'
 import * as dataSignal from '../dataSignal'
 
-import type { StreamRecord } from '../../streamProvider/types'
 import { TABLE } from './constants'
-import { StreamProvider } from '../../streamProvider/StreamProvider'
+
+import { mockDB, mockStreamProviderWithSpy } from './__tests__/test-utils'
 
 /**
  * We use this mock function due to JSDOM not supporting full File API : https://developer.mozilla.org/en-US/docs/Web/API/Blob/text
@@ -24,36 +22,6 @@ function mockFile(content: string, name: string, options: { type: string }) {
         type: options.type,
         size: content.length,
     } as unknown as File
-}
-
-function mockDB() {
-    const connectionMock = {
-        query: vi.fn().mockResolvedValue({}),
-        insertArrowTable: vi.fn().mockResolvedValue({}),
-    } as unknown as AsyncDuckDBConnection
-
-    vi.spyOn(db, 'getDB').mockResolvedValue({
-        conn: connectionMock,
-        db: {} as unknown as AsyncDuckDB,
-    })
-
-    return connectionMock
-}
-
-function mockStreamProviderWithSpy(records: StreamRecord[]) {
-    const provider = new (class extends StreamProvider {
-        readonly name = 'test'
-        readonly displayName = 'Test Provider'
-        readonly filePattern = /test\.json$/
-        readonly fileContentType = 'application/json'
-
-        readFile = vi.fn(async () => records)
-        transform = vi.fn((raw) => raw as StreamRecord[])
-    })()
-
-    const processFileSpy = vi.spyOn(provider, 'processFile')
-
-    return { provider, processFileSpy }
 }
 
 describe('insertFilesInDatabase', () => {

--- a/app/src/db/queries/insertUrlInDatabase.test.ts
+++ b/app/src/db/queries/insertUrlInDatabase.test.ts
@@ -1,46 +1,14 @@
 import { vi, describe, it, expect, afterEach, beforeEach } from 'vitest'
 
-import * as db from '../getDB'
 import { insertUrlInDatabase } from './insertUrlInDatabase'
-import { AsyncDuckDB, AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
 import * as adapters from '../../streamProvider'
 import { SpotifyStreamProvider } from '../../streamProvider/SpotifyStreamProvider/SpotifyStreamProvider'
 import * as precompute from '../precompute'
 import * as dataSignal from '../dataSignal'
+import { mockDB, mockStreamProviderWithSpy } from './__tests__/test-utils'
 
 import type { StreamRecord } from '../../streamProvider/types'
 import { TABLE } from './constants'
-import { StreamProvider } from '../../streamProvider/StreamProvider'
-
-function mockDB() {
-    const connectionMock = {
-        query: vi.fn().mockResolvedValue({}),
-        insertArrowTable: vi.fn().mockResolvedValue({}),
-    } as unknown as AsyncDuckDBConnection
-
-    vi.spyOn(db, 'getDB').mockResolvedValue({
-        conn: connectionMock,
-        db: {} as unknown as AsyncDuckDB,
-    })
-
-    return connectionMock
-}
-
-function mockStreamProviderWithSpy(records: StreamRecord[]) {
-    const provider = new (class extends StreamProvider {
-        readonly name = 'test'
-        readonly displayName = 'Test Provider'
-        readonly filePattern = /test\.json$/
-        readonly fileContentType = 'application/json'
-
-        readFile = vi.fn(async () => records)
-        transform = vi.fn((raw) => raw as StreamRecord[])
-    })()
-
-    const processFileSpy = vi.spyOn(provider, 'processFile')
-
-    return { provider, processFileSpy }
-}
 
 describe('insertUrlInDatabase', () => {
     beforeEach(() => {

--- a/app/src/db/queries/insertUrlInDatabase.test.ts
+++ b/app/src/db/queries/insertUrlInDatabase.test.ts
@@ -1,0 +1,238 @@
+import { vi, describe, it, expect, afterEach, beforeEach } from 'vitest'
+
+import * as db from '../getDB'
+import { insertUrlInDatabase } from './insertUrlInDatabase'
+import { AsyncDuckDB, AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
+import * as adapters from '../../streamProvider'
+import { SpotifyStreamProvider } from '../../streamProvider/SpotifyStreamProvider/SpotifyStreamProvider'
+import * as precompute from '../precompute'
+import * as dataSignal from '../dataSignal'
+
+import type { StreamRecord } from '../../streamProvider/types'
+import { TABLE } from './constants'
+import { StreamProvider } from '../../streamProvider/StreamProvider'
+
+function mockDB() {
+    const connectionMock = {
+        query: vi.fn().mockResolvedValue({}),
+        insertArrowTable: vi.fn().mockResolvedValue({}),
+    } as unknown as AsyncDuckDBConnection
+
+    vi.spyOn(db, 'getDB').mockResolvedValue({
+        conn: connectionMock,
+        db: {} as unknown as AsyncDuckDB,
+    })
+
+    return connectionMock
+}
+
+function mockStreamProviderWithSpy(records: StreamRecord[]) {
+    const provider = new (class extends StreamProvider {
+        readonly name = 'test'
+        readonly displayName = 'Test Provider'
+        readonly filePattern = /test\.json$/
+        readonly fileContentType = 'application/json'
+
+        readFile = vi.fn(async () => records)
+        transform = vi.fn((raw) => raw as StreamRecord[])
+    })()
+
+    const processFileSpy = vi.spyOn(provider, 'processFile')
+
+    return { provider, processFileSpy }
+}
+
+describe('insertUrlInDatabase', () => {
+    beforeEach(() => {
+        vi.spyOn(precompute, 'precomputeDerivedTables').mockResolvedValue(
+            undefined
+        )
+        vi.spyOn(dataSignal, 'dispatchDataLoaded').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    describe('error handling', () => {
+        it('should throw error when fetch fails', async () => {
+            const connectionMock = mockDB()
+            vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+                ok: false,
+                statusText: 'Not Found',
+            } as Response)
+
+            const url = new URL('https://example.com/data.json')
+
+            await expect(insertUrlInDatabase(url)).rejects.toThrow(
+                'Failed to fetch demo data: Not Found'
+            )
+
+            expect(connectionMock.query).not.toHaveBeenCalled()
+            expect(connectionMock.insertArrowTable).not.toHaveBeenCalled()
+        })
+
+        it('should throw error when no provider detected', async () => {
+            const connectionMock = mockDB()
+            vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+                ok: true,
+                blob: async () =>
+                    new Blob([JSON.stringify([])], {
+                        type: 'application/json',
+                    }),
+            } as Response)
+            vi.spyOn(adapters, 'detectProvider').mockReturnValue(undefined)
+
+            const url = new URL('https://example.com/data.json')
+
+            await expect(insertUrlInDatabase(url)).rejects.toThrow(
+                'No provider found for the demo data URL'
+            )
+
+            expect(connectionMock.query).not.toHaveBeenCalled()
+            expect(connectionMock.insertArrowTable).not.toHaveBeenCalled()
+        })
+
+        it('should throw error when no valid stream records', async () => {
+            const connectionMock = mockDB()
+            const { provider, processFileSpy } = mockStreamProviderWithSpy([])
+
+            vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+                ok: true,
+                blob: async () =>
+                    new Blob([JSON.stringify([])], {
+                        type: 'application/json',
+                    }),
+            } as Response)
+            vi.spyOn(adapters, 'detectProvider').mockReturnValue(provider)
+
+            const url = new URL('https://example.com/data.json')
+
+            await expect(insertUrlInDatabase(url)).rejects.toThrow(
+                'No valid stream records found in demo data'
+            )
+
+            expect(processFileSpy).toHaveBeenCalledTimes(1)
+            expect(connectionMock.query).not.toHaveBeenCalled()
+            expect(connectionMock.insertArrowTable).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('real provider detection from URL filename', () => {
+        it('should detect Spotify provider and process data using real detectProvider', async () => {
+            const connectionMock = mockDB()
+
+            const spotifyRawData = [
+                {
+                    spotify_track_uri: 'spotify:track:123',
+                    master_metadata_track_name: 'Test Song',
+                    master_metadata_album_artist_name: 'Test Artist',
+                    master_metadata_album_album_name: 'Test Album',
+                    ts: '2024-01-01T12:00:00Z',
+                    ms_played: 180000,
+                    platform: 'Test_Platform',
+                },
+            ]
+
+            vi.spyOn(
+                SpotifyStreamProvider.prototype,
+                'readFile'
+            ).mockResolvedValue(spotifyRawData)
+            vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+                ok: true,
+                blob: async () =>
+                    new Blob([JSON.stringify(spotifyRawData)], {
+                        type: 'application/json',
+                    }),
+            } as Response)
+
+            const url = new URL(
+                'https://example.com/Streaming_History_Audio_2024.json'
+            )
+            await insertUrlInDatabase(url)
+
+            expect(connectionMock.query).toHaveBeenCalledWith(
+                `DROP TABLE IF EXISTS ${TABLE}`
+            )
+            expect(connectionMock.insertArrowTable).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('successful processing', () => {
+        it('should process demo data and insert into database', async () => {
+            const connectionMock = mockDB()
+
+            const mockRecords: StreamRecord[] = [
+                {
+                    track_uri: 'spotify:track:123',
+                    track_name: 'Test Song',
+                    artist_name: 'Test Artist',
+                    album_name: 'Test Album',
+                    ts: '2024-01-01T12:00:00Z',
+                    ms_played: 180000,
+                    platform: 'Test_Platform',
+                },
+            ]
+            const { provider, processFileSpy } =
+                mockStreamProviderWithSpy(mockRecords)
+
+            vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+                ok: true,
+                blob: async () =>
+                    new Blob([JSON.stringify(mockRecords)], {
+                        type: 'application/json',
+                    }),
+            } as Response)
+            vi.spyOn(adapters, 'detectProvider').mockReturnValue(provider)
+
+            const url = new URL('https://example.com/data.json')
+            await insertUrlInDatabase(url)
+
+            expect(processFileSpy).toHaveBeenCalledTimes(1)
+            expect(connectionMock.query).toHaveBeenCalledWith(
+                `DROP TABLE IF EXISTS ${TABLE}`
+            )
+            expect(connectionMock.insertArrowTable).toHaveBeenCalledTimes(1)
+        })
+
+        it('should call precomputeDerivedTables after insertArrowTable', async () => {
+            const connectionMock = mockDB()
+
+            const mockRecords: StreamRecord[] = [
+                {
+                    track_uri: 'spotify:track:123',
+                    track_name: 'Test Song',
+                    artist_name: 'Test Artist',
+                    album_name: 'Test Album',
+                    ts: '2024-01-01T12:00:00Z',
+                    ms_played: 180000,
+                    platform: 'Test_Platform',
+                },
+            ]
+            const { provider } = mockStreamProviderWithSpy(mockRecords)
+
+            vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+                ok: true,
+                blob: async () =>
+                    new Blob([JSON.stringify(mockRecords)], {
+                        type: 'application/json',
+                    }),
+            } as Response)
+            vi.spyOn(adapters, 'detectProvider').mockReturnValue(provider)
+
+            const url = new URL('https://example.com/data.json')
+            await insertUrlInDatabase(url)
+
+            const precomputeSpy = vi.mocked(precompute.precomputeDerivedTables)
+            expect(precomputeSpy).toHaveBeenCalledTimes(1)
+            expect(precomputeSpy).toHaveBeenCalledWith(connectionMock)
+
+            const insertCallOrder = (
+                connectionMock.insertArrowTable as ReturnType<typeof vi.fn>
+            ).mock.invocationCallOrder[0]
+            const precomputeCallOrder =
+                precomputeSpy.mock.invocationCallOrder[0]
+            expect(precomputeCallOrder).toBeGreaterThan(insertCallOrder)
+        })
+    })
+})

--- a/app/src/db/queries/insertUrlInDatabase.ts
+++ b/app/src/db/queries/insertUrlInDatabase.ts
@@ -1,29 +1,39 @@
 import { getDB } from '../getDB'
 import { TABLE, DROP_TABLE_QUERY } from './constants'
+import { tableFromJSON } from 'apache-arrow'
+import { detectProvider } from '../../streamProvider'
 import { precomputeDerivedTables } from '../precompute'
 import { dispatchDataLoaded } from '../dataSignal'
 
 export async function insertUrlInDatabase(jsonUrl: URL) {
+    const response = await fetch(jsonUrl.toString())
+    if (!response.ok) {
+        throw new Error(`Failed to fetch demo data: ${response.statusText}`)
+    }
+
+    const blob = await response.blob()
+    const filename = jsonUrl.pathname.split('/').pop() || 'streaming_data.json'
+    const file = new File([blob], filename, { type: 'application/json' })
+
+    const provider = detectProvider(file)
+    if (!provider) {
+        throw new Error('No provider found for the demo data URL')
+    }
+
+    const records = await provider.processFile(file)
+
+    if (records.length === 0) {
+        throw new Error('No valid stream records found in demo data')
+    }
+
+    const arrowTableContent = tableFromJSON(records)
+
     const { conn } = await getDB()
     await conn.query(DROP_TABLE_QUERY)
-    await conn.insertJSONFromPath(jsonUrl.toString(), { name: TABLE })
-    // The Spotify fields are renamed to match the `StreamRecord` model.
-    // `insertUrlInDatabase` is only used by the `DemoButton`, which provides a Spotify file.
-    // It's acceptable to apply this transformation here as a temporary hotfix, but ideally,
-    // we should use the transformation from `SpotifyStreamProvider` and automatically detect
-    // the correct provider to use.
-    await conn.query(
-        `ALTER TABLE ${TABLE} RENAME COLUMN spotify_track_uri TO track_uri`
-    )
-    await conn.query(
-        `ALTER TABLE ${TABLE} RENAME COLUMN master_metadata_track_name TO track_name`
-    )
-    await conn.query(
-        `ALTER TABLE ${TABLE} RENAME COLUMN master_metadata_album_artist_name TO artist_name`
-    )
-    await conn.query(
-        `ALTER TABLE ${TABLE} RENAME COLUMN master_metadata_album_album_name TO album_name`
-    )
+    await conn.insertArrowTable(arrowTableContent, {
+        name: TABLE,
+        create: true,
+    })
 
     await precomputeDerivedTables(conn)
     dispatchDataLoaded()


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

`insertUrlInDatabase.ts` (demo flow) manually renames 4 Spotify columns via `ALTER TABLE`, duplicating the transformation logic already present in `SpotifyStreamProvider.transform()`. It bypasses the entire StreamProvider pipeline, no validation (`isValidStreamRecord`), no filtering (`isLongEnoughStream`), and is hardcoded for Spotify only. Any Spotify export schema change requires fixing two separate code paths.

Recent synthetic dataset filename changes (commits `c64712a2`, `808889e1`) highlighted this fragility: the demo URL had to be manually updated, but the duplicated ALTER TABLE logic remains a maintenance risk.

## 🎹 Proposal

Refactor `insertUrlInDatabase` to use the same StreamProvider pipeline as `insertFilesInDatabase`:
1. `fetch()` the demo JSON URL
2. Wrap the response in a `File` object
3. `detectProvider()` to find the matching provider adapter
4. `provider.processFile()` for transform → validate -> filter
5. `tableFromJSON()` -> `conn.insertArrowTable()` (same as the file upload path)
6. Remove the 4 `ALTER TABLE` statements and the hardcoded Spotify dependency

## 🎶 Comments

The `console.debug` assertion was removed from tests as it tests an implementation detail, the core data flow assertions provide sufficient coverage.

## 🎤 Test

The demo button still works.