### PR TITLE
refactor(funfacts): replace one-liner query functions with query record

### DIFF
--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
@@ -5,6 +5,7 @@ import { FunFacts } from '.'
 import * as query from '../../../../db/queries/queryDB'
 import * as db from '../../../../db/getDB'
 import { DATA_LOADED_EVENT } from '../../../../db/dataSignal'
+import { FunFactResult } from './queries'
 
 const allFactTitles = [
     '🌅 Musical Breakfast',
@@ -133,5 +134,26 @@ describe('FunFacts Component', () => {
         const secondFact = container.textContent
 
         expect(secondFact).not.toBe(firstFact)
+    })
+
+    it('logs error when loading fun fact fails', async () => {
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+
+        vi.spyOn(query, 'queryDBAsJSON').mockRejectedValue(
+            new Error('DB failure')
+        )
+
+        render(<FunFacts />)
+
+        await waitFor(() => {
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Error loading fun fact:',
+                expect.any(Error)
+            )
+        })
+
+        consoleSpy.mockRestore()
     })
 })

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, vi, expect, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
 import { FunFacts } from '.'
+import { factConfig } from './FunFacts'
 
 import * as query from '../../../../db/queries/queryDB'
 import * as db from '../../../../db/getDB'
 import { DATA_LOADED_EVENT } from '../../../../db/dataSignal'
-import { FunFactResult, queryDefinitions } from './queries'
+import { FunFactResult, queryDefinitions, queries } from './queries'
 
 describe('FunFacts Component', () => {
     beforeEach(() => {
@@ -132,5 +133,30 @@ describe('FunFacts Component', () => {
         })
 
         consoleSpy.mockRestore()
+    })
+
+    describe('factConfig coherence', () => {
+        function extractFactType(sql: string): string | null {
+            const match = sql.match(/'([a-z_]+)'\s+as\s+fact_type/)
+            return match?.[1] ?? null
+        }
+
+        it('should ensure default exists in factConfig', () => {
+            expect(factConfig('non_existent_fun_fact')).toBeDefined()
+        })
+
+        it('should know all the fact types used', () => {
+            const usedTypes = Object.values(queries).map(
+                extractFactType
+            ) as string[]
+
+            const defaultType = factConfig('non_existent_fun_fact')
+
+            const knownTypes = usedTypes
+                .map(factConfig)
+                .filter((q) => q.title != defaultType.title)
+
+            expect(knownTypes.length).toBe(usedTypes.length)
+        })
     })
 })

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
@@ -5,53 +5,26 @@ import { FunFacts } from '.'
 import * as query from '../../../../db/queries/queryDB'
 import * as db from '../../../../db/getDB'
 import { DATA_LOADED_EVENT } from '../../../../db/dataSignal'
