### PR TITLE
feat(charts): keep fun fact cards visible with fallback messages for empty and error states

### DIFF
--- a/app/src/components/Charts/SimpleCharts/FunFacts/CozyAlbum.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/CozyAlbum.sql
@@ -22,17 +22,8 @@ sunday_album_listening as (
 )
 
 select
-    'cozy_album' as fact_type,
     album_name as main_text,
     artist_name as second_text,
+    'cozy_album' as fact_type,
     'the album that wraps your Sundays in musical coziness' as context
 from sunday_album_listening
-
-union all
-
-select
-    'cozy_album' as fact_type,
-    null as main_text,
-    'This fun fact is unfortunately unavailable' as second_text,
-    'feel like listening to an album today?' as context
-where not exists (select 1 from sunday_album_listening)

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
@@ -7,8 +7,7 @@ import * as db from '../../../../db/getDB'
 import { DATA_LOADED_EVENT } from '../../../../db/dataSignal'
 import { FunFactResult, facts } from './queries'
 
-const EMPTY_MESSAGE =
-    'Not enough listening data to generate fun facts — keep streaming!'
+const EMPTY_MESSAGE = 'Not enough data for this fun fact — keep listening!'
 const ERROR_MESSAGE = 'Something went wrong while loading fun facts'
 
 describe('FunFacts Component', () => {
@@ -68,7 +67,7 @@ describe('FunFacts Component', () => {
                     {
                         fact_type: match[1],
                         main_text: `Test ${match[1]} #${callIndex}`,
-                        value: callIndex,
+                        fact_value: callIndex,
                         unit: 'streams',
                     },
                 ] as FunFactResult[]
@@ -164,6 +163,9 @@ describe('FunFacts Component', () => {
         await waitFor(() => {
             expect(screen.getByText(EMPTY_MESSAGE)).toBeDefined()
         })
+
+        const hasAnyTitle = facts.some((f) => screen.queryByText(f.title))
+        expect(hasAnyTitle).toBe(true)
     })
 
     it('should show error state when query fails', async () => {
@@ -202,7 +204,7 @@ describe('FunFacts Component', () => {
             {
                 fact_type: 'morning_favorite',
                 main_text: 'Test morning_favorite',
-                value: 1,
+                fact_value: 1,
                 unit: 'streams',
             },
         ] as FunFactResult[])
@@ -210,30 +212,29 @@ describe('FunFacts Component', () => {
         fireEvent.click(screen.getByTitle('New fact'))
 
         await waitFor(() => {
-            expect(screen.getByText('🌅 Musical Breakfast')).toBeDefined()
+            expect(screen.queryByText(ERROR_MESSAGE)).toBeNull()
+            const hasAnyTitle = facts.some((f) => screen.queryByText(f.title))
+            expect(hasAnyTitle).toBe(true)
         })
     })
 
-    it('should handle cozy album with null main_text', async () => {
+    it('should show empty state when query returns null main_text and no other content', async () => {
         vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue([
             {
                 fact_type: 'dummy_fact_type',
                 main_text: null,
-                second_text: 'This fun fact is unfortunately unavailable',
-                value: undefined,
-                context: 'feel like listening to an album today?',
             },
         ] as FunFactResult[])
         render(<FunFacts />)
 
         await waitFor(() => {
-            expect(
-                screen.getByText('This fun fact is unfortunately unavailable')
-            ).toBeDefined()
+            expect(screen.getByText(EMPTY_MESSAGE)).toBeDefined()
         })
+        const hasAnyTitle = facts.some((f) => screen.queryByText(f.title))
+        expect(hasAnyTitle).toBe(true)
     })
 
-    it('should show cozy album title when rendering', async () => {
+    it('should render content when query returns main_text and value', async () => {
         vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue([
             {
                 fact_type: 'cozy_album',
@@ -248,11 +249,38 @@ describe('FunFacts Component', () => {
         render(<FunFacts />)
 
         await waitFor(() => {
-            expect(screen.getByText('💿 Cozy Album')).toBeDefined()
+            expect(screen.getByText('Cozy Album')).toBeDefined()
         })
-        expect(screen.getByText('Cozy Album')).toBeDefined()
         expect(
             screen.getByText((content) => content.includes('10'))
         ).toBeDefined()
+    })
+
+    it('does not show generic fallback identity when all facts are empty', async () => {
+        vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue([])
+        render(<FunFacts />)
+
+        await waitFor(() => {
+            const el = document.querySelector('[data-fact-type]')
+            expect(el?.getAttribute('data-fact-type')).not.toBe('fallback_fact')
+        })
+    })
+
+    it('displays numeric value when query returns fact_value', async () => {
+        vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue([
+            {
+                fact_type: 'morning_favorite',
+                main_text: 'Some Artist',
+                fact_value: 42,
+                unit: 'streams',
+            },
+        ] as FunFactResult[])
+        render(<FunFacts />)
+
+        await waitFor(() => {
+            expect(
+                screen.getByText((content) => content.includes('42'))
+            ).toBeDefined()
+        })
     })
 })

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
@@ -7,6 +7,10 @@ import * as db from '../../../../db/getDB'
 import { DATA_LOADED_EVENT } from '../../../../db/dataSignal'
 import { FunFactResult, facts } from './queries'
 
+const EMPTY_MESSAGE =
+    'Not enough listening data to generate fun facts — keep streaming!'
+const ERROR_MESSAGE = 'Something went wrong while loading fun facts'
+
 describe('FunFacts Component', () => {
     beforeEach(() => {
         vi.clearAllMocks()
@@ -53,7 +57,22 @@ describe('FunFacts Component', () => {
     })
 
     it('should refresh fact on DATA_LOADED_EVENT', async () => {
-        const querySpy = vi.spyOn(query, 'queryDBAsJSON')
+        let callIndex = 0
+        const querySpy = vi
+            .spyOn(query, 'queryDBAsJSON')
+            .mockImplementation(async (sql: string) => {
+                const match = sql.match(/'([a-z_]+)'\s+as\s+fact_type/)
+                if (!match) return []
+                callIndex++
+                return [
+                    {
+                        fact_type: match[1],
+                        main_text: `Test ${match[1]} #${callIndex}`,
+                        value: callIndex,
+                        unit: 'streams',
+                    },
+                ] as FunFactResult[]
+            })
         const { container } = render(<FunFacts />)
 
         await waitFor(() => {
@@ -136,5 +155,104 @@ describe('FunFacts Component', () => {
         })
 
         consoleSpy.mockRestore()
+    })
+
+    it('should show empty state when no data is available', async () => {
+        vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue([])
+        render(<FunFacts />)
+
+        await waitFor(() => {
+            expect(screen.getByText(EMPTY_MESSAGE)).toBeDefined()
+        })
+    })
+
+    it('should show error state when query fails', async () => {
+        vi.spyOn(query, 'queryDBAsJSON').mockRejectedValue(
+            new Error('DB error')
+        )
+        render(<FunFacts />)
+
+        await waitFor(() => {
+            expect(screen.getByText(ERROR_MESSAGE)).toBeDefined()
+        })
+    })
+
+    it('should have a refresh button in error state', async () => {
+        vi.spyOn(query, 'queryDBAsJSON').mockRejectedValue(
+            new Error('DB error')
+        )
+        render(<FunFacts />)
+
+        await waitFor(() => {
+            expect(screen.getByTitle('New fact')).toBeDefined()
+        })
+    })
+
+    it('should retry loading a fact after error when clicking refresh', async () => {
+        const spy = vi
+            .spyOn(query, 'queryDBAsJSON')
+            .mockRejectedValue(new Error('DB error'))
+        render(<FunFacts />)
+
+        await waitFor(() => {
+            expect(screen.getByText(ERROR_MESSAGE)).toBeDefined()
+        })
+
+        spy.mockResolvedValue([
+            {
+                fact_type: 'morning_favorite',
+                main_text: 'Test morning_favorite',
+                value: 1,
+                unit: 'streams',
+            },
+        ] as FunFactResult[])
+
+        fireEvent.click(screen.getByTitle('New fact'))
+
+        await waitFor(() => {
+            expect(screen.getByText('🌅 Musical Breakfast')).toBeDefined()
+        })
+    })
+
+    it('should handle cozy album with null main_text', async () => {
+        vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue([
+            {
+                fact_type: 'dummy_fact_type',
+                main_text: null,
+                second_text: 'This fun fact is unfortunately unavailable',
+                value: undefined,
+                context: 'feel like listening to an album today?',
+            },
+        ] as FunFactResult[])
+        render(<FunFacts />)
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('This fun fact is unfortunately unavailable')
+            ).toBeDefined()
+        })
+    })
+
+    it('should show cozy album title when rendering', async () => {
+        vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue([
+            {
+                fact_type: 'cozy_album',
+                main_text: 'Cozy Album',
+                second_text: 'Cozy Artist',
+                fact_value: 10,
+                unit: 'streams',
+                context:
+                    'the album that wraps your Sundays in musical coziness',
+            },
+        ] as FunFactResult[])
+        render(<FunFacts />)
+
+        await waitFor(() => {
+            expect(screen.getByText('💿 Cozy Album')).toBeDefined()
+        })
+        expect(screen.getByText('Cozy Album')).toBeDefined()
+        expect(
+            screen.getByText((content) => content.includes('10'))
+        ).toBeDefined()
     })
 })

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
@@ -4,11 +4,11 @@ export type FunFactProps = {
     fact_type: string
     title: string
     emoji: string
-    main_text: string
-    second_text?: string | undefined
-    value: string | number
-    unit?: string | undefined
-    context?: string | undefined
+    main_text: string | undefined
+    second_text?: string
+    value?: number | string
+    unit?: string
+    context?: string
 }
 
 type Props = {

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode } from 'react'
+import type { FC } from 'react'
 
 export type FunFactProps = {
     fact_type: string
@@ -18,70 +18,74 @@ type Props = {
     error: string | undefined
 }
 
-const LoadingSkeleton: FC = () => (
-    <div className="space-y-2 animate-pulse">
-        <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-3/4" />
-        <div className="h-3 bg-gray-200 dark:bg-slate-700 rounded w-full" />
-        <div className="h-3 bg-gray-200 dark:bg-slate-700 rounded w-5/6" />
-    </div>
+type ContentProps = {
+    fact: FunFactProps | undefined
+    error: string | undefined
+    isLoading: boolean
+}
+
+const EmptyFunFact: FC = () => (
+    <p className="text-lg text-gray-600 dark:text-gray-300 italic">
+        Not enough data for this fun fact — keep listening!
+    </p>
 )
-export const FunFacts: FC<Props> = ({ fact, error, onRefresh, isLoading }) => {
-    const config = fact
-        ? fact
-        : { fact_type: 'fallback_fact', title: '🎲 Fun Fact', emoji: '🎲' }
 
-    const renderContent = (): ReactNode => {
-        if (fact) {
-            const { main_text, second_text, value, unit, context } = fact
-            const valueDisplayed =
-                typeof value === 'number' ? value.toLocaleString() : value
-
-            return (
-                <>
-                    {main_text && (
-                        <div className="text-2xl md:text-4xl font-bold text-gray-900 dark:text-white mb-2 break-words text-balance">
-                            {main_text}
-                        </div>
-                    )}
-                    <div className="text-lg text-gray-600 dark:text-gray-300">
-                        {second_text}{' '}
-                        {second_text && valueDisplayed ? '(' : undefined}
-                        <span className="font-bold text-blue-600 dark:text-blue-400">
-                            {valueDisplayed}
-                            {unit === '%' ? unit : undefined}
-                        </span>{' '}
-                        {unit !== '%' ? unit : undefined}
-                        {second_text && valueDisplayed ? ')' : undefined}
-                    </div>
-                    {context && (
-                        <div className="text-sm text-gray-600 dark:text-gray-400 mt-1 italic">
-                            {context}
-                        </div>
-                    )}
-                </>
-            )
-        }
-
-        if (error) {
-            return (
-                <div className="text-lg text-gray-600 dark:text-gray-300">
-                    Something went wrong while loading fun facts
-                </div>
-            )
-        }
-
-        if (isLoading) {
-            return <LoadingSkeleton />
-        }
-
+const FunFactContent: FC<ContentProps> = ({ fact, error, isLoading }) => {
+    if (isLoading && !fact) {
         return (
-            <div className="text-lg text-gray-600 dark:text-gray-300">
-                Not enough listening data to generate fun facts — keep
-                streaming!
+            <div className="space-y-2 animate-pulse">
+                <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-3/4" />
+                <div className="h-3 bg-gray-200 dark:bg-slate-700 rounded w-full" />
+                <div className="h-3 bg-gray-200 dark:bg-slate-700 rounded w-5/6" />
             </div>
         )
     }
 
+    if (error) {
+        return (
+            <div className="text-lg text-gray-600 dark:text-gray-300">
+                Something went wrong while loading fun facts
+            </div>
+        )
+    }
+
+    // type guard — unreachable in practice: skeleton renders while fact is null
+    if (!fact) return <EmptyFunFact />
+
+    if (!(fact.main_text || fact.value !== undefined || fact.second_text)) {
+        return <EmptyFunFact />
+    }
+
+    const { main_text, second_text, value, unit, context } = fact
+    const valueDisplayed =
+        typeof value === 'number' ? value.toLocaleString() : value
+
+    return (
+        <>
+            {main_text && (
+                <div className="text-2xl md:text-4xl font-bold text-gray-900 dark:text-white mb-2 break-words text-balance">
+                    {main_text}
+                </div>
+            )}
+            <div className="text-lg text-gray-600 dark:text-gray-300">
+                {second_text} {second_text && valueDisplayed ? '(' : undefined}
+                <span className="font-bold text-blue-600 dark:text-blue-400">
+                    {valueDisplayed}
+                    {unit === '%' ? unit : undefined}
+                </span>{' '}
+                {unit !== '%' ? unit : undefined}
+                {second_text && valueDisplayed ? ')' : undefined}
+            </div>
+            {context && (
+                <div className="text-sm text-gray-600 dark:text-gray-400 mt-1 italic">
+                    {context}
+                </div>
+            )}
+        </>
+    )
+}
+
+export const FunFacts: FC<Props> = ({ fact, error, onRefresh, isLoading }) => {
     return (
         <div className="col-span-1 md:col-span-2 lg:col-span-3 p-6 bg-gradient-to-br from-purple-50 to-blue-50 dark:from-gray-900 dark:to-slate-900 rounded-2xl shadow border border-purple-100 dark:border-gray-700 relative overflow-hidden group transition-all duration-300 shadow-glass hover:shadow-glass-lg hover:scale-[1.01] animate-fade-in">
             <div className="absolute top-0 right-0 p-4 transition-opacity">
@@ -101,18 +105,22 @@ export const FunFacts: FC<Props> = ({ fact, error, onRefresh, isLoading }) => {
 
             <div
                 className="flex flex-col md:flex-row items-center gap-6"
-                data-fact-type={config.fact_type}
+                data-fact-type={fact?.fact_type}
             >
                 <div className="text-6xl md:text-8xl flex-shrink-0 animate-bounce-slow">
-                    {config.emoji}
+                    {fact?.emoji}
                 </div>
 
                 <div className="flex-1 text-center md:text-left">
                     <div className="text-sm font-bold text-purple-600 dark:text-purple-400 uppercase tracking-wider mb-2">
-                        {config.title}
+                        {fact?.title}
                     </div>
 
-                    {renderContent()}
+                    <FunFactContent
+                        fact={fact}
+                        error={error}
+                        isLoading={isLoading}
+                    />
                 </div>
             </div>
         </div>

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react'
+import type { FC, ReactNode } from 'react'
 
 export type FunFactProps = {
     fact_type: string
@@ -12,16 +12,76 @@ export type FunFactProps = {
 }
 
 type Props = {
-    fact: FunFactProps
+    fact: FunFactProps | undefined
     onRefresh: () => void
     isLoading: boolean
+    error: string | undefined
+    isEmpty: boolean
 }
 
-export const FunFacts: FC<Props> = ({ fact, onRefresh, isLoading }) => {
-    const valueDisplayed =
-        typeof fact.value === 'number'
-            ? fact.value.toLocaleString()
-            : fact.value
+const LoadingSkeleton: FC = () => (
+    <div className="space-y-2 animate-pulse">
+        <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-3/4" />
+        <div className="h-3 bg-gray-200 dark:bg-slate-700 rounded w-full" />
+        <div className="h-3 bg-gray-200 dark:bg-slate-700 rounded w-5/6" />
+    </div>
+)
+export const FunFacts: FC<Props> = ({ fact, error, onRefresh, isLoading }) => {
+    const config = fact
+        ? fact
+        : { fact_type: 'fallback_fact', title: '🎲 Fun Fact', emoji: '🎲' }
+
+    const renderContent = (): ReactNode => {
+        if (fact) {
+            const { main_text, second_text, value, unit, context } = fact
+            const valueDisplayed =
+                typeof value === 'number' ? value.toLocaleString() : value
+
+            return (
+                <>
+                    {main_text && (
+                        <div className="text-2xl md:text-4xl font-bold text-gray-900 dark:text-white mb-2 break-words text-balance">
+                            {main_text}
+                        </div>
+                    )}
+                    <div className="text-lg text-gray-600 dark:text-gray-300">
+                        {second_text}{' '}
+                        {second_text && valueDisplayed ? '(' : undefined}
+                        <span className="font-bold text-blue-600 dark:text-blue-400">
+                            {valueDisplayed}
+                            {unit === '%' ? unit : undefined}
+                        </span>{' '}
+                        {unit !== '%' ? unit : undefined}
+                        {second_text && valueDisplayed ? ')' : undefined}
+                    </div>
+                    {context && (
+                        <div className="text-sm text-gray-600 dark:text-gray-400 mt-1 italic">
+                            {context}
+                        </div>
+                    )}
+                </>
+            )
+        }
+
+        if (error) {
+            return (
+                <div className="text-lg text-gray-600 dark:text-gray-300">
+                    Something went wrong while loading fun facts
+                </div>
+            )
+        }
+
+        if (isLoading) {
+            return <LoadingSkeleton />
+        }
+
+        return (
+            <div className="text-lg text-gray-600 dark:text-gray-300">
+                Not enough listening data to generate fun facts — keep
+                streaming!
+            </div>
+        )
+    }
 
     return (
         <div className="col-span-1 md:col-span-2 lg:col-span-3 p-6 bg-gradient-to-br from-purple-50 to-blue-50 dark:from-gray-900 dark:to-slate-900 rounded-2xl shadow border border-purple-100 dark:border-gray-700 relative overflow-hidden group transition-all duration-300 shadow-glass hover:shadow-glass-lg hover:scale-[1.01] animate-fade-in">
@@ -42,37 +102,18 @@ export const FunFacts: FC<Props> = ({ fact, onRefresh, isLoading }) => {
 
             <div
                 className="flex flex-col md:flex-row items-center gap-6"
-                data-fact-type={fact.fact_type}
+                data-fact-type={config.fact_type}
             >
                 <div className="text-6xl md:text-8xl flex-shrink-0 animate-bounce-slow">
-                    {fact.emoji}
+                    {config.emoji}
                 </div>
 
                 <div className="flex-1 text-center md:text-left">
                     <div className="text-sm font-bold text-purple-600 dark:text-purple-400 uppercase tracking-wider mb-2">
-                        {fact.title}
+                        {config.title}
                     </div>
 
-                    <div className="text-2xl md:text-4xl font-bold text-gray-900 dark:text-white mb-2 break-words text-balance">
-                        {fact.main_text}
-                    </div>
-
-                    <div className="text-lg text-gray-600 dark:text-gray-300">
-                        {fact.second_text}{' '}
-                        {fact.second_text && valueDisplayed ? '(' : undefined}
-                        <span className="font-bold text-blue-600 dark:text-blue-400">
-                            {valueDisplayed}
-                            {fact.unit === '%' ? fact.unit : undefined}
-                        </span>{' '}
-                        {fact.unit !== '%' ? fact.unit : undefined}
-                        {fact.second_text && valueDisplayed ? ')' : undefined}
-                    </div>
-
-                    {fact.context && (
-                        <div className="text-sm text-gray-600 dark:text-gray-400 mt-1 italic">
-                            {fact.context}
-                        </div>
-                    )}
+                    {renderContent()}
                 </div>
             </div>
         </div>

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
@@ -16,7 +16,6 @@ type Props = {
     onRefresh: () => void
     isLoading: boolean
     error: string | undefined
-    isEmpty: boolean
 }
 
 const LoadingSkeleton: FC = () => (

--- a/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
@@ -13,13 +13,11 @@ export function FunFacts() {
     const [fact, setFact] = useState<FunFactProps | undefined>(undefined)
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState<string | undefined>(undefined)
-    const [isEmpty, setIsEmpty] = useState(false)
     const seenFactsRef = useRef<Set<string>>(new Set())
 
     const loadRandomFact = useCallback(async () => {
         setIsLoading(true)
         setError(undefined)
-        setIsEmpty(false)
         try {
             if (seenFactsRef.current.size === facts.length) {
                 seenFactsRef.current.clear()
@@ -60,7 +58,6 @@ export function FunFacts() {
 
             if (!found) {
                 setFact(undefined)
-                setIsEmpty(true)
             }
         } catch (error) {
             console.error('Error loading fun fact:', error)
@@ -95,7 +92,6 @@ export function FunFacts() {
             onRefresh={loadRandomFact}
             isLoading={isLoading}
             error={error}
-            isEmpty={isEmpty}
         />
     )
 }

--- a/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
@@ -27,41 +27,27 @@ export function FunFacts() {
                 (fact) => !seenFactsRef.current.has(fact.fact_type)
             )
 
-            let found = false
-
             const candidates = unseenFacts.length > 0 ? unseenFacts : facts
 
-            const shuffled = shuffle(candidates)
+            const [factDefinition] = shuffle(candidates)
 
-            for (const factDefinition of shuffled) {
-                const [result] = await queryDBAsJSON<FunFactResult>(
-                    factDefinition.sql
-                )
+            seenFactsRef.current.add(factDefinition.fact_type)
 
-                seenFactsRef.current.add(factDefinition.fact_type)
-                if (result) {
-                    const { fact_value, ...rest } = result
-                    setFact({
-                        title: factDefinition.title,
-                        emoji: factDefinition.emoji,
-                        ...rest,
-                        value: fact_value,
-                    })
-                    found = true
-                    break
-                }
-                console.warn(
-                    'An empty result is returned by a fun fact:',
-                    factDefinition.fact_type
-                )
-            }
-
-            if (!found) {
-                setFact(undefined)
-            }
+            const [result] = await queryDBAsJSON<FunFactResult>(
+                factDefinition.sql
+            )
+            setFact({
+                title: factDefinition.title,
+                emoji: factDefinition.emoji,
+                fact_type: factDefinition.fact_type,
+                main_text: result?.main_text ?? undefined,
+                second_text: result?.second_text,
+                value: result?.fact_value,
+                unit: result?.unit,
+                context: result?.context,
+            })
         } catch (error) {
             console.error('Error loading fun fact:', error)
-            setFact(undefined)
             setError(
                 error instanceof Error
                     ? error.message

--- a/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
@@ -10,12 +10,16 @@ const shuffle = <T,>(array: readonly T[]): T[] => {
 }
 
 export function FunFacts() {
-    const [fact, setFact] = useState<FunFactProps | null>(null)
-    const [isLoading, setIsLoading] = useState(false)
+    const [fact, setFact] = useState<FunFactProps | undefined>(undefined)
+    const [isLoading, setIsLoading] = useState(true)
+    const [error, setError] = useState<string | undefined>(undefined)
+    const [isEmpty, setIsEmpty] = useState(false)
     const seenFactsRef = useRef<Set<string>>(new Set())
 
     const loadRandomFact = useCallback(async () => {
         setIsLoading(true)
+        setError(undefined)
+        setIsEmpty(false)
         try {
             if (seenFactsRef.current.size === facts.length) {
                 seenFactsRef.current.clear()
@@ -24,6 +28,8 @@ export function FunFacts() {
             const unseenFacts = facts.filter(
                 (fact) => !seenFactsRef.current.has(fact.fact_type)
             )
+
+            let found = false
 
             const candidates = unseenFacts.length > 0 ? unseenFacts : facts
 
@@ -43,6 +49,7 @@ export function FunFacts() {
                         ...rest,
                         value: fact_value,
                     })
+                    found = true
                     break
                 }
                 console.warn(
@@ -50,8 +57,19 @@ export function FunFacts() {
                     factDefinition.fact_type
                 )
             }
+
+            if (!found) {
+                setFact(undefined)
+                setIsEmpty(true)
+            }
         } catch (error) {
             console.error('Error loading fun fact:', error)
+            setFact(undefined)
+            setError(
+                error instanceof Error
+                    ? error.message
+                    : 'Failed to load fun fact'
+            )
         } finally {
             setIsLoading(false)
         }
@@ -71,13 +89,13 @@ export function FunFacts() {
             window.removeEventListener(DATA_LOADED_EVENT, handleDataLoaded)
     }, [loadRandomFact])
 
-    if (!fact) return null
-
     return (
         <FunFactsView
             fact={fact}
             onRefresh={loadRandomFact}
             isLoading={isLoading}
+            error={error}
+            isEmpty={isEmpty}
         />
     )
 }

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
@@ -622,20 +622,10 @@ describe('FunFacts queries', () => {
               { artist_name: 'artist1', album_name: 'album1', track_name: 't3', ts: RECENT_SUNDAY },
             ]
 
-            it('returns error message if no album satisfies the rules', async () => {
+            it('returns empty result if no album satisfies the rules', async () => {
                 await createTestTable(conn, testData)
                 const rows = await testQuery(conn, getFact('cozy_album').sql)
-                expect(rows.length).toBe(1)
-                expect(rows[0].fact_type).toBe('cozy_album')
-                expect(rows[0].main_text).toBeNull()
-                expect(rows[0].second_text).toBe(
-                    'This fun fact is unfortunately unavailable'
-                )
-                expect(rows[0].fact_value).toBeUndefined()
-                expect(rows[0].unit).toBeUndefined()
-                expect(rows[0].context).toBe(
-                    'feel like listening to an album today?'
-                )
+                expect(rows.length).toBe(0)
             })
         })
     })

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.tsx
@@ -22,9 +22,9 @@ import sqlQueryCozyAlbum from './CozyAlbum.sql?raw'
 
 export type FunFactResult = {
     fact_type: string
-    main_text: string
+    main_text: string | undefined
     second_text?: string
-    fact_value: number | string
+    fact_value?: number | string
     unit?: string
     context?: string
 }

--- a/app/src/db/queries/queryDB.ts
+++ b/app/src/db/queries/queryDB.ts
@@ -1,7 +1,7 @@
 import { getDB } from '../getDB'
 
 export async function queryDBAsJSON<
-    T extends Record<string, string | number | null>,
+    T extends Record<string, string | number | null | undefined>,
 >(query: string): Promise<T[]> {
     const { conn } = await getDB()
     const table = await conn.query(query)


### PR DESCRIPTION
Fun fact cards now remain visible at all times, providing feedback even when data is unavailable or something goes wrong.

- When no fun fact can be generated from the available listening data, a message invites users to keep streaming so facts can appear
- When a query fails, an error message is displayed and users can click the refresh button to try loading a different fact
- While facts are loading, a skeleton placeholder is shown so the layout stays stable
- The Cozy Album fun fact with a null result is rendered correctly in the UI instead of leaving an empty area