### PR TITLE
refactor(funfacts): merge fact metadata and query definitions into a single facts array

### DIFF
--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
@@ -1,12 +1,11 @@
 import { describe, it, vi, expect, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
 import { FunFacts } from '.'
-import { factConfig } from './FunFacts'
 
 import * as query from '../../../../db/queries/queryDB'
 import * as db from '../../../../db/getDB'
 import { DATA_LOADED_EVENT } from '../../../../db/dataSignal'
-import { FunFactResult, queryDefinitions, queries } from './queries'
+import { FunFactResult, facts } from './queries'
 
 describe('FunFacts Component', () => {
     beforeEach(() => {
@@ -16,13 +15,14 @@ describe('FunFacts Component', () => {
 
         vi.spyOn(query, 'queryDBAsJSON').mockImplementation(async (_sql) => {
             void _sql
-            const queryName = queryDefinitions[i % queryDefinitions.length].name
+            const fact = facts[i % facts.length]
             i++
             return [
                 {
-                    fact_type: 'dummy_fact',
-                    main_text: queryName,
-                    value: 1,
+                    fact_type: fact.fact_type,
+                    main_text: `main_text_for_${fact.fact_type}`,
+                    value: i % 2 === 0 ? 1 : 'one',
+                    context: i % 2 === 0 ? undefined : 'dummy_context',
                 },
             ] as FunFactResult[]
         })
@@ -37,9 +37,7 @@ describe('FunFacts Component', () => {
         render(<FunFacts />)
 
         await waitFor(() => {
-            const hasAnyTitle = queryDefinitions.some((q) =>
-                screen.queryByText(q.name)
-            )
+            const hasAnyTitle = facts.some((f) => screen.queryByText(f.title))
             expect(hasAnyTitle).toBe(true)
         })
 
@@ -77,19 +75,24 @@ describe('FunFacts Component', () => {
     })
 
     it('refreshes fact when clicking button', async () => {
-        const { container } = render(<FunFacts />)
+        render(<FunFacts />)
 
         await waitFor(() => {
             expect(screen.getByTitle('New fact')).toBeDefined()
         })
 
-        const first = container.textContent
+        const el = document.querySelector('[data-fact-type]')
+        const firstFactType = el?.getAttribute('data-fact-type')
+        expect(firstFactType).toBeTruthy()
 
         fireEvent.click(screen.getByTitle('New fact'))
 
         await waitFor(() => {
-            expect(container.textContent).not.toBe(first)
+            const el = document.querySelector('[data-fact-type]')
+            const secondFactType = el?.getAttribute('data-fact-type')
+            expect(secondFactType).not.toBe(firstFactType)
         })
+        expect(query.queryDBAsJSON).toHaveBeenCalledTimes(2)
     })
 
     it('repeats facts after full cycle reset', async () => {
@@ -97,21 +100,21 @@ describe('FunFacts Component', () => {
 
         render(<FunFacts />)
 
-        await waitFor(() => {
-            expect(screen.getByTitle('New fact')).toBeDefined()
-        })
+        const button = await screen.findByTitle('New fact')
 
-        const button = screen.getByTitle('New fact')
-
-        for (let i = 0; i < queryDefinitions.length * 2; i++) {
+        for (let i = 0; i < facts.length * 2; i++) {
             fireEvent.click(button)
 
             await waitFor(() => {
-                seen.add(document.body.textContent ?? '')
+                const el = document.querySelector('[data-fact-type]')
+                const factType = el?.getAttribute('data-fact-type')
+
+                expect(factType).toBeTruthy()
+                seen.add(factType!)
             })
         }
 
-        expect(seen.size).toBe(queryDefinitions.length)
+        expect(seen.size).toBe(facts.length)
     })
 
     it('logs error when loading fun fact fails', async () => {
@@ -133,30 +136,5 @@ describe('FunFacts Component', () => {
         })
 
         consoleSpy.mockRestore()
-    })
-
-    describe('factConfig coherence', () => {
-        function extractFactType(sql: string): string | null {
-            const match = sql.match(/'([a-z_]+)'\s+as\s+fact_type/)
-            return match?.[1] ?? null
-        }
-
-        it('should ensure default exists in factConfig', () => {
-            expect(factConfig('non_existent_fun_fact')).toBeDefined()
-        })
-
-        it('should know all the fact types used', () => {
-            const usedTypes = Object.values(queries).map(
-                extractFactType
-            ) as string[]
-
-            const defaultType = factConfig('non_existent_fun_fact')
-
-            const knownTypes = usedTypes
-                .map(factConfig)
-                .filter((q) => q.title != defaultType.title)
-
-            expect(knownTypes.length).toBe(usedTypes.length)
-        })
     })
 })

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
@@ -1,77 +1,27 @@
 import type { FC } from 'react'
-import type { FunFactResult } from './queries'
+
+export type FunFactProps = {
+    fact_type: string
+    title: string
+    emoji: string
+    main_text: string
+    second_text?: string | undefined
+    value: string | number
+    unit?: string | undefined
+    context?: string | undefined
+}
 
 type Props = {
-    fact: FunFactResult
+    fact: FunFactProps
     onRefresh: () => void
     isLoading: boolean
 }
 
-export const factConfig = (type: string) => {
-    switch (type) {
-        // Moments
-        case 'morning_favorite':
-            return { title: '🌅 Musical Breakfast', emoji: '🥐' }
-        case 'afternoon_favorite':
-            return { title: '☀️ Afternoon Boost', emoji: '⚡️' }
-        case 'evening_favorite':
-            return { title: '🌆 Calm Return', emoji: '🛋️' }
-        case 'night_favorite':
-            return { title: '🌙 Musical Insomnia', emoji: '💤' }
-        case 'weekend_favorite':
-            return { title: '🎉 Weekend Vibes', emoji: '🕺' }
-
-        // Loyalty
-        case 'absolute_loyalty':
-            return { title: '❤️ Absolute Loyalty', emoji: '💍' }
-        case 'subscribed_artist':
-            return { title: '🎸 Monthly Subscription', emoji: '📬' }
-
-        // Nostalgia
-        case 'nostalgic_return':
-            return { title: '🕰️ Nostalgic Return', emoji: '📼' }
-        case 'forgotten_artist':
-            return { title: '🕰️ Forgotten Artist', emoji: '💔' }
-
-        // Records
-        case 'binge_listener':
-            return { title: '🎧 Binge Listener', emoji: '🎶' }
-        case 'unbeatable_streak':
-            return { title: '🔥 Unbeatable Streak', emoji: '🏆' }
-        case 'variety_day':
-            return { title: '🌈 Variety Day', emoji: '🎨' }
-        case 'one_hit_wonder':
-            return { title: '⭐ One-Hit Wonder', emoji: '🎵' }
-        case 'marathon':
-            return { title: '🏃 Marathon', emoji: '☄️' }
-
-        // Discovery
-        case 'recent_discovery':
-            return { title: '🎵 Recent Discovery', emoji: '✨' }
-        case 'current_obsession':
-            return { title: '🔁 Current Obsession', emoji: '🎯' }
-
-        // Misc
-        case 'musical_anniversary':
-            return { title: '🎉 Musical Anniversary', emoji: '🎂' }
-        case 'first_artist':
-            return { title: '🦖 The Very First', emoji: '1️⃣' }
-        case 'track_proposition':
-            return { title: '🔮 Listening Proposition', emoji: '🐙' }
-        case 'cozy_album':
-            return { title: '💿 Cozy Album', emoji: '☁️' }
-
-        default:
-            return { title: '🎲 Fun Fact', emoji: '🎲' }
-    }
-}
-
 export const FunFacts: FC<Props> = ({ fact, onRefresh, isLoading }) => {
-    const { fact_type, main_text, second_text, value, unit, context } = fact
-    const { title, emoji } = factConfig(fact_type)
-
     const valueDisplayed =
-        typeof value === 'number' ? value.toLocaleString() : value
+        typeof fact.value === 'number'
+            ? fact.value.toLocaleString()
+            : fact.value
 
     return (
         <div className="col-span-1 md:col-span-2 lg:col-span-3 p-6 bg-gradient-to-br from-purple-50 to-blue-50 dark:from-gray-900 dark:to-slate-900 rounded-2xl shadow border border-purple-100 dark:border-gray-700 relative overflow-hidden group transition-all duration-300 shadow-glass hover:shadow-glass-lg hover:scale-[1.01] animate-fade-in">
@@ -90,34 +40,37 @@ export const FunFacts: FC<Props> = ({ fact, onRefresh, isLoading }) => {
                 </button>
             </div>
 
-            <div className="flex flex-col md:flex-row items-center gap-6">
+            <div
+                className="flex flex-col md:flex-row items-center gap-6"
+                data-fact-type={fact.fact_type}
+            >
                 <div className="text-6xl md:text-8xl flex-shrink-0 animate-bounce-slow">
-                    {emoji}
+                    {fact.emoji}
                 </div>
 
                 <div className="flex-1 text-center md:text-left">
                     <div className="text-sm font-bold text-purple-600 dark:text-purple-400 uppercase tracking-wider mb-2">
-                        {title}
+                        {fact.title}
                     </div>
 
                     <div className="text-2xl md:text-4xl font-bold text-gray-900 dark:text-white mb-2 break-words text-balance">
-                        {main_text}
+                        {fact.main_text}
                     </div>
 
                     <div className="text-lg text-gray-600 dark:text-gray-300">
-                        {second_text}{' '}
-                        {second_text && valueDisplayed ? '(' : undefined}
+                        {fact.second_text}{' '}
+                        {fact.second_text && valueDisplayed ? '(' : undefined}
                         <span className="font-bold text-blue-600 dark:text-blue-400">
                             {valueDisplayed}
-                            {unit === '%' ? unit : undefined}
+                            {fact.unit === '%' ? fact.unit : undefined}
                         </span>{' '}
-                        {unit !== '%' ? unit : undefined}
-                        {second_text && valueDisplayed ? ')' : undefined}
+                        {fact.unit !== '%' ? fact.unit : undefined}
+                        {fact.second_text && valueDisplayed ? ')' : undefined}
                     </div>
 
-                    {context && (
+                    {fact.context && (
                         <div className="text-sm text-gray-600 dark:text-gray-400 mt-1 italic">
-                            {context}
+                            {fact.context}
                         </div>
                     )}
                 </div>

--- a/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
@@ -1,43 +1,51 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { queryDefinitions, type FunFactResult } from './queries'
+import { type FunFactResult, facts } from './queries'
 import { queryDBAsJSON } from '../../../../db/queries/queryDB'
 import { DATA_LOADED_EVENT } from '../../../../db/dataSignal'
-import { FunFacts as FunFactsView } from './FunFacts'
+import { FunFacts as FunFactsView, type FunFactProps } from './FunFacts'
+
+const shuffle = <T,>(array: readonly T[]): T[] => {
+    const copy = [...array]
+    return copy.sort(() => Math.random() - 0.5)
+}
 
 export function FunFacts() {
-    const [fact, setFact] = useState<FunFactResult | null>(null)
+    const [fact, setFact] = useState<FunFactProps | null>(null)
     const [isLoading, setIsLoading] = useState(false)
     const seenFactsRef = useRef<Set<string>>(new Set())
 
     const loadRandomFact = useCallback(async () => {
         setIsLoading(true)
         try {
-            if (seenFactsRef.current.size === queryDefinitions.length) {
+            if (seenFactsRef.current.size === facts.length) {
                 seenFactsRef.current.clear()
             }
 
-            const unseenQueries = queryDefinitions.filter(
-                (q) => !seenFactsRef.current.has(q.name)
-            )
-            const availableQueries =
-                unseenQueries.length > 0 ? unseenQueries : queryDefinitions
-
-            const shuffled = [...availableQueries].sort(
-                () => Math.random() - 0.5
+            const unseenFacts = facts.filter(
+                (fact) => !seenFactsRef.current.has(fact.fact_type)
             )
 
-            for (const queryDef of shuffled) {
-                const [result] =
-                    (await queryDBAsJSON<FunFactResult>(queryDef.sql)) || []
+            const candidates = unseenFacts.length > 0 ? unseenFacts : facts
 
-                seenFactsRef.current.add(queryDef.name)
+            const shuffled = shuffle(candidates)
+
+            for (const factDefinition of shuffled) {
+                const [result] = await queryDBAsJSON<FunFactResult>(
+                    factDefinition.sql
+                )
+
+                seenFactsRef.current.add(factDefinition.fact_type)
                 if (result) {
-                    setFact(result)
+                    setFact({
+                        title: factDefinition.title,
+                        emoji: factDefinition.emoji,
+                        ...result,
+                    })
                     break
                 }
                 console.warn(
                     'An empty result is returned by a fun fact:',
-                    queryDef.name
+                    factDefinition.fact_type
                 )
             }
         } catch (error) {
@@ -49,7 +57,7 @@ export function FunFacts() {
 
     useEffect(() => {
         loadRandomFact()
-    }, [])
+    }, [loadRandomFact])
 
     useEffect(() => {
         const handleDataLoaded = () => {

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { queryDefinitions, queries } from './queries'
+import { facts } from './queries'
 import {
     createTestConnection,
     closeTestConnection,
@@ -11,6 +11,9 @@ import type { DuckDBConnection } from '@duckdb/node-api'
 
 let conn: DuckDBConnection
 
+const getFact = (fact_type: string) =>
+    facts.find((f) => f.fact_type === fact_type)!
+
 describe('FunFacts queries', () => {
     beforeAll(async () => {
         conn = await createTestConnection()
@@ -20,18 +23,16 @@ describe('FunFacts queries', () => {
         closeTestConnection(conn)
     })
 
-    it('all query definitions expose sql', () => {
-        for (const queryDefinition of queryDefinitions) {
-            expect(queryDefinition.name).toBeTruthy()
-            expect(queryDefinition.sql).toBeTruthy()
-        }
-    })
-
-    it('queryDefinitions is consistent with queries', () => {
-        const queryKeys = Object.keys(queries).sort()
-        const definitionKeys = queryDefinitions.map((q) => q.name).sort()
-
-        expect(definitionKeys).toEqual(queryKeys)
+    it('all fact definitions expose build sql', () => {
+        facts.forEach((fact) => {
+            expect(fact.fact_type).toBeTruthy()
+            expect(fact.title).toBeTruthy()
+            expect(fact.emoji).toBeTruthy()
+            expect(fact.sql).toBeTruthy()
+            expect(fact.sql).not.toContain('$')
+            expect(fact.sql).not.toContain('{')
+            expect(fact.sql).not.toContain('}')
+        })
     })
 
     describe('Favorite artist queries', () => {
@@ -55,7 +56,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryMorningFavorite returns artist with most morning streams', async () => {
-            const rows = await testQuery(conn, queries.morning_favorite)
+            const rows = await testQuery(conn, getFact('morning_favorite').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('morning_favorite')
@@ -66,7 +67,10 @@ describe('FunFacts queries', () => {
         })
 
         it('queryAfternoonFavorite returns artist with most afternoon streams', async () => {
-            const rows = await testQuery(conn, queries.afternoon_favorite)
+            const rows = await testQuery(
+                conn,
+                getFact('afternoon_favorite').sql
+            )
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('afternoon_favorite')
@@ -77,7 +81,9 @@ describe('FunFacts queries', () => {
         })
 
         it('queryEveningFavorite returns artist with most evening streams', async () => {
-            const result = await conn.runAndReadAll(queries.evening_favorite)
+            const result = await conn.runAndReadAll(
+                getFact('evening_favorite').sql
+            )
             const rows = result.getRowObjectsJson()
             expect(rows.length).toBe(1)
             const row = rows[0]
@@ -89,7 +95,9 @@ describe('FunFacts queries', () => {
         })
 
         it('queryNightFavorite returns artist with most night streams', async () => {
-            const result = await conn.runAndReadAll(queries.night_favorite)
+            const result = await conn.runAndReadAll(
+                getFact('night_favorite').sql
+            )
             const rows = result.getRowObjectsJson()
             expect(rows.length).toBe(1)
             const row = rows[0]
@@ -115,7 +123,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryMarathon returns longest consecutive artist stream', async () => {
-            const rows = await testQuery(conn, queries.marathon)
+            const rows = await testQuery(conn, getFact('marathon').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('marathon')
@@ -136,7 +144,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryOneHitWonder returns track with highest percentage of artist streams', async () => {
-            const rows = await testQuery(conn, queries.one_hit_wonder)
+            const rows = await testQuery(conn, getFact('one_hit_wonder').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('one_hit_wonder')
@@ -166,7 +174,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryWeekendFavorite returns artist with most weekend streams', async () => {
-            const rows = await testQuery(conn, queries.weekend_favorite)
+            const rows = await testQuery(conn, getFact('weekend_favorite').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('weekend_favorite')
@@ -194,7 +202,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryAbsoluteLoyalty returns artist with highest listening time percentage', async () => {
-            const rows = await testQuery(conn, queries.absolute_loyalty)
+            const rows = await testQuery(conn, getFact('absolute_loyalty').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('absolute_loyalty')
@@ -219,7 +227,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryNostalgicReturn returns recently played artist with longest gap', async () => {
-            const rows = await testQuery(conn, queries.nostalgic_return)
+            const rows = await testQuery(conn, getFact('nostalgic_return').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('nostalgic_return')
@@ -247,7 +255,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryVarietyDay returns day with most distinct artists', async () => {
-            const rows = await testQuery(conn, queries.variety_day)
+            const rows = await testQuery(conn, getFact('variety_day').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('variety_day')
@@ -270,7 +278,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryBingeListener returns day with most listening time', async () => {
-            const rows = await testQuery(conn, queries.binge_listener)
+            const rows = await testQuery(conn, getFact('binge_listener').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('binge_listener')
@@ -299,7 +307,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryCurrentObsession returns most played track in last 30 days', async () => {
-            const rows = await testQuery(conn, queries.current_obsession)
+            const rows = await testQuery(conn, getFact('current_obsession').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('current_obsession')
@@ -325,7 +333,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryRecentDiscovery returns recently discovered artist with most streams', async () => {
-            const rows = await testQuery(conn, queries.recent_discovery)
+            const rows = await testQuery(conn, getFact('recent_discovery').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('recent_discovery')
@@ -352,7 +360,7 @@ describe('FunFacts queries', () => {
         })
 
         it('querySubscribedArtist returns artist present in most months', async () => {
-            const rows = await testQuery(conn, queries.subscribed_artist)
+            const rows = await testQuery(conn, getFact('subscribed_artist').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('subscribed_artist')
@@ -376,7 +384,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryFirstArtist returns first artist listened to', async () => {
-            const rows = await testQuery(conn, queries.first_artist)
+            const rows = await testQuery(conn, getFact('first_artist').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('first_artist')
@@ -387,7 +395,10 @@ describe('FunFacts queries', () => {
         })
 
         it('queryMusicalAnniversary returns artist listened to for longest time', async () => {
-            const rows = await testQuery(conn, queries.musical_anniversary)
+            const rows = await testQuery(
+                conn,
+                getFact('musical_anniversary').sql
+            )
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('musical_anniversary')
@@ -415,7 +426,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryUnbeatableStreak returns longest consecutive listening days', async () => {
-            const rows = await testQuery(conn, queries.unbeatable_streak)
+            const rows = await testQuery(conn, getFact('unbeatable_streak').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('unbeatable_streak')
@@ -442,7 +453,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryForgottenArtist returns top artist not listened to recently', async () => {
-            const rows = await testQuery(conn, queries.forgotten_artist)
+            const rows = await testQuery(conn, getFact('forgotten_artist').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('forgotten_artist')
@@ -466,7 +477,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryTrackProposition returns a random track', async () => {
-            const rows = await testQuery(conn, queries.track_proposition)
+            const rows = await testQuery(conn, getFact('track_proposition').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.fact_type).toBe('track_proposition')
@@ -501,7 +512,7 @@ describe('FunFacts queries', () => {
             it('contains album and artist names', async () => {
                 await createTestTable(conn, testData)
 
-                const rows = await testQuery(conn, queries.cozy_album)
+                const rows = await testQuery(conn, getFact('cozy_album').sql)
                 expect(rows.length).toBe(1)
                 expect(rows[0].fact_type).toBe('cozy_album')
                 expect(rows[0].main_text).toBe('album1')
@@ -538,7 +549,7 @@ describe('FunFacts queries', () => {
 
             it('includes Sunday and Monday before 4am only', async () => {
                 await createTestTable(conn, testData)
-                const rows = await testQuery(conn, queries.cozy_album)
+                const rows = await testQuery(conn, getFact('cozy_album').sql)
                 expect(rows.length).toBe(1)
                 expect(rows[0].main_text).toBe('album1')
             })
@@ -568,7 +579,7 @@ describe('FunFacts queries', () => {
 
             it('ignores listens older than one year', async () => {
                 await createTestTable(conn, testData)
-                const rows = await testQuery(conn, queries.cozy_album)
+                const rows = await testQuery(conn, getFact('cozy_album').sql)
                 expect(rows.length).toBe(1)
                 expect(rows[0].main_text).toBe('album2')
             })
@@ -597,7 +608,7 @@ describe('FunFacts queries', () => {
 
             it('requires at least 7 distinct tracks', async () => {
                 await createTestTable(conn, testData)
-                const rows = await testQuery(conn, queries.cozy_album)
+                const rows = await testQuery(conn, getFact('cozy_album').sql)
                 expect(rows.length).toBe(1)
                 expect(rows[0].main_text).toBe('album2')
             })
@@ -613,7 +624,7 @@ describe('FunFacts queries', () => {
 
             it('returns error message if no album satisfies the rules', async () => {
                 await createTestTable(conn, testData)
-                const rows = await testQuery(conn, queries.cozy_album)
+                const rows = await testQuery(conn, getFact('cozy_album').sql)
                 expect(rows.length).toBe(1)
                 expect(rows[0].fact_type).toBe('cozy_album')
                 expect(rows[0].main_text).toBeNull()

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.tsx
@@ -31,30 +31,125 @@ export type FunFactResult = {
 
 const build = (sql: string) => sql.replaceAll('${table}', TABLE)
 
-export const queries = {
-    morning_favorite: build(sqlQueryMorningFavorite),
-    afternoon_favorite: build(sqlQueryAfternoonFavorite),
-    evening_favorite: build(sqlQueryEveningFavorite),
-    night_favorite: build(sqlQueryNightFavorite),
-    weekend_favorite: build(sqlQueryWeekendFavorite),
-    nostalgic_return: build(sqlQueryNostalgicReturn),
-    forgotten_artist: build(sqlQueryForgottenArtist),
-    absolute_loyalty: build(sqlQueryAbsoluteLoyalty),
-    subscribed_artist: build(sqlQuerySubscribedArtist),
-    musical_anniversary: build(sqlQueryMusicalAnniversary),
-    first_artist: build(sqlQueryFirstArtist),
-    one_hit_wonder: build(sqlQueryOneHitWonder),
-    variety_day: build(sqlQueryVarietyDay),
-    binge_listener: build(sqlQueryBingeListener),
-    current_obsession: build(sqlQueryCurrentObsession),
-    recent_discovery: build(sqlQueryRecentDiscovery),
-    marathon: build(sqlQueryMarathon),
-    unbeatable_streak: build(sqlQueryUnbeatableStreak),
-    track_proposition: build(sqlQueryTrackProposition),
-    cozy_album: build(sqlQueryCozyAlbum),
-} as const
-
-export const queryDefinitions = Object.entries(queries).map(([name, sql]) => ({
-    name,
-    sql,
-}))
+export const facts = [
+    {
+        fact_type: 'morning_favorite',
+        title: '🌅 Musical Breakfast',
+        emoji: '🥐',
+        sql: build(sqlQueryMorningFavorite),
+    },
+    {
+        fact_type: 'afternoon_favorite',
+        title: '☀️ Afternoon Boost',
+        emoji: '⚡️',
+        sql: build(sqlQueryAfternoonFavorite),
+    },
+    {
+        fact_type: 'evening_favorite',
+        title: '🌆 Calm Return',
+        emoji: '🛋️',
+        sql: build(sqlQueryEveningFavorite),
+    },
+    {
+        fact_type: 'night_favorite',
+        title: '🌙 Musical Insomnia',
+        emoji: '💤',
+        sql: build(sqlQueryNightFavorite),
+    },
+    {
+        fact_type: 'weekend_favorite',
+        title: '🎉 Weekend Vibes',
+        emoji: '🕺',
+        sql: build(sqlQueryWeekendFavorite),
+    },
+    {
+        fact_type: 'nostalgic_return',
+        title: '🕰️ Nostalgic Return',
+        emoji: '📼',
+        sql: build(sqlQueryNostalgicReturn),
+    },
+    {
+        fact_type: 'forgotten_artist',
+        title: '🕰️ Forgotten Artist',
+        emoji: '💔',
+        sql: build(sqlQueryForgottenArtist),
+    },
+    {
+        fact_type: 'absolute_loyalty',
+        title: '❤️ Absolute Loyalty',
+        emoji: '💍',
+        sql: build(sqlQueryAbsoluteLoyalty),
+    },
+    {
+        fact_type: 'subscribed_artist',
+        title: '🎸 Monthly Subscription',
+        emoji: '📬',
+        sql: build(sqlQuerySubscribedArtist),
+    },
+    {
+        fact_type: 'musical_anniversary',
+        title: '🎉 Musical Anniversary',
+        emoji: '🎂',
+        sql: build(sqlQueryMusicalAnniversary),
+    },
+    {
+        fact_type: 'first_artist',
+        title: '🦖 The Very First',
+        emoji: '1️⃣',
+        sql: build(sqlQueryFirstArtist),
+    },
+    {
+        fact_type: 'one_hit_wonder',
+        title: '⭐ One-Hit Wonder',
+        emoji: '🎵',
+        sql: build(sqlQueryOneHitWonder),
+    },
+    {
+        fact_type: 'variety_day',
+        title: '🌈 Variety Day',
+        emoji: '🎨',
+        sql: build(sqlQueryVarietyDay),
+    },
+    {
+        fact_type: 'binge_listener',
+        title: '🎧 Binge Listener',
+        emoji: '🎶',
+        sql: build(sqlQueryBingeListener),
+    },
+    {
+        fact_type: 'current_obsession',
+        title: '🔁 Current Obsession',
+        emoji: '🎯',
+        sql: build(sqlQueryCurrentObsession),
+    },
+    {
+        fact_type: 'recent_discovery',
+        title: '🎵 Recent Discovery',
+        emoji: '✨',
+        sql: build(sqlQueryRecentDiscovery),
+    },
+    {
+        fact_type: 'marathon',
+        title: '🏃 Marathon',
+        emoji: '☄️',
+        sql: build(sqlQueryMarathon),
+    },
+    {
+        fact_type: 'unbeatable_streak',
+        title: '🔥 Unbeatable Streak',
+        emoji: '🏆',
+        sql: build(sqlQueryUnbeatableStreak),
+    },
+    {
+        fact_type: 'track_proposition',
+        title: '🔮 Listening Proposition',
+        emoji: '🐙',
+        sql: build(sqlQueryTrackProposition),
+    },
+    {
+        fact_type: 'cozy_album',
+        title: '💿 Cozy Album',
+        emoji: '☁️',
+        sql: build(sqlQueryCozyAlbum),
+    },
+] as const


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

A fun fact is defined in two places: 
- `app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx`
- `app/src/components/Charts/SimpleCharts/FunFacts/queries.tsx`

## 🎹 Proposal

Merge fact metadata and query definitions into a single facts array.

## 🎶 Comments

Follow-up #366

## 🎤 Test

<!-- Instructions for reproducing the problem and how you tested the fix. -->
