### PR TITLE
feat(charts): unify tooltips across EvolutionOverTime and FavoriteWeekday

### DIFF
--- a/app/src/components/Charts/SimpleCharts/CalendarHeatmap/CalendarHeatmap.tsx
+++ b/app/src/components/Charts/SimpleCharts/CalendarHeatmap/CalendarHeatmap.tsx
@@ -102,6 +102,7 @@ export const CalendarHeatmap: FC<Props> = ({ data, year, isLoading }) => {
                             gap: `${CELL_GAP}px`,
                             minWidth: `${minGridWidth}px`,
                         }}
+                        onMouseLeave={() => setTooltip(null)}
                     >
                         {DAY_LABELS.map((label, dayIdx) => (
                             <div
@@ -138,7 +139,6 @@ export const CalendarHeatmap: FC<Props> = ({ data, year, isLoading }) => {
                                         onMouseEnter={(e) =>
                                             handleMouseEnter(e, cell)
                                         }
-                                        onMouseLeave={() => setTooltip(null)}
                                     />
                                 )
                             )

--- a/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { EvolutionOverTime } from './EvolutionOverTime'
 
 describe('EvolutionOverTime Component', () => {
@@ -8,7 +8,7 @@ describe('EvolutionOverTime Component', () => {
         screen.getByText('No data for this year')
     })
 
-    it('renders correctly with data', async () => {
+    it('renders correctly with data', () => {
         const data = [
             { year: 2020, streams: 100, ms_played: 60 * 60 * 1000 },
             { year: 2021, streams: 150, ms_played: 60 * 60 * 1000 },
@@ -19,10 +19,28 @@ describe('EvolutionOverTime Component', () => {
         render(<EvolutionOverTime data={data} year={currentYear} />)
 
         screen.getByRole('heading', { name: /📈Soundtrack Growth/ })
-        screen.getByText('2020 100 streams (1h 0m 0s)')
-        screen.getByText('2021 150 streams (1h 0m 0s)')
-        screen.getByText('2022 200 streams (1h 0m 0s)')
         screen.getByText('Total streams')
         screen.getByText('450')
+    })
+
+    it('shows tooltip on bar hover', () => {
+        const data = [
+            { year: 2020, streams: 100, ms_played: 60 * 60 * 1000 },
+            { year: 2021, streams: 150, ms_played: 2 * 60 * 60 * 1000 },
+            { year: 2022, streams: 200, ms_played: 3 * 60 * 60 * 1000 },
+        ]
+
+        render(<EvolutionOverTime data={data} year={2022} />)
+
+        const barElements = document.querySelectorAll('.flex-1')
+        expect(barElements.length).toBe(3)
+
+        fireEvent.mouseEnter(barElements[0])
+
+        expect(screen.getByText('100 streams')).toBeDefined()
+        expect(screen.getByText('1h 0m 0s')).toBeDefined()
+
+        fireEvent.mouseLeave(barElements[0].parentElement!)
+        expect(screen.queryByText('100 streams')).toBeNull()
     })
 })

--- a/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.test.tsx
@@ -39,6 +39,8 @@ describe('EvolutionOverTime Component', () => {
 
         expect(screen.getByText('100 streams')).toBeDefined()
         expect(screen.getByText('1h 0m 0s')).toBeDefined()
+        expect(screen.getByText('450 total streams')).toBeDefined()
+        expect(screen.getByText('6h 0m 0s total listening')).toBeDefined()
 
         fireEvent.mouseLeave(barElements[0].parentElement!)
         expect(screen.queryByText('100 streams')).toBeNull()

--- a/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.tsx
+++ b/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.tsx
@@ -25,6 +25,8 @@ export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
         : 0
     const currentYearData = data?.find((d) => d.year === year)
     const totalStreams = data?.reduce((acc, curr) => acc + curr.streams, 0) ?? 0
+    const totalMsPlayed =
+        data?.reduce((acc, curr) => acc + curr.ms_played, 0) ?? 0
     const startYear = data?.length ? Math.min(...data.map((d) => d.year)) : 0
 
     return (
@@ -119,6 +121,13 @@ export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
                     </div>
                     <div className="text-gray-300 dark:text-gray-400">
                         {formatDuration(tooltip.ms_played)}
+                    </div>
+                    <div className="border-t border-gray-700 my-1.5" />
+                    <div className="text-gray-300 dark:text-gray-400">
+                        {totalStreams.toLocaleString()} total streams
+                    </div>
+                    <div className="text-gray-300 dark:text-gray-400">
+                        {formatDuration(totalMsPlayed)} total listening
                     </div>
                 </ChartTooltip>
             )}

--- a/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.tsx
+++ b/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.tsx
@@ -1,7 +1,16 @@
 import type { FC } from 'react'
+import { useState } from 'react'
 import type { EvolutionResult } from './query'
 import { formatDuration } from '../../../../utils/formatDuration'
-import { ChartCard, ChartCardEmpty } from '../shared'
+import { ChartCard, ChartCardEmpty, ChartTooltip } from '../shared'
+
+type TooltipState = {
+    x: number
+    y: number
+    year: number
+    streams: number
+    ms_played: number
+}
 
 type Props = {
     data: EvolutionResult[] | undefined
@@ -10,6 +19,7 @@ type Props = {
 }
 
 export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
+    const [tooltip, setTooltip] = useState<TooltipState | null>(null)
     const maxStreams = data?.length
         ? Math.max(...data.map((d) => d.streams))
         : 0
@@ -29,14 +39,29 @@ export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
                 <ChartCardEmpty />
             ) : (
                 <>
-                    <div className="flex items-end gap-1 h-24 mt-4 mb-2">
+                    <div
+                        className="flex items-end gap-1 h-24 mt-4 mb-2"
+                        onMouseLeave={() => setTooltip(null)}
+                    >
                         {data.map((d) => {
                             const height = (d.streams / maxStreams) * 100
                             return (
                                 <div
                                     key={d.year}
-                                    className="flex-1 bg-brand-blue dark:bg-brand-blue rounded-t relative group"
+                                    className="flex-1 bg-brand-blue dark:bg-brand-blue rounded-t relative"
                                     style={{ height: `${height}%` }}
+                                    onMouseEnter={(e) => {
+                                        const rect = (
+                                            e.currentTarget as HTMLElement
+                                        ).getBoundingClientRect()
+                                        setTooltip({
+                                            x: rect.left + rect.width / 2,
+                                            y: rect.top,
+                                            year: d.year,
+                                            streams: d.streams,
+                                            ms_played: d.ms_played,
+                                        })
+                                    }}
                                 >
                                     <div
                                         className={`absolute bottom-0 left-0 right-0 bg-brand-blue rounded-t transition-all duration-300 ${
@@ -46,12 +71,6 @@ export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
                                         }`}
                                         style={{ height: '100%' }}
                                     ></div>
-                                    <div className="opacity-0 group-hover:opacity-100 absolute bottom-full left-1/2 -translate-x-1/2 mb-1 bg-black text-white text-xs px-2 py-1 rounded pointer-events-none whitespace-nowrap z-10">
-                                        {d.year}
-                                        <br /> {d.streams.toLocaleString()}{' '}
-                                        streams
-                                        <br /> ({formatDuration(d.ms_played)})
-                                    </div>
                                 </div>
                             )
                         })}
@@ -91,6 +110,17 @@ export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
                         )}
                     </ul>
                 </>
+            )}
+            {tooltip && (
+                <ChartTooltip x={tooltip.x} y={tooltip.y}>
+                    <div className="font-semibold">{tooltip.year}</div>
+                    <div className="text-gray-300 dark:text-gray-400">
+                        {tooltip.streams.toLocaleString()} streams
+                    </div>
+                    <div className="text-gray-300 dark:text-gray-400">
+                        {formatDuration(tooltip.ms_played)}
+                    </div>
+                </ChartTooltip>
             )}
         </ChartCard>
     )

--- a/app/src/components/Charts/SimpleCharts/FavoriteWeekday/FavoriteWeekday.sql
+++ b/app/src/components/Charts/SimpleCharts/FavoriteWeekday/FavoriteWeekday.sql
@@ -1,27 +1,25 @@
 with
-selected_streams as (
-    select *
-    from ${table}
-    where ${year_condition}
-),
-
-day_streams as (
+daily_stats as (
     select
         dayname(ts::date) as day_name,
         count(*) as stream_count,
-        count(*)::double / (
+        coalesce(sum(ms_played), 0)::double as ms_played,
+        (
             select count(*)
-            from selected_streams
-        )::double * 100 as pct
-    from selected_streams
+            from ${table}
+            where ${year_condition}
+        ) as total_count
+    from ${table}
+    where ${year_condition}
     group by dayname(ts::date)
 )
 
 select
     day_name,
+    ms_played,
     stream_count::double as stream_count,
-    pct
-from day_streams
+    stream_count::double / total_count * 100 as pct
+from daily_stats
 order by
     case day_name
         when 'Monday' then 1

--- a/app/src/components/Charts/SimpleCharts/FavoriteWeekday/FavoriteWeekday.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/FavoriteWeekday/FavoriteWeekday.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { FavoriteWeekday } from './FavoriteWeekday'
 
 describe('FavoriteWeekday Component', () => {
@@ -9,13 +9,18 @@ describe('FavoriteWeekday Component', () => {
     })
 
     const data = [
-        { day_name: 'Monday', stream_count: 10, pct: 10 },
-        { day_name: 'Tuesday', stream_count: 20, pct: 20 },
-        { day_name: 'Wednesday', stream_count: 30, pct: 30 }, // Favorite
-        { day_name: 'Thursday', stream_count: 15, pct: 15 },
-        { day_name: 'Friday', stream_count: 10, pct: 10 },
-        { day_name: 'Saturday', stream_count: 10, pct: 10 },
-        { day_name: 'Sunday', stream_count: 5, pct: 5 },
+        { day_name: 'Monday', stream_count: 10, ms_played: 600000, pct: 10 },
+        { day_name: 'Tuesday', stream_count: 20, ms_played: 1200000, pct: 20 },
+        {
+            day_name: 'Wednesday',
+            stream_count: 30,
+            ms_played: 1800000,
+            pct: 30,
+        }, // Favorite
+        { day_name: 'Thursday', stream_count: 15, ms_played: 900000, pct: 15 },
+        { day_name: 'Friday', stream_count: 10, ms_played: 600000, pct: 10 },
+        { day_name: 'Saturday', stream_count: 10, ms_played: 600000, pct: 10 },
+        { day_name: 'Sunday', stream_count: 5, ms_played: 300000, pct: 5 },
     ]
 
     it('renders correctly and highlights favorite day', () => {
@@ -31,5 +36,21 @@ describe('FavoriteWeekday Component', () => {
         screen.getByText('Fri')
         screen.getByText('Sat')
         screen.getByText('Sun')
+    })
+
+    it('shows tooltip on bar hover', () => {
+        render(<FavoriteWeekday data={data} />)
+
+        const barElements = document.querySelectorAll('.overflow-hidden')
+        expect(barElements.length).toBe(7)
+
+        fireEvent.mouseEnter(barElements[0])
+
+        expect(screen.getByText('Monday')).toBeDefined()
+        expect(screen.getByText('10 streams')).toBeDefined()
+        expect(screen.getByText('10m 0s')).toBeDefined()
+
+        fireEvent.mouseLeave(barElements[0].parentElement!.parentElement!)
+        expect(screen.queryByText('10 streams')).toBeNull()
     })
 })

--- a/app/src/components/Charts/SimpleCharts/FavoriteWeekday/FavoriteWeekday.tsx
+++ b/app/src/components/Charts/SimpleCharts/FavoriteWeekday/FavoriteWeekday.tsx
@@ -1,6 +1,16 @@
 import type { FC } from 'react'
+import { useState } from 'react'
 import type { FavoriteWeekdayResult } from './query'
-import { ChartCard, ChartCardEmpty, ChartHero } from '../shared'
+import { formatDuration } from '../../../../utils/formatDuration'
+import { ChartCard, ChartCardEmpty, ChartHero, ChartTooltip } from '../shared'
+
+type TooltipState = {
+    x: number
+    y: number
+    day_name: string
+    stream_count: number
+    ms_played: number
+}
 
 type Props = {
     data: FavoriteWeekdayResult[] | undefined
@@ -18,6 +28,7 @@ const DAY_ABBREVIATIONS: Record<string, string> = {
 }
 
 export const FavoriteWeekday: FC<Props> = ({ data, isLoading }) => {
+    const [tooltip, setTooltip] = useState<TooltipState | null>(null)
     const favoriteDay = data
         ? data.reduce((max, day) => (day.pct > max.pct ? day : max), data[0])
         : undefined
@@ -40,7 +51,10 @@ export const FavoriteWeekday: FC<Props> = ({ data, isLoading }) => {
                         labelColor="text-orange-400"
                     />
 
-                    <div className="grid grid-cols-7 gap-1">
+                    <div
+                        className="grid grid-cols-7 gap-1"
+                        onMouseLeave={() => setTooltip(null)}
+                    >
                         {data.map((day) => {
                             const isFavorite =
                                 day.day_name === favoriteDay!.day_name
@@ -54,7 +68,21 @@ export const FavoriteWeekday: FC<Props> = ({ data, isLoading }) => {
                                     <div className="text-[10px] font-medium text-gray-600 dark:text-gray-400">
                                         {DAY_ABBREVIATIONS[day.day_name]}
                                     </div>
-                                    <div className="w-full h-16 bg-gray-200 dark:bg-slate-700/50 rounded-sm flex items-end overflow-hidden">
+                                    <div
+                                        className="w-full h-16 bg-gray-200 dark:bg-slate-700/50 rounded-sm flex items-end overflow-hidden"
+                                        onMouseEnter={(e) => {
+                                            const rect = (
+                                                e.currentTarget as HTMLElement
+                                            ).getBoundingClientRect()
+                                            setTooltip({
+                                                x: rect.left + rect.width / 2,
+                                                y: rect.top,
+                                                day_name: day.day_name,
+                                                stream_count: day.stream_count,
+                                                ms_played: day.ms_played,
+                                            })
+                                        }}
+                                    >
                                         <div
                                             className={`w-full rounded-sm transition-all duration-300 ${
                                                 isFavorite
@@ -72,6 +100,17 @@ export const FavoriteWeekday: FC<Props> = ({ data, isLoading }) => {
                         })}
                     </div>
                 </>
+            )}
+            {tooltip && (
+                <ChartTooltip x={tooltip.x} y={tooltip.y}>
+                    <div className="font-semibold">{tooltip.day_name}</div>
+                    <div className="text-gray-300 dark:text-gray-400">
+                        {tooltip.stream_count.toLocaleString()} streams
+                    </div>
+                    <div className="text-gray-300 dark:text-gray-400">
+                        {formatDuration(tooltip.ms_played)}
+                    </div>
+                </ChartTooltip>
             )}
         </ChartCard>
     )

--- a/app/src/components/Charts/SimpleCharts/FavoriteWeekday/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/FavoriteWeekday/query.test.ts
@@ -12,16 +12,16 @@ import type { DuckDBConnection } from '@duckdb/node-api'
 let conn: DuckDBConnection
 
 const testData: TestStreamEntry[] = [
-    { ts: '2025-12-01' }, // Monday
-    { ts: '2025-12-01' },
-    { ts: '2025-12-02' },
-    { ts: '2025-12-03' },
-    { ts: '2025-12-04' },
-    { ts: '2025-12-05' },
-    { ts: '2025-12-06' },
-    { ts: '2025-12-07' },
+    { ts: '2025-12-01', ms_played: 60000 }, // Monday
+    { ts: '2025-12-01', ms_played: 30000 },
+    { ts: '2025-12-02', ms_played: 45000 }, // Tuesday
+    { ts: '2025-12-03', ms_played: 72000 }, // Wednesday
+    { ts: '2025-12-04', ms_played: 36000 }, // Thursday
+    { ts: '2025-12-05', ms_played: 90000 }, // Friday
+    { ts: '2025-12-06', ms_played: 15000 }, // Saturday
+    { ts: '2025-12-07', ms_played: 80000 }, // Sunday
     // Another year
-    { ts: '2024-12-01' },
+    { ts: '2024-12-01', ms_played: 10000 },
 ]
 
 describe('FavoriteWeekday Query', () => {
@@ -41,13 +41,43 @@ describe('FavoriteWeekday Query', () => {
         const rows = await testQuery(conn, queryFavoriteWeekday(2025))
 
         expect(rows).toEqual([
-            { day_name: 'Monday', stream_count: 2, pct: 25 },
-            { day_name: 'Tuesday', stream_count: 1, pct: 12.5 },
-            { day_name: 'Wednesday', stream_count: 1, pct: 12.5 },
-            { day_name: 'Thursday', stream_count: 1, pct: 12.5 },
-            { day_name: 'Friday', stream_count: 1, pct: 12.5 },
-            { day_name: 'Saturday', stream_count: 1, pct: 12.5 },
-            { day_name: 'Sunday', stream_count: 1, pct: 12.5 },
+            { day_name: 'Monday', stream_count: 2, ms_played: 90000, pct: 25 },
+            {
+                day_name: 'Tuesday',
+                stream_count: 1,
+                ms_played: 45000,
+                pct: 12.5,
+            },
+            {
+                day_name: 'Wednesday',
+                stream_count: 1,
+                ms_played: 72000,
+                pct: 12.5,
+            },
+            {
+                day_name: 'Thursday',
+                stream_count: 1,
+                ms_played: 36000,
+                pct: 12.5,
+            },
+            {
+                day_name: 'Friday',
+                stream_count: 1,
+                ms_played: 90000,
+                pct: 12.5,
+            },
+            {
+                day_name: 'Saturday',
+                stream_count: 1,
+                ms_played: 15000,
+                pct: 12.5,
+            },
+            {
+                day_name: 'Sunday',
+                stream_count: 1,
+                ms_played: 80000,
+                pct: 12.5,
+            },
         ])
 
         const totalPct = rows.reduce((sum, row) => sum + (row.pct as number), 0)

--- a/app/src/components/Charts/SimpleCharts/FavoriteWeekday/query.tsx
+++ b/app/src/components/Charts/SimpleCharts/FavoriteWeekday/query.tsx
@@ -5,6 +5,7 @@ import sqlQueryFavoriteWeekday from './FavoriteWeekday.sql?raw'
 export type FavoriteWeekdayResult = {
     day_name: string
     stream_count: number
+    ms_played: number
     pct: number
 }
 


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Soundtrack Growth (EvolutionOverTime) used a basic CSS-only hover tooltip that looked different from other charts, and Your Power Day (FavoriteWeekday) had no tooltip at all, making it harder to see detailed information on hover. Additionally, the CalendarHeatmap tooltip flickered when moving between adjacent cells.

## 🎹 Proposal

- EvolutionOverTime (Soundtrack Growth): replaced the CSS tooltip with the shared ChartTooltip component for visual consistency. The tooltip now shows per-year stream count, listening duration, and cumulative totals across all years.
- FavoriteWeekday (Your Power Day): added an interactive tooltip on each day's bar displaying the day name, stream count, and listening duration.
- CalendarHeatmap (Hourly Streams): moved tooltip dismissal from individual cells to the container grid, preventing flicker when navigating between adjacent cells.

## 🎶 Comments

Built on feedback from the earlier ChartTooltip adoption on Around the Clock and Calendar Heatmap: same pattern, same look and feel.

## 🎤 Test

Hover any year bar on EvolutionOverTime to see year, streams, listening duration, and cumulative totals. Hover any day bar on FavoriteWeekday to see day name, streams, and listening duration. Hover off to verify the tooltip disappears. Hover between adjacent cells on CalendarHeatmap and observe no flicker.