### PR TITLE
refactor(topartist): capitalize setTopArtistByCount setter

### DIFF
--- a/app/src/components/Charts/DetailedCharts/TopArtist/index.tsx
+++ b/app/src/components/Charts/DetailedCharts/TopArtist/index.tsx
@@ -8,7 +8,7 @@ import { queryDBAsJSON } from '../../../../db/queries/queryDB'
 import { useState, useEffect } from 'react'
 
 export function TopArtist() {
-    const [topArtistByCount, settopArtistByCount] = useState<
+    const [topArtistByCount, setTopArtistByCount] = useState<
         TopArtistQueryResult[] | undefined
     >()
     const [topArtistByDuration, setTopArtistByDuration] = useState<
@@ -21,7 +21,7 @@ export function TopArtist() {
             const topByCount = await queryDBAsJSON<TopArtistQueryResult>(
                 queryTopArtistByCount()
             )
-            settopArtistByCount(topByCount)
+            setTopArtistByCount(topByCount)
             const topByDuration = await queryDBAsJSON<TopArtistQueryResult>(
                 queryTopArtistByDuration()
             )


### PR DESCRIPTION
## 🔇 Problem
The state setter for `topArtistByCount` is named `settopArtistByCount` (lowercase 't') while the parallel setter for duration correctly uses `setTopArtistByDuration`.

## 🎹 Proposal
Rename to `setTopArtistByCount` for consistency.

## 🎤 Test
Verify the TopArtist chart renders correctly in the preview.