### PR TITLE
docs(layout): replace astro scaffold meta description

### DIFF
--- a/app/src/layouts/Layout.astro
+++ b/app/src/layouts/Layout.astro
@@ -12,7 +12,10 @@ import '../styles/global.css'
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
-        <meta name="description" content="Astro description" />
+        <meta
+            name="description"
+            content="Tracksy — Privacy-first music streaming data visualization"
+        />
         <meta name="viewport" content="width=device-width" />
         <link
             rel="icon"


### PR DESCRIPTION
## 🔇 Problem
The `<meta name="description">` in `Layout.astro` still reads "Astro description", the project scaffold default.

## 🎹 Proposal
Replace with an accurate description for the project.

## 🎤 Test
Check the meta description in the browser tab or page source.