### PR TITLE
chore: remove next.js use client directive from streaks component

### DIFF
--- a/app/src/components/Charts/DetailedCharts/Streaks/Streaks.tsx
+++ b/app/src/components/Charts/DetailedCharts/Streaks/Streaks.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React, { useEffect, useRef, useState } from 'react'
 import * as Plot from '@observablehq/plot'
 import dayjs from 'dayjs'


### PR DESCRIPTION
## 🔇 Problem
`Streaks.tsx` has a `'use client'` directive at the top. This is a Next.js App Router concept with no effect in Astro.

## 🎹 Proposal
Remove the directive line.

## 🎤 Test
Verify the Streaks chart renders correctly in the preview.