-import { FunFactResult } from './queries'
-
-const allFactTitles = [
-    '🌅 Musical Breakfast',
-    '☀️ Afternoon Boost',
-    '🌆 Calm Return',
-    '🌙 Musical Insomnia',
-    '🌙 Night Champion',
-    '🎉 Weekend Vibes',
-    '⏰ Peak Hour',
-    '📅 Favorite Day',
-    '❤️ Absolute Loyalty',
-    '🎸 Monthly Subscription',
-    '🕰️ Nostalgic Return',
-    '🕰️ Forgotten Artist',
-    '🎧 Binge Listener',
-    '🔥 Unbeatable Streak',
-    '🌈 Variety Day',
-    '⭐ One-Hit Wonder',
-    '🏃 Marathon',
-    '🎵 Recent Discovery',
-    '🔁 Current Obsession',
-    '🎉 Musical Anniversary',
-    '🦖 The Very First',
-    '🔮 Listening Proposition',
-    '🫂 Most Comforting Album',
-    '🎲 Fun Fact',
-]
+import { FunFactResult, queryDefinitions } from './queries'
 
 describe('FunFacts Component', () => {
     beforeEach(() => {
         vi.clearAllMocks()
 
-        vi.spyOn(query, 'queryDBAsJSON').mockImplementation(
-            async (sql: string) => {
-                const match = sql.match(/'([a-z_]+)'\s+as\s+fact_type/)
-                if (!match) return []
-                return [
-                    {
-                        fact_type: match[1],
-                        main_text: `Test ${match[1]}`,
-                        value: 1,
-                        unit: 'streams',
-                    },
-                ] as FunFactResult[]
-            }
-        )
+        let i = 0
+
+        vi.spyOn(query, 'queryDBAsJSON').mockImplementation(async (_sql) => {
+            void _sql
+            const queryName = queryDefinitions[i % queryDefinitions.length].name
+            i++
+            return [
+                {
+                    fact_type: 'dummy_fact',
+                    main_text: queryName,
+                    value: 1,
+                },
+            ] as FunFactResult[]
+        })
 
         vi.spyOn(db, 'getDB').mockResolvedValue({
             db: vi.fn(),
@@ -62,30 +35,21 @@ describe('FunFacts Component', () => {
     it('should render a fun fact', async () => {
         render(<FunFacts />)
 
-        await waitFor(
-            () => {
-                const hasTitle = allFactTitles.some((title) => {
-                    try {
-                        screen.getByText(title)
-                        return true
-                    } catch {
-                        return false
-                    }
-                })
-                expect(hasTitle).toBe(true)
-            },
-            { timeout: 3000 }
-        )
+        await waitFor(() => {
+            const hasAnyTitle = queryDefinitions.some((q) =>
+                screen.queryByText(q.name)
+            )
+            expect(hasAnyTitle).toBe(true)
+        })
 
-        expect(query.queryDBAsJSON).toHaveBeenCalledWith(expect.any(String))
+        expect(query.queryDBAsJSON).toHaveBeenCalled()
     })
 
     it('should have a refresh button', async () => {
         render(<FunFacts />)
 
         await waitFor(() => {
-            const button = screen.getByTitle('New fact')
-            expect(button).toBeDefined()
+            expect(screen.getByTitle('New fact')).toBeDefined()
         })
     })
 
@@ -97,43 +61,56 @@ describe('FunFacts Component', () => {
             expect(container.textContent).toBeTruthy()
         })
 
-        const firstFact = container.textContent
-        const callCountAfterMount = querySpy.mock.calls.length
+        const first = container.textContent
+        const calls = querySpy.mock.calls.length
 
         act(() => {
             window.dispatchEvent(new CustomEvent(DATA_LOADED_EVENT))
         })
 
         await waitFor(() => {
-            expect(querySpy.mock.calls.length).toBeGreaterThan(
-                callCountAfterMount
-            )
+            expect(querySpy.mock.calls.length).toBeGreaterThan(calls)
         })
 
-        expect(container.textContent).not.toBe(firstFact)
+        expect(container.textContent).not.toBe(first)
     })
 
-    it('should refresh to a different fact when clicking refresh', async () => {
+    it('refreshes fact when clicking button', async () => {
         const { container } = render(<FunFacts />)
 
         await waitFor(() => {
-            expect(container.textContent).toBeTruthy()
+            expect(screen.getByTitle('New fact')).toBeDefined()
         })
 
-        const firstFact = container.textContent
+        const first = container.textContent
 
         fireEvent.click(screen.getByTitle('New fact'))
 
-        await waitFor(
-            () => {
-                expect(container.textContent).not.toBe(firstFact)
-            },
-            { timeout: 2000 }
-        )
+        await waitFor(() => {
+            expect(container.textContent).not.toBe(first)
+        })
+    })
 
-        const secondFact = container.textContent
+    it('repeats facts after full cycle reset', async () => {
+        const seen = new Set<string>()
 
-        expect(secondFact).not.toBe(firstFact)
+        render(<FunFacts />)
+
+        await waitFor(() => {
+            expect(screen.getByTitle('New fact')).toBeDefined()
+        })
+
+        const button = screen.getByTitle('New fact')
+
+        for (let i = 0; i < queryDefinitions.length * 2; i++) {
+            fireEvent.click(button)
+
+            await waitFor(() => {
+                seen.add(document.body.textContent ?? '')
+            })
+        }
+
+        expect(seen.size).toBe(queryDefinitions.length)
     })
 
     it('logs error when loading fun fact fails', async () => {

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
@@ -4,7 +4,6 @@ import { FunFacts } from '.'
 
 import * as query from '../../../../db/queries/queryDB'
 import * as db from '../../../../db/getDB'
-import { FunFactResult } from './queries'
 import { DATA_LOADED_EVENT } from '../../../../db/dataSignal'
 
 const allFactTitles = [
@@ -36,6 +35,8 @@ const allFactTitles = [
 
 describe('FunFacts Component', () => {
     beforeEach(() => {
+        vi.clearAllMocks()
+
         vi.spyOn(query, 'queryDBAsJSON').mockImplementation(
             async (sql: string) => {
                 const match = sql.match(/'([a-z_]+)'\s+as\s+fact_type/)
@@ -74,6 +75,8 @@ describe('FunFacts Component', () => {
             },
             { timeout: 3000 }
         )
+
+        expect(query.queryDBAsJSON).toHaveBeenCalledWith(expect.any(String))
     })
 
     it('should have a refresh button', async () => {

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
@@ -18,14 +18,8 @@ export const factConfig = (type: string) => {
             return { title: '🌆 Calm Return', emoji: '🛋️' }
         case 'night_favorite':
             return { title: '🌙 Musical Insomnia', emoji: '💤' }
-        case 'night_champion':
-            return { title: '🌙 Night Champion', emoji: '🏅' }
         case 'weekend_favorite':
             return { title: '🎉 Weekend Vibes', emoji: '🕺' }
-
-        // Habits
-        case 'favorite_weekday':
-            return { title: '📅 Favorite Day', emoji: '📅' }
 
         // Loyalty
         case 'absolute_loyalty':

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
@@ -7,7 +7,7 @@ type Props = {
     isLoading: boolean
 }
 
-const factConfig = (type: string) => {
+export const factConfig = (type: string) => {
     switch (type) {
         // Moments
         case 'morning_favorite':

--- a/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { QUERY_FUNCTIONS, type FunFactResult } from './queries'
+import { queryDefinitions, type FunFactResult } from './queries'
 import { queryDBAsJSON } from '../../../../db/queries/queryDB'
 import { DATA_LOADED_EVENT } from '../../../../db/dataSignal'
 import { FunFacts as FunFactsView } from './FunFacts'
@@ -12,32 +12,32 @@ export function FunFacts() {
     const loadRandomFact = useCallback(async () => {
         setIsLoading(true)
         try {
-            if (seenFactsRef.current.size === QUERY_FUNCTIONS.length) {
+            if (seenFactsRef.current.size === queryDefinitions.length) {
                 seenFactsRef.current.clear()
             }
 
-            const unseenQueries = QUERY_FUNCTIONS.filter(
+            const unseenQueries = queryDefinitions.filter(
                 (q) => !seenFactsRef.current.has(q.name)
             )
             const availableQueries =
-                unseenQueries.length > 0 ? unseenQueries : QUERY_FUNCTIONS
+                unseenQueries.length > 0 ? unseenQueries : queryDefinitions
 
             const shuffled = [...availableQueries].sort(
                 () => Math.random() - 0.5
             )
 
-            for (const queryFn of shuffled) {
+            for (const queryDef of shuffled) {
                 const [result] =
-                    (await queryDBAsJSON<FunFactResult>(queryFn())) || []
+                    (await queryDBAsJSON<FunFactResult>(queryDef.sql)) || []
 
-                seenFactsRef.current.add(queryFn.name)
+                seenFactsRef.current.add(queryDef.name)
                 if (result) {
                     setFact(result)
                     break
                 }
                 console.warn(
                     'An empty result is returned by a fun fact:',
-                    queryFn.name
+                    queryDef.name
                 )
             }
         } catch (error) {

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
@@ -36,54 +36,18 @@ describe('FunFacts queries', () => {
 
     describe('Favorite artist queries', () => {
         const testData: TestStreamEntry[] = [
-            {
-                ts: '2024-02-07T06:00:00',
-                artist_name: 'top_morning_artist',
-            },
-            {
-                ts: '2024-02-07T07:00:00',
-                artist_name: 'top_morning_artist',
-            },
-            {
-                ts: '2024-02-07T08:00:00',
-                artist_name: 'morning_artist',
-            },
-            {
-                ts: '2024-02-07T12:00:00',
-                artist_name: 'top_afternoon_artist',
-            },
-            {
-                ts: '2024-02-07T13:00:00',
-                artist_name: 'afternoon_artist',
-            },
-            {
-                ts: '2024-02-07T14:00:00',
-                artist_name: 'top_afternoon_artist',
-            },
-            {
-                ts: '2024-02-07T18:00:00',
-                artist_name: 'evening_artist',
-            },
-            {
-                ts: '2024-02-07T19:00:00',
-                artist_name: 'top_evening_artist',
-            },
-            {
-                ts: '2024-02-07T20:00:00',
-                artist_name: 'top_evening_artist',
-            },
-            {
-                ts: '2024-02-07T00:00:00',
-                artist_name: 'top_night_artist',
-            },
-            {
-                ts: '2024-02-07T01:00:00',
-                artist_name: 'night_artist',
-            },
-            {
-                ts: '2024-02-07T02:00:00',
-                artist_name: 'top_night_artist',
-            },
+            { ts: '2024-02-07T06:00:00', artist_name: 'top_morning_artist' },
+            { ts: '2024-02-07T07:00:00', artist_name: 'top_morning_artist' },
+            { ts: '2024-02-07T08:00:00', artist_name: 'morning_artist' },
+            { ts: '2024-02-07T12:00:00', artist_name: 'top_afternoon_artist' },
+            { ts: '2024-02-07T13:00:00', artist_name: 'afternoon_artist' },
+            { ts: '2024-02-07T14:00:00', artist_name: 'top_afternoon_artist' },
+            { ts: '2024-02-07T18:00:00', artist_name: 'evening_artist' },
+            { ts: '2024-02-07T19:00:00', artist_name: 'top_evening_artist' },
+            { ts: '2024-02-07T20:00:00', artist_name: 'top_evening_artist' },
+            { ts: '2024-02-07T00:00:00', artist_name: 'top_night_artist' },
+            { ts: '2024-02-07T01:00:00', artist_name: 'night_artist' },
+            { ts: '2024-02-07T02:00:00', artist_name: 'top_night_artist' },
         ]
 
         beforeEach(async () => {
@@ -139,26 +103,11 @@ describe('FunFacts queries', () => {
 
     describe('Marathon queries', () => {
         const testData: TestStreamEntry[] = [
-            {
-                ts: '2024-01-01',
-                artist_name: 'consecutive_stream_artist',
-            },
-            {
-                ts: '2024-01-02',
-                artist_name: 'consecutive_stream_artist',
-            },
-            {
-                ts: '2024-01-03',
-                artist_name: 'consecutive_stream_artist',
-            },
-            {
-                ts: '2024-01-04',
-                artist_name: 'middle_stream_artist',
-            },
-            {
-                ts: '2024-01-05',
-                artist_name: 'consecutive_stream_artist',
-            },
+            { ts: '2024-01-01', artist_name: 'consecutive_stream_artist' },
+            { ts: '2024-01-02', artist_name: 'consecutive_stream_artist' },
+            { ts: '2024-01-03', artist_name: 'consecutive_stream_artist' },
+            { ts: '2024-01-04', artist_name: 'middle_stream_artist' },
+            { ts: '2024-01-05', artist_name: 'consecutive_stream_artist' },
         ]
 
         beforeEach(async () => {
@@ -179,10 +128,7 @@ describe('FunFacts queries', () => {
 
     describe('One hit wonder queries', () => {
         const testData: TestStreamEntry[] = [
-            {
-                artist_name: 'one_hit_wonder_artist',
-                track_name: 'hit_track',
-            },
+            { artist_name: 'one_hit_wonder_artist', track_name: 'hit_track' },
         ]
 
         beforeEach(async () => {
@@ -206,31 +152,13 @@ describe('FunFacts queries', () => {
     describe('Weekend favorite queries', () => {
         const testData: TestStreamEntry[] = [
             // Week
-            {
-                ts: '2025-12-01',
-                artist_name: 'week_artist',
-            },
-            {
-                ts: '2025-12-02',
-                artist_name: 'week_artist',
-            },
-            {
-                ts: '2025-12-03',
-                artist_name: 'weekend_artist',
-            },
-            // Week-end
-            {
-                ts: '2025-12-07',
-                artist_name: 'week_artist',
-            },
-            {
-                ts: '2025-12-07',
-                artist_name: 'weekend_artist',
-            },
-            {
-                ts: '2025-12-07',
-                artist_name: 'weekend_artist',
-            },
+            { ts: '2025-12-01', artist_name: 'week_artist' },
+            { ts: '2025-12-02', artist_name: 'week_artist' },
+            { ts: '2025-12-03', artist_name: 'weekend_artist' },
+            // Weekend
+            { ts: '2025-12-07', artist_name: 'week_artist' },
+            { ts: '2025-12-07', artist_name: 'weekend_artist' },
+            { ts: '2025-12-07', artist_name: 'weekend_artist' },
         ]
 
         beforeEach(async () => {
@@ -251,38 +179,14 @@ describe('FunFacts queries', () => {
 
     describe('Absolute loyalty queries', () => {
         const testData: TestStreamEntry[] = [
-            {
-                artist_name: 'loyal_artist',
-                reason_end: 'trackdone',
-            },
-            {
-                artist_name: 'loyal_artist',
-                reason_end: 'trackdone',
-            },
-            {
-                artist_name: 'loyal_artist',
-                reason_end: 'trackdone',
-            },
-            {
-                artist_name: 'loyal_artist',
-                reason_end: 'clickrow',
-            },
-            {
-                artist_name: 'artist1',
-                reason_end: 'fwdbtn',
-            },
-            {
-                artist_name: 'artist1',
-                reason_end: 'trackdone',
-            },
-            {
-                artist_name: 'artist1',
-                reason_end: 'trackdone',
-            },
-            {
-                artist_name: 'artist1',
-                reason_end: 'clickrow',
-            },
+            { artist_name: 'loyal_artist', reason_end: 'trackdone' },
+            { artist_name: 'loyal_artist', reason_end: 'trackdone' },
+            { artist_name: 'loyal_artist', reason_end: 'trackdone' },
+            { artist_name: 'loyal_artist', reason_end: 'clickrow' },
+            { artist_name: 'artist1', reason_end: 'fwdbtn' },
+            { artist_name: 'artist1', reason_end: 'trackdone' },
+            { artist_name: 'artist1', reason_end: 'trackdone' },
+            { artist_name: 'artist1', reason_end: 'clickrow' },
         ]
 
         beforeEach(async () => {
@@ -303,26 +207,11 @@ describe('FunFacts queries', () => {
 
     describe('Nostalgic return queries', () => {
         const testData: TestStreamEntry[] = [
-            {
-                ts: '2024-01-01',
-                artist_name: 'nostalgic_artist',
-            },
-            {
-                ts: '2024-01-01',
-                artist_name: 'nostalgic_artist',
-            },
-            {
-                ts: '2025-01-01',
-                artist_name: 'nostalgic_artist',
-            },
-            {
-                ts: '2025-01-01',
-                artist_name: 'artist1',
-            },
-            {
-                ts: '2025-01-01',
-                artist_name: 'artist2',
-            },
+            { ts: '2024-01-01', artist_name: 'nostalgic_artist' },
+            { ts: '2024-01-01', artist_name: 'nostalgic_artist' },
+            { ts: '2025-01-01', artist_name: 'nostalgic_artist' },
+            { ts: '2025-01-01', artist_name: 'artist1' },
+            { ts: '2025-01-01', artist_name: 'artist2' },
         ]
 
         beforeEach(async () => {
@@ -393,39 +282,16 @@ describe('FunFacts queries', () => {
     })
 
     describe('Current obsession queries', () => {
+        // prettier-ignore
         const testData: TestStreamEntry[] = [
             // Recent streams
-            {
-                ts: '2025-01-01',
-                artist_name: 'artist1',
-                track_name: 'current_hit',
-            },
-            {
-                ts: '2025-01-01',
-                artist_name: 'artist1',
-                track_name: 'current_hit',
-            },
-            {
-                ts: '2025-01-01',
-                artist_name: 'artist1',
-                track_name: 'track1',
-            },
+            { ts: '2025-01-01', artist_name: 'artist1', track_name: 'current_hit' },
+            { ts: '2025-01-01', artist_name: 'artist1', track_name: 'current_hit' },
+            { ts: '2025-01-01', artist_name: 'artist1', track_name: 'track1' },
             // Old streams
-            {
-                ts: '2024-01-01',
-                artist_name: 'artist1',
-                track_name: 'track1',
-            },
-            {
-                ts: '2024-01-01',
-                artist_name: 'artist1',
-                track_name: 'track1',
-            },
-            {
-                ts: '2024-01-01',
-                artist_name: 'artist1',
-                track_name: 'current_hit',
-            },
+            { ts: '2024-01-01', artist_name: 'artist1', track_name: 'track1' },
+            { ts: '2024-01-01', artist_name: 'artist1', track_name: 'track1' },
+            { ts: '2024-01-01', artist_name: 'artist1', track_name: 'current_hit' },
         ]
 
         beforeEach(async () => {
@@ -447,23 +313,11 @@ describe('FunFacts queries', () => {
     describe('Recent discovery queries', () => {
         const testData: TestStreamEntry[] = [
             // Recent streams
-            {
-                ts: '2025-01-01',
-                artist_name: 'recent_discovery_artist',
-            },
-            {
-                ts: '2025-01-01',
-                artist_name: 'already_discovered_artist',
-            },
-            {
-                ts: '2025-01-01',
-                artist_name: 'already_discovered_artist',
-            },
+            { ts: '2025-01-01', artist_name: 'recent_discovery_artist' },
+            { ts: '2025-01-01', artist_name: 'already_discovered_artist' },
+            { ts: '2025-01-01', artist_name: 'already_discovered_artist' },
             // Old streams
-            {
-                ts: '2024-01-01',
-                artist_name: 'already_discovered_artist',
-            },
+            { ts: '2024-01-01', artist_name: 'already_discovered_artist' },
         ]
 
         beforeEach(async () => {
@@ -484,18 +338,9 @@ describe('FunFacts queries', () => {
 
     describe('Subscribed artist queries', () => {
         const testData: TestStreamEntry[] = [
-            {
-                ts: '2024-01-01',
-                artist_name: 'subscribed_artist',
-            },
-            {
-                ts: '2024-02-01',
-                artist_name: 'subscribed_artist',
-            },
-            {
-                ts: '2024-03-01',
-                artist_name: 'subscribed_artist',
-            },
+            { ts: '2024-01-01', artist_name: 'subscribed_artist' },
+            { ts: '2024-02-01', artist_name: 'subscribed_artist' },
+            { ts: '2024-03-01', artist_name: 'subscribed_artist' },
             { ts: '2024-04-01', artist_name: 'artist1' },
             { ts: '2024-05-01', artist_name: 'artist1' },
             { ts: '2024-05-02', artist_name: 'artist1' },
@@ -520,22 +365,10 @@ describe('FunFacts queries', () => {
 
     describe('Old artist queries', () => {
         const testData: TestStreamEntry[] = [
-            {
-                ts: '2006-01-01',
-                artist_name: 'first_artist',
-            },
-            {
-                ts: '2008-01-01',
-                artist_name: 'second_artist',
-            },
-            {
-                ts: '2018-01-01',
-                artist_name: 'second_artist',
-            },
-            {
-                ts: '2024-01-01',
-                artist_name: 'first_artist',
-            },
+            { ts: '2006-01-01', artist_name: 'first_artist' },
+            { ts: '2008-01-01', artist_name: 'second_artist' },
+            { ts: '2018-01-01', artist_name: 'second_artist' },
+            { ts: '2024-01-01', artist_name: 'first_artist' },
         ]
 
         beforeEach(async () => {
@@ -596,27 +429,12 @@ describe('FunFacts queries', () => {
     describe('Forgotten artist queries', () => {
         const testData: TestStreamEntry[] = [
             // Old streams
-            {
-                ts: '2024-01-01',
-                artist_name: 'forgotten_artist',
-            },
-            {
-                ts: '2024-01-01',
-                artist_name: 'old_artist',
-            },
+            { ts: '2024-01-01', artist_name: 'forgotten_artist' },
+            { ts: '2024-01-01', artist_name: 'old_artist' },
             // Recent streams
-            {
-                ts: '2025-01-01',
-                artist_name: 'old_artist',
-            },
-            {
-                ts: '2025-01-01',
-                artist_name: 'new_artist',
-            },
-            {
-                ts: '2025-01-01',
-                artist_name: 'new_artist',
-            },
+            { ts: '2025-01-01', artist_name: 'old_artist' },
+            { ts: '2025-01-01', artist_name: 'new_artist' },
+            { ts: '2025-01-01', artist_name: 'new_artist' },
         ]
 
         beforeEach(async () => {
@@ -639,14 +457,8 @@ describe('FunFacts queries', () => {
 
     describe('Track proposition queries', () => {
         const testData: TestStreamEntry[] = [
-            {
-                artist_name: 'artist1',
-                track_name: 'track1',
-            },
-            {
-                artist_name: 'artist2',
-                track_name: 'track2',
-            },
+            { artist_name: 'artist1', track_name: 'track1' },
+            { artist_name: 'artist2', track_name: 'track2' },
         ]
 
         beforeEach(async () => {
@@ -684,7 +496,7 @@ describe('FunFacts queries', () => {
                 { artist_name: 'artist1', track_name: 'track5', album_name: 'album1', ts: RECENT_SUNDAY },
                 { artist_name: 'artist1', track_name: 'track6', album_name: 'album1', ts: RECENT_SUNDAY },
                 { artist_name: 'artist1', track_name: 'track7', album_name: 'album1', ts: RECENT_SUNDAY },
-          ]
+            ]
 
             it('contains album and artist names', async () => {
                 await createTestTable(conn, testData)
@@ -710,10 +522,9 @@ describe('FunFacts queries', () => {
                 { artist_name: 'artist1', album_name: 'album1', track_name: 't2', ts: RECENT_SUNDAY },
                 { artist_name: 'artist1', album_name: 'album1', track_name: 't3', ts: RECENT_SUNDAY },
                 { artist_name: 'artist1', album_name: 'album1', track_name: 't4', ts: RECENT_SUNDAY },
-                { artist_name: 'artist1', album_name: 'album1', track_name: 't5', ts: RECENT_MON_2AM },  // Monday 2am (valid)
-                { artist_name: 'artist1', album_name: 'album1', track_name: 't6', ts: RECENT_MON_3AM },  // Monday 3am (valid)
+                { artist_name: 'artist1', album_name: 'album1', track_name: 't5', ts: RECENT_MON_2AM },
+                { artist_name: 'artist1', album_name: 'album1', track_name: 't6', ts: RECENT_MON_3AM },
                 { artist_name: 'artist1', album_name: 'album1', track_name: 't7', ts: RECENT_SUNDAY },
-
                 // album2 -> 8 distinct tracks but Monday 6am (invalid)
                 { artist_name: 'artist2', album_name: 'album2', track_name: 'a1', ts: RECENT_MON_6AM },
                 { artist_name: 'artist2', album_name: 'album2', track_name: 'a2', ts: RECENT_MON_6AM },

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
@@ -1,26 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import {
-    queryAfternoonFavorite,
-    queryEveningFavorite,
-    queryNightFavorite,
-    queryMorningFavorite,
-    queryMarathon,
-    queryOneHitWonder,
-    queryWeekendFavorite,
-    queryAbsoluteLoyalty,
-    queryNostalgicReturn,
-    queryVarietyDay,
-    queryBingeListener,
-    queryCurrentObsession,
-    queryRecentDiscovery,
-    querySubscribedArtist,
-    queryMusicalAnniversary,
-    queryFirstArtist,
-    queryUnbeatableStreak,
-    queryForgottenArtist,
-    queryTrackProposition,
-    queryCozyAlbum,
-} from './queries'
+import { queryDefinitions, queries } from './queries'
 import {
     createTestConnection,
     closeTestConnection,
@@ -39,6 +18,20 @@ describe('FunFacts queries', () => {
 
     afterAll(() => {
         closeTestConnection(conn)
+    })
+
+    it('all query definitions expose sql', () => {
+        for (const queryDefinition of queryDefinitions) {
+            expect(queryDefinition.name).toBeTruthy()
+            expect(queryDefinition.sql).toBeTruthy()
+        }
+    })
+
+    it('queryDefinitions is consistent with queries', () => {
+        const queryKeys = Object.keys(queries).sort()
+        const definitionKeys = queryDefinitions.map((q) => q.name).sort()
+
+        expect(definitionKeys).toEqual(queryKeys)
     })
 
     describe('Favorite artist queries', () => {
@@ -98,7 +91,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryMorningFavorite returns artist with most morning streams', async () => {
-            const rows = await testQuery(conn, queryMorningFavorite())
+            const rows = await testQuery(conn, queries.morning_favorite)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('morning_favorite')
@@ -109,7 +102,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryAfternoonFavorite returns artist with most afternoon streams', async () => {
-            const rows = await testQuery(conn, queryAfternoonFavorite())
+            const rows = await testQuery(conn, queries.afternoon_favorite)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('afternoon_favorite')
@@ -120,7 +113,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryEveningFavorite returns artist with most evening streams', async () => {
-            const result = await conn.runAndReadAll(queryEveningFavorite())
+            const result = await conn.runAndReadAll(queries.evening_favorite)
             const rows = result.getRowObjectsJson()
             expect(rows.length).toBe(1)
             const row = rows[0]
@@ -132,7 +125,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryNightFavorite returns artist with most night streams', async () => {
-            const result = await conn.runAndReadAll(queryNightFavorite())
+            const result = await conn.runAndReadAll(queries.night_favorite)
             const rows = result.getRowObjectsJson()
             expect(rows.length).toBe(1)
             const row = rows[0]
@@ -173,7 +166,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryMarathon returns longest consecutive artist stream', async () => {
-            const rows = await testQuery(conn, queryMarathon())
+            const rows = await testQuery(conn, queries.marathon)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('marathon')
@@ -197,7 +190,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryOneHitWonder returns track with highest percentage of artist streams', async () => {
-            const rows = await testQuery(conn, queryOneHitWonder())
+            const rows = await testQuery(conn, queries.one_hit_wonder)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('one_hit_wonder')
@@ -245,7 +238,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryWeekendFavorite returns artist with most weekend streams', async () => {
-            const rows = await testQuery(conn, queryWeekendFavorite())
+            const rows = await testQuery(conn, queries.weekend_favorite)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('weekend_favorite')
@@ -297,7 +290,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryAbsoluteLoyalty returns artist with highest listening time percentage', async () => {
-            const rows = await testQuery(conn, queryAbsoluteLoyalty())
+            const rows = await testQuery(conn, queries.absolute_loyalty)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('absolute_loyalty')
@@ -337,7 +330,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryNostalgicReturn returns recently played artist with longest gap', async () => {
-            const rows = await testQuery(conn, queryNostalgicReturn())
+            const rows = await testQuery(conn, queries.nostalgic_return)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('nostalgic_return')
@@ -365,7 +358,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryVarietyDay returns day with most distinct artists', async () => {
-            const rows = await testQuery(conn, queryVarietyDay())
+            const rows = await testQuery(conn, queries.variety_day)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('variety_day')
@@ -388,7 +381,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryBingeListener returns day with most listening time', async () => {
-            const rows = await testQuery(conn, queryBingeListener())
+            const rows = await testQuery(conn, queries.binge_listener)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('binge_listener')
@@ -440,7 +433,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryCurrentObsession returns most played track in last 30 days', async () => {
-            const rows = await testQuery(conn, queryCurrentObsession())
+            const rows = await testQuery(conn, queries.current_obsession)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('current_obsession')
@@ -478,7 +471,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryRecentDiscovery returns recently discovered artist with most streams', async () => {
-            const rows = await testQuery(conn, queryRecentDiscovery())
+            const rows = await testQuery(conn, queries.recent_discovery)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('recent_discovery')
@@ -514,7 +507,7 @@ describe('FunFacts queries', () => {
         })
 
         it('querySubscribedArtist returns artist present in most months', async () => {
-            const rows = await testQuery(conn, querySubscribedArtist())
+            const rows = await testQuery(conn, queries.subscribed_artist)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('subscribed_artist')
@@ -550,7 +543,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryFirstArtist returns first artist listened to', async () => {
-            const rows = await testQuery(conn, queryFirstArtist())
+            const rows = await testQuery(conn, queries.first_artist)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('first_artist')
@@ -561,7 +554,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryMusicalAnniversary returns artist listened to for longest time', async () => {
-            const rows = await testQuery(conn, queryMusicalAnniversary())
+            const rows = await testQuery(conn, queries.musical_anniversary)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('musical_anniversary')
@@ -589,7 +582,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryUnbeatableStreak returns longest consecutive listening days', async () => {
-            const rows = await testQuery(conn, queryUnbeatableStreak())
+            const rows = await testQuery(conn, queries.unbeatable_streak)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('unbeatable_streak')
@@ -631,7 +624,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryForgottenArtist returns top artist not listened to recently', async () => {
-            const rows = await testQuery(conn, queryForgottenArtist())
+            const rows = await testQuery(conn, queries.forgotten_artist)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('forgotten_artist')
@@ -661,7 +654,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryTrackProposition returns a random track', async () => {
-            const rows = await testQuery(conn, queryTrackProposition())
+            const rows = await testQuery(conn, queries.track_proposition)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('track_proposition')
@@ -695,8 +688,8 @@ describe('FunFacts queries', () => {
 
             it('contains album and artist names', async () => {
                 await createTestTable(conn, testData)
-                const rows = await testQuery(conn, queryCozyAlbum())
 
+                const rows = await testQuery(conn, queries.cozy_album)
                 expect(rows.length).toBe(1)
                 expect(rows[0].fact_type).toBe('cozy_album')
                 expect(rows[0].main_text).toBe('album1')
@@ -734,7 +727,7 @@ describe('FunFacts queries', () => {
 
             it('includes Sunday and Monday before 4am only', async () => {
                 await createTestTable(conn, testData)
-                const rows = await testQuery(conn, queryCozyAlbum())
+                const rows = await testQuery(conn, queries.cozy_album)
                 expect(rows.length).toBe(1)
                 expect(rows[0].main_text).toBe('album1')
             })
@@ -752,7 +745,6 @@ describe('FunFacts queries', () => {
                 { artist_name: 'artist1', album_name: 'album1', track_name: 't6', ts: OLD_SUNDAY },
                 { artist_name: 'artist1', album_name: 'album1', track_name: 't7', ts: OLD_SUNDAY },
                 { artist_name: 'artist1', album_name: 'album1', track_name: 't8', ts: OLD_SUNDAY },
-
                 // album2 -> 7 distinct tracks within last year (should win)
                 { artist_name: 'artist2', album_name: 'album2', track_name: 'a1', ts: RECENT_SUNDAY },
                 { artist_name: 'artist2', album_name: 'album2', track_name: 'a2', ts: RECENT_SUNDAY },
@@ -765,7 +757,7 @@ describe('FunFacts queries', () => {
 
             it('ignores listens older than one year', async () => {
                 await createTestTable(conn, testData)
-                const rows = await testQuery(conn, queryCozyAlbum())
+                const rows = await testQuery(conn, queries.cozy_album)
                 expect(rows.length).toBe(1)
                 expect(rows[0].main_text).toBe('album2')
             })
@@ -782,7 +774,6 @@ describe('FunFacts queries', () => {
                 { artist_name: 'artist1', album_name: 'album1', track_name: 't5', ts: RECENT_SUNDAY },
                 { artist_name: 'artist1', album_name: 'album1', track_name: 't6', ts: RECENT_SUNDAY },
                 { artist_name: 'artist1', album_name: 'album1', track_name: 't1', ts: RECENT_SUNDAY },
-
                 // album2 -> 7 distinct tracks (should win)
                 { artist_name: 'artist2', album_name: 'album2', track_name: 'a1', ts: RECENT_SUNDAY },
                 { artist_name: 'artist2', album_name: 'album2', track_name: 'a2', ts: RECENT_SUNDAY },
@@ -795,7 +786,7 @@ describe('FunFacts queries', () => {
 
             it('requires at least 7 distinct tracks', async () => {
                 await createTestTable(conn, testData)
-                const rows = await testQuery(conn, queryCozyAlbum())
+                const rows = await testQuery(conn, queries.cozy_album)
                 expect(rows.length).toBe(1)
                 expect(rows[0].main_text).toBe('album2')
             })
@@ -811,7 +802,7 @@ describe('FunFacts queries', () => {
 
             it('returns error message if no album satisfies the rules', async () => {
                 await createTestTable(conn, testData)
-                const rows = await testQuery(conn, queryCozyAlbum())
+                const rows = await testQuery(conn, queries.cozy_album)
                 expect(rows.length).toBe(1)
                 expect(rows[0].fact_type).toBe('cozy_album')
                 expect(rows[0].main_text).toBeNull()

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.tsx
@@ -29,105 +29,32 @@ export type FunFactResult = {
     context?: string
 }
 
-export function queryMorningFavorite(): string {
-    return sqlQueryMorningFavorite.replaceAll('${table}', TABLE)
-}
+const build = (sql: string) => sql.replaceAll('${table}', TABLE)
 
-export function queryAfternoonFavorite(): string {
-    return sqlQueryAfternoonFavorite.replaceAll('${table}', TABLE)
-}
+export const queries = {
+    morning_favorite: build(sqlQueryMorningFavorite),
+    afternoon_favorite: build(sqlQueryAfternoonFavorite),
+    evening_favorite: build(sqlQueryEveningFavorite),
+    night_favorite: build(sqlQueryNightFavorite),
+    weekend_favorite: build(sqlQueryWeekendFavorite),
+    nostalgic_return: build(sqlQueryNostalgicReturn),
+    forgotten_artist: build(sqlQueryForgottenArtist),
+    absolute_loyalty: build(sqlQueryAbsoluteLoyalty),
+    subscribed_artist: build(sqlQuerySubscribedArtist),
+    musical_anniversary: build(sqlQueryMusicalAnniversary),
+    first_artist: build(sqlQueryFirstArtist),
+    one_hit_wonder: build(sqlQueryOneHitWonder),
+    variety_day: build(sqlQueryVarietyDay),
+    binge_listener: build(sqlQueryBingeListener),
+    current_obsession: build(sqlQueryCurrentObsession),
+    recent_discovery: build(sqlQueryRecentDiscovery),
+    marathon: build(sqlQueryMarathon),
+    unbeatable_streak: build(sqlQueryUnbeatableStreak),
+    track_proposition: build(sqlQueryTrackProposition),
+    cozy_album: build(sqlQueryCozyAlbum),
+} as const
 
-export function queryEveningFavorite(): string {
-    return sqlQueryEveningFavorite.replaceAll('${table}', TABLE)
-}
-
-export function queryNightFavorite(): string {
-    return sqlQueryNightFavorite.replaceAll('${table}', TABLE)
-}
-
-export function queryWeekendFavorite(): string {
-    return sqlQueryWeekendFavorite.replaceAll('${table}', TABLE)
-}
-
-export function queryNostalgicReturn(): string {
-    return sqlQueryNostalgicReturn.replaceAll('${table}', TABLE)
-}
-
-export function queryForgottenArtist(): string {
-    return sqlQueryForgottenArtist.replaceAll('${table}', TABLE)
-}
-
-export function queryAbsoluteLoyalty(): string {
-    return sqlQueryAbsoluteLoyalty.replaceAll('${table}', TABLE)
-}
-
-export function querySubscribedArtist(): string {
-    return sqlQuerySubscribedArtist.replaceAll('${table}', TABLE)
-}
-
-export function queryMusicalAnniversary(): string {
-    return sqlQueryMusicalAnniversary.replaceAll('${table}', TABLE)
-}
-
-export function queryFirstArtist(): string {
-    return sqlQueryFirstArtist.replaceAll('${table}', TABLE)
-}
-
-export function queryOneHitWonder(): string {
-    return sqlQueryOneHitWonder.replaceAll('${table}', TABLE)
-}
-
-export function queryVarietyDay(): string {
-    return sqlQueryVarietyDay.replaceAll('${table}', TABLE)
-}
-
-export function queryBingeListener(): string {
-    return sqlQueryBingeListener.replaceAll('${table}', TABLE)
-}
-
-export function queryCurrentObsession(): string {
-    return sqlQueryCurrentObsession.replaceAll('${table}', TABLE)
-}
-
-export function queryRecentDiscovery(): string {
-    return sqlQueryRecentDiscovery.replaceAll('${table}', TABLE)
-}
-
-export function queryMarathon(): string {
-    return sqlQueryMarathon.replaceAll('${table}', TABLE)
-}
-
-export function queryUnbeatableStreak(): string {
-    return sqlQueryUnbeatableStreak.replaceAll('${table}', TABLE)
-}
-
-export function queryTrackProposition(): string {
-    return sqlQueryTrackProposition.replaceAll('${table}', TABLE)
-}
-
-export function queryCozyAlbum(): string {
-    return sqlQueryCozyAlbum.replaceAll('${table}', TABLE)
-}
-
-export const QUERY_FUNCTIONS = [
-    queryAfternoonFavorite,
-    queryEveningFavorite,
-    queryNightFavorite,
-    queryMorningFavorite,
-    queryMarathon,
-    queryOneHitWonder,
-    queryWeekendFavorite,
-    queryAbsoluteLoyalty,
-    queryNostalgicReturn,
-    queryVarietyDay,
-    queryBingeListener,
-    queryCurrentObsession,
-    queryFirstArtist,
-    queryRecentDiscovery,
-    querySubscribedArtist,
-    queryMusicalAnniversary,
-    queryUnbeatableStreak,
-    queryForgottenArtist,
-    queryTrackProposition,
-    queryCozyAlbum,
-]
+export const queryDefinitions = Object.entries(queries).map(([name, sql]) => ({
+    name,
+    sql,
+}))


### PR DESCRIPTION
## 🔇 Problem
The FunFacts module exports a lot of nearly identical one-liner query functions, each calling `replaceAll` with a different SQL import. Adding a new fact requires duplicating the boilerplate.

## 🎹 Proposal
Consolidate into a single `QUERIES` record mapping fact keys to their SQL strings. The `QUERY_FUNCTIONS` array used by the consumer is now derived from the record. The test file references `QUERIES` directly instead of individual function imports.

## 🎤 Test
Manually verify fun facts load and cycle correctly in the preview.