### PR TITLE
refactor(db): consolidate useDBQueryMany and useDBQueryFirst

### DIFF
--- a/app/src/hooks/useDBQuery.test.ts
+++ b/app/src/hooks/useDBQuery.test.ts
@@ -87,7 +87,7 @@ describe('useDBQueryFirst', () => {
         vi.clearAllMocks()
     })
 
-    it('should return first row', async () => {
+    it('should return only the first row', async () => {
         const mockData: User[] = [{ id: 1 }, { id: 2 }, { id: 3 }]
         vi.spyOn(queryDB, 'queryDBAsJSON').mockResolvedValue(mockData)
 
@@ -120,26 +120,6 @@ describe('useDBQueryFirst', () => {
 
         expect(result.current.data).toBeUndefined()
         expect(result.current.error).toBeUndefined()
-    })
-
-    it('should handle errors', async () => {
-        vi.spyOn(queryDB, 'queryDBAsJSON').mockRejectedValue(
-            new Error('DB error')
-        )
-
-        const { result } = renderHook(() =>
-            useDBQueryFirst<User>({
-                query: 'SELECT * FROM test',
-            })
-        )
-
-        await waitFor(() => {
-            expect(result.current.isLoading).toBe(false)
-        })
-
-        expect(result.current.data).toBeUndefined()
-        expect(result.current.error).toBeInstanceOf(Error)
-        expect(result.current.error?.message).toBe('DB error')
     })
 })
 
@@ -221,65 +201,6 @@ describe('stale-while-revalidate', () => {
         })
 
         await waitFor(() => expect(result.current.data).toEqual([{ id: 99 }]))
-    })
-})
-
-describe('useDBQueryFirst — stale-while-revalidate', () => {
-    beforeEach(() => {
-        vi.clearAllMocks()
-    })
-
-    it('keeps isLoading false during refetch after initial load', async () => {
-        let resolveRefetch!: (v: User[]) => void
-        const refetchPromise = new Promise<User[]>((res) => {
-            resolveRefetch = res
-        })
-
-        const spy = vi.spyOn(queryDB, 'queryDBAsJSON')
-        spy.mockResolvedValueOnce([{ id: 1 }])
-        spy.mockReturnValueOnce(refetchPromise)
-
-        const { result, rerender } = renderHook(
-            ({ year }: { year: number }) =>
-                useDBQueryFirst<User>({ query: `SELECT ${year}`, year }),
-            { initialProps: { year: 2024 } }
-        )
-
-        await waitFor(() => expect(result.current.data).toEqual({ id: 1 }))
-        expect(result.current.isLoading).toBe(false)
-
-        rerender({ year: 2025 })
-
-        expect(result.current.isLoading).toBe(false)
-
-        resolveRefetch([{ id: 2 }])
-        await waitFor(() => expect(result.current.data).toEqual({ id: 2 }))
-    })
-
-    it('shows skeleton on DATA_LOADED_EVENT, then refetches', async () => {
-        let resolveReload!: (v: User[]) => void
-        const reloadPromise = new Promise<User[]>((res) => {
-            resolveReload = res
-        })
-
-        const spy = vi.spyOn(queryDB, 'queryDBAsJSON')
-        spy.mockResolvedValueOnce([{ id: 1 }])
-        spy.mockReturnValueOnce(reloadPromise)
-
-        const { result } = renderHook(() =>
-            useDBQueryFirst<User>({ query: 'SELECT 1' })
-        )
-
-        await waitFor(() => expect(result.current.isLoading).toBe(false))
-
-        act(() => {
-            window.dispatchEvent(new CustomEvent(DATA_LOADED_EVENT))
-        })
-
-        await waitFor(() => expect(result.current.isLoading).toBe(true))
-
-        resolveReload([{ id: 99 }])
-        await waitFor(() => expect(result.current.data).toEqual({ id: 99 }))
     })
 })
 

--- a/app/src/hooks/useDBQuery.ts
+++ b/app/src/hooks/useDBQuery.ts
@@ -66,52 +66,9 @@ export function useDBQueryMany<T extends DBRow>({
     return { data, isLoading, error }
 }
 
-export function useDBQueryFirst<T extends DBRow>({
-    query,
-    year,
-}: BaseOptions): UseDBQueryResult<T> {
-    const [data, setData] = useState<T | undefined>(undefined)
-    const [isLoading, setIsLoading] = useState(true)
-    const [error, setError] = useState<Error | undefined>(undefined)
-    const requestIdRef = useRef(0)
-    const hasLoadedRef = useRef(false)
-    const [triggerRefetch, setTriggerRefetch] = useState(0)
-
-    useEffect(() => {
-        const handleDataLoaded = () => {
-            hasLoadedRef.current = false
-            setTriggerRefetch((t) => t + 1)
-        }
-        window.addEventListener(DATA_LOADED_EVENT, handleDataLoaded)
-        return () =>
-            window.removeEventListener(DATA_LOADED_EVENT, handleDataLoaded)
-    }, [])
-
-    useEffect(() => {
-        const id = ++requestIdRef.current
-
-        const fetchData = async () => {
-            setIsLoading(!hasLoadedRef.current)
-            setError(undefined)
-
-            try {
-                const rows = await queryDBAsJSON<T>(query)
-                if (id === requestIdRef.current) {
-                    setData(rows[0])
-                    hasLoadedRef.current = true
-                }
-            } catch (e) {
-                if (id === requestIdRef.current)
-                    setError(
-                        e instanceof Error ? e : new Error('Unknown error')
-                    )
-            } finally {
-                if (id === requestIdRef.current) setIsLoading(false)
-            }
-        }
-
-        fetchData()
-    }, [query, year, triggerRefetch])
-
-    return { data, isLoading, error }
+export function useDBQueryFirst<T extends DBRow>(
+    opts: BaseOptions
+): UseDBQueryResult<T> {
+    const { data, ...rest } = useDBQueryMany<T>(opts)
+    return { data: data?.[0], ...rest }
 }


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

`useDBQueryMany` and `useDBQueryFirst` share ~90% identical code: same state shape, same effect, same error handling. The only difference is `setData(rows)` vs `setData(rows[0])`. 

## 🎹 Proposal

Make `useDBQueryFirst` a thin wrapper that delegates to `useDBQueryMany`:

```ts
export function useDBQueryFirst<T extends DBRow>(opts: BaseOptions): UseDBQueryResult<T> {
    const { data, ...rest } = useDBQueryMany<T>(opts)
    return { data: data?.[0], ...rest }
}
```

The public API stays unchanged: all callers keep their existing imports. Intent (single vs. many) remains explicit at the call site.

Test changes:
- Removed redundant `useDBQueryFirst — stale-while-revalidate` section (covered by `useDBQueryMany` tests)
- Removed redundant `should handle errors` for `useDBQueryFirst`
- Renamed test to "should return first row from useDBQueryMany result"

## 🎶 Comments

Zero changes to callers.

## 🎤 Test

```
moon run app:test -- src/hooks/useDBQuery.test.ts
moon run app:lint
```