### PR TITLE
fix(app): enable RF04 SQL linter rule and fix keyword identifier violations

### DIFF
--- a/app/.sqruff
+++ b/app/.sqruff
@@ -7,10 +7,7 @@ rules = all
 # RF02: Unqualified reference <reference> found in select with more than one referenced table/view.
 #       Too many warnings; to be corrected in separate PR
 #       https://github.com/Gudsfile/tracksy/issues/294
-# RF04: Keywords should not be used as identifiers
-#       Too many warnings; to be corrected in separate PR
-#       https://github.com/Gudsfile/tracksy/issues/293
-exclude_rules = ST07, RF02, RF04
+exclude_rules = ST07, RF02
 warn_unused_ignores = True
 max_line_length = 80
 
@@ -42,3 +39,11 @@ preferred_not_equal_style = c_style
 
 [sqruff:templater:placeholder]
 param_style = dollar
+# Provide non-keyword substitutions so the RF04 linter does not flag
+# ${table} -> "table" (a reserved word) as an identifier violation.
+table = listen_history
+year_condition = true
+order_condition = streaks desc
+# ${year} only appears inside SQL string literals (e.g. '${ year}-01-01'),
+# so this substitution is a no-op for linting but documents the expected type.
+year = 2024

--- a/app/src/components/Charts/DetailedCharts/ArtistDiscovery/ArtistDiscovery.sql
+++ b/app/src/components/Charts/DetailedCharts/ArtistDiscovery/ArtistDiscovery.sql
@@ -9,7 +9,7 @@ with artist_first_year as (
 
 yearly_discoveries as (
     select
-        discovery_year as year,
+        discovery_year as stream_year,
         count(*) as new_artists
     from artist_first_year
     group by discovery_year
@@ -23,31 +23,32 @@ year_bounds as (
 ),
 
 all_years as (
-    select year
+    select stream_year
     from year_bounds,
-        generate_series(min_year, max_year) as t (year)
+        generate_series(min_year, max_year) as t (stream_year)
 ),
 
 filled_years as (
     select
-        all_years.year,
+        all_years.stream_year,
         coalesce(yearly_discoveries.new_artists, 0) as new_artists
     from all_years as all_years
-    left join yearly_discoveries on all_years.year = yearly_discoveries.year
+    left join yearly_discoveries
+    on all_years.stream_year = yearly_discoveries.stream_year
 ),
 
 cumulative as (
     select
-        year,
+        stream_year,
         new_artists,
-        sum(new_artists) over (order by year) as cumulative_artists
+        sum(new_artists) over (order by stream_year) as cumulative_artists
     from filled_years
 ),
 
 artist_listens as (
     select
         artist_name as artist,
-        year(ts::date) as year,
+        year(ts::date) as stream_year,
         count(*) as listen_count
     from ${table}
     where artist_name is not null
@@ -56,19 +57,19 @@ artist_listens as (
 
 avg_listens as (
     select
-        year,
+        stream_year,
         avg(listen_count) as avg_listens_per_artist
     from artist_listens
-    group by year
+    group by stream_year
 )
 
 select
-    cumulative.year::int as year,
+    cumulative.stream_year::int as stream_year,
     cumulative.new_artists::double as new_artists,
     cumulative.cumulative_artists::double as cumulative_artists,
     coalesce(
         avg_listens.avg_listens_per_artist, 0
     )::double as avg_listens_per_artist
 from cumulative
-left join avg_listens on cumulative.year = avg_listens.year
-order by cumulative.year
+left join avg_listens on cumulative.stream_year = avg_listens.stream_year
+order by cumulative.stream_year

--- a/app/src/components/Charts/DetailedCharts/ArtistDiscovery/plot.tsx
+++ b/app/src/components/Charts/DetailedCharts/ArtistDiscovery/plot.tsx
@@ -54,19 +54,19 @@ export function ArtistDiscoveryPlot({
         if (mode === 'cumulative') {
             marks.push(
                 Plot.areaY(data, {
-                    x: 'year',
+                    x: 'stream_year',
                     y: 'cumulative_artists',
                     fill: 'url(#gradient-cumulative)',
                     fillOpacity: 0.3,
                 }),
                 Plot.lineY(data, {
-                    x: 'year',
+                    x: 'stream_year',
                     y: 'cumulative_artists',
                     stroke: '#8b5cf6',
                     strokeWidth: 2.5,
                 }),
                 Plot.dot(data, {
-                    x: 'year',
+                    x: 'stream_year',
                     y: 'cumulative_artists',
                     fill: '#8b5cf6',
                     r: 4,
@@ -77,13 +77,13 @@ export function ArtistDiscoveryPlot({
         if (mode === 'new') {
             marks.push(
                 Plot.lineY(data, {
-                    x: 'year',
+                    x: 'stream_year',
                     y: 'new_artists',
                     stroke: '#06b6d4',
                     strokeWidth: 2,
                 }),
                 Plot.dot(data, {
-                    x: 'year',
+                    x: 'stream_year',
                     y: 'new_artists',
                     fill: '#06b6d4',
                     r: 3,
@@ -95,7 +95,7 @@ export function ArtistDiscoveryPlot({
             Plot.lineY(
                 data,
                 Plot.mapY((D: number[]) => D.map(yAvg), {
-                    x: 'year',
+                    x: 'stream_year',
                     y: 'avg_listens_per_artist',
                     stroke: '#f59e0b',
                     strokeWidth: 2.5,

--- a/app/src/components/Charts/DetailedCharts/ArtistDiscovery/query.test.tsx
+++ b/app/src/components/Charts/DetailedCharts/ArtistDiscovery/query.test.tsx
@@ -31,30 +31,30 @@ describe('ArtistDiscovery Query', () => {
                 (
                     a: Record<string, DuckDBValue>,
                     b: Record<string, DuckDBValue>
-                ) => (a.year as number) - (b.year as number)
+                ) => (a.stream_year as number) - (b.stream_year as number)
             )
 
         expect(rows).toEqual([
             {
-                year: 2020,
+                stream_year: 2020,
                 new_artists: 2,
                 cumulative_artists: 2,
                 avg_listens_per_artist: 1.5,
             },
             {
-                year: 2021,
+                stream_year: 2021,
                 new_artists: 1,
                 cumulative_artists: 3,
                 avg_listens_per_artist: 1,
             },
             {
-                year: 2022,
+                stream_year: 2022,
                 new_artists: 0,
                 cumulative_artists: 3,
                 avg_listens_per_artist: 0,
             },
             {
-                year: 2023,
+                stream_year: 2023,
                 new_artists: 0,
                 cumulative_artists: 3,
                 avg_listens_per_artist: 2,

--- a/app/src/components/Charts/DetailedCharts/ArtistDiscovery/query.ts
+++ b/app/src/components/Charts/DetailedCharts/ArtistDiscovery/query.ts
@@ -2,7 +2,7 @@ import { TABLE } from '../../../../db/queries/constants'
 import sqlQueryArtistDiscovery from './ArtistDiscovery.sql?raw'
 
 export type ArtistDiscoveryQueryResult = {
-    year: number
+    stream_year: number
     new_artists: number
     cumulative_artists: number
     avg_listens_per_artist: number

--- a/app/src/components/Charts/DetailedCharts/Streaks/Streaks.sql
+++ b/app/src/components/Charts/DetailedCharts/Streaks/Streaks.sql
@@ -1,4 +1,4 @@
 select
-    day,
+    stream_date,
     1 as played
-from (select distinct ts::date::text as day from ${table})
+from (select distinct ts::date::text as stream_date from ${table})

--- a/app/src/components/Charts/DetailedCharts/Streaks/Streaks.tsx
+++ b/app/src/components/Charts/DetailedCharts/Streaks/Streaks.tsx
@@ -16,7 +16,9 @@ export function Streaks({ data }: Props) {
         if (!data || data.length === 0) return []
 
         const playedDates = Array.from(
-            new Set(data.map((item) => dayjs(item.day).format('YYYY-MM-DD')))
+            new Set(
+                data.map((item) => dayjs(item.stream_date).format('YYYY-MM-DD'))
+            )
         ).sort()
 
         const start = dayjs(playedDates[0])

--- a/app/src/components/Charts/DetailedCharts/Streaks/query.test.ts
+++ b/app/src/components/Charts/DetailedCharts/Streaks/query.test.ts
@@ -29,28 +29,31 @@ describe('Streaks Query', () => {
                 (
                     a: Record<string, DuckDBValue>,
                     b: Record<string, DuckDBValue>
-                ) => ((a.day as string) < (b.day as string) ? -1 : 1)
+                ) =>
+                    (a.stream_date as string) < (b.stream_date as string)
+                        ? -1
+                        : 1
             )
 
         expect(rows).toEqual([
             {
-                day: '2020-01-01',
+                stream_date: '2020-01-01',
                 played: 1,
             },
             {
-                day: '2020-01-02',
+                stream_date: '2020-01-02',
                 played: 1,
             },
             {
-                day: '2020-01-03',
+                stream_date: '2020-01-03',
                 played: 1,
             },
             {
-                day: '2020-01-10',
+                stream_date: '2020-01-10',
                 played: 1,
             },
             {
-                day: '2020-01-11',
+                stream_date: '2020-01-11',
                 played: 1,
             },
         ])

--- a/app/src/components/Charts/DetailedCharts/Streaks/query.ts
+++ b/app/src/components/Charts/DetailedCharts/Streaks/query.ts
@@ -6,6 +6,6 @@ export function queryStreaks() {
 }
 
 export type StreaksQueryResult = {
-    day: string
+    stream_date: string
     played: number
 }

--- a/app/src/components/Charts/DetailedCharts/StreamPerDayOfWeek/StreamPerDayOfWeek.sql
+++ b/app/src/components/Charts/DetailedCharts/StreamPerDayOfWeek/StreamPerDayOfWeek.sql
@@ -1,8 +1,8 @@
 select
     dayofweek(ts::date)::integer as day_of_week,
-    hour(ts::datetime)::integer as hour,
+    hour(ts::datetime)::integer as play_hour,
     count(*)::double as count_streams
 from ${table}
 where ${year_condition}
 group by dayofweek(ts::date), hour(ts::datetime)
-order by day_of_week, hour
+order by day_of_week, play_hour

--- a/app/src/components/Charts/DetailedCharts/StreamPerDayOfWeek/plot.tsx
+++ b/app/src/components/Charts/DetailedCharts/StreamPerDayOfWeek/plot.tsx
@@ -31,7 +31,7 @@ export function buildPlot(
         },
         marks: [
             Plot.rect(data, {
-                x: 'hour',
+                x: 'play_hour',
                 y: 'day_of_week',
                 fill: 'count_streams',
                 tip: {

--- a/app/src/components/Charts/DetailedCharts/StreamPerDayOfWeek/query.test.ts
+++ b/app/src/components/Charts/DetailedCharts/StreamPerDayOfWeek/query.test.ts
@@ -26,14 +26,14 @@ describe('StreamPerDayOfWeek query', () => {
         )
         const rows = result.getRowObjects()
         expect(rows).toEqual([
-            { day_of_week: 0, hour: 4, count_streams: 1 },
-            { day_of_week: 1, hour: 4, count_streams: 2 },
-            { day_of_week: 1, hour: 10, count_streams: 1 },
-            { day_of_week: 2, hour: 6, count_streams: 1 },
-            { day_of_week: 3, hour: 4, count_streams: 1 },
-            { day_of_week: 5, hour: 4, count_streams: 2 },
-            { day_of_week: 5, hour: 10, count_streams: 1 },
-            { day_of_week: 6, hour: 6, count_streams: 1 },
+            { day_of_week: 0, play_hour: 4, count_streams: 1 },
+            { day_of_week: 1, play_hour: 4, count_streams: 2 },
+            { day_of_week: 1, play_hour: 10, count_streams: 1 },
+            { day_of_week: 2, play_hour: 6, count_streams: 1 },
+            { day_of_week: 3, play_hour: 4, count_streams: 1 },
+            { day_of_week: 5, play_hour: 4, count_streams: 2 },
+            { day_of_week: 5, play_hour: 10, count_streams: 1 },
+            { day_of_week: 6, play_hour: 6, count_streams: 1 },
         ])
     })
 
@@ -43,10 +43,10 @@ describe('StreamPerDayOfWeek query', () => {
         )
         const rows = result.getRowObjects()
         expect(rows).toEqual([
-            { day_of_week: 0, hour: 4, count_streams: 1 },
-            { day_of_week: 5, hour: 4, count_streams: 2 },
-            { day_of_week: 5, hour: 10, count_streams: 1 },
-            { day_of_week: 6, hour: 6, count_streams: 1 },
+            { day_of_week: 0, play_hour: 4, count_streams: 1 },
+            { day_of_week: 5, play_hour: 4, count_streams: 2 },
+            { day_of_week: 5, play_hour: 10, count_streams: 1 },
+            { day_of_week: 6, play_hour: 6, count_streams: 1 },
         ])
     })
 })

--- a/app/src/components/Charts/DetailedCharts/StreamPerDayOfWeek/query.ts
+++ b/app/src/components/Charts/DetailedCharts/StreamPerDayOfWeek/query.ts
@@ -11,6 +11,6 @@ export function streamPerDayOfWeekQueryByYear(year: number | undefined) {
 
 export type StreamPerDayOfWeekQueryResult = {
     day_of_week: number
-    hour: number
+    play_hour: number
     count_streams: number
 }

--- a/app/src/components/Charts/DetailedCharts/StreamPerMonth/StreamPerMonth.sql
+++ b/app/src/components/Charts/DetailedCharts/StreamPerMonth/StreamPerMonth.sql
@@ -1,5 +1,5 @@
 with all_months as (
-    select last_day(month) as ts
+    select last_day(month_start) as ts
     from generate_series(
         (
             select date_trunc('year', min(ts::date))
@@ -15,7 +15,7 @@ with all_months as (
             where ${year_condition}
         ),
         interval 1 month
-    ) as t (month)
+    ) as t (month_start)
 ),
 
 monthly_streams as (

--- a/app/src/components/Charts/DetailedCharts/Top10AlbumsEvolution/Top10AlbumsEvolution.sql
+++ b/app/src/components/Charts/DetailedCharts/Top10AlbumsEvolution/Top10AlbumsEvolution.sql
@@ -8,7 +8,7 @@ album_listening as (
     select
         album_name,
         artist_name,
-        year(ts::date)::int as year,
+        year(ts::date)::int as stream_year,
         count(*) as playing_days_count
     from ${table}, max_date
     group by album_name, artist_name, ts::date
@@ -19,12 +19,12 @@ album_listening as (
 
 album_yearly_play_counts as (
     select
-        year,
+        stream_year,
         album_name as album,
         artist_name as artist,
         count(*)::int as play_count
     from album_listening
-    group by year, album_name, artist_name
+    group by stream_year, album_name, artist_name
 ),
 
 album_total_play_counts as (
@@ -47,22 +47,22 @@ top_10_global_albums as (
 
 yearly_ranks as (
     select
-        year,
+        stream_year,
         album,
         artist,
         play_count,
         row_number()
-            over (partition by year order by play_count desc)
-        ::int as rank
+            over (partition by stream_year order by play_count desc)
+        ::int as stream_rank
     from album_yearly_play_counts
 )
 
 select
-    yr.year,
+    yr.stream_year,
     yr.album,
     yr.artist,
-    yr.rank,
+    yr.stream_rank,
     yr.play_count
 from yearly_ranks as yr
 inner join top_10_global_albums using (artist, album)
-order by yr.year, yr.rank
+order by yr.stream_year, yr.stream_rank

--- a/app/src/components/Charts/DetailedCharts/Top10AlbumsEvolution/plot.tsx
+++ b/app/src/components/Charts/DetailedCharts/Top10AlbumsEvolution/plot.tsx
@@ -20,7 +20,7 @@ export function Top10AlbumsEvolutionPlot({
 
         const sortedData = [...data].sort((a, b) => {
             if (a.album !== b.album) return a.album.localeCompare(b.album)
-            return a.year - b.year
+            return a.stream_year - b.stream_year
         })
 
         const albumLastPoints = Array.from(
@@ -31,7 +31,7 @@ export function Top10AlbumsEvolutionPlot({
         })
 
         const sortedLabels = [...albumLastPoints].sort(
-            (a, b) => a.rank - b.rank
+            (a, b) => a.stream_rank - b.stream_rank
         )
         const labelsEven = sortedLabels.filter((_, i) => i % 2 === 0)
         const labelsOdd = sortedLabels.filter((_, i) => i % 2 === 1)
@@ -61,21 +61,21 @@ export function Top10AlbumsEvolutionPlot({
             },
             marks: [
                 Plot.lineY(sortedData, {
-                    x: 'year',
-                    y: 'rank',
+                    x: 'stream_year',
+                    y: 'stream_rank',
                     stroke: 'album',
                     strokeWidth: 2.5,
                 }),
                 Plot.dot(sortedData, {
-                    x: 'year',
-                    y: 'rank',
+                    x: 'stream_year',
+                    y: 'stream_rank',
                     fill: 'album',
                     r: 4,
                 }),
 
                 Plot.text(labelsEven, {
-                    x: 'year',
-                    y: 'rank',
+                    x: 'stream_year',
+                    y: 'stream_rank',
                     text: 'album',
                     fill: 'album',
                     dx: 10,
@@ -85,8 +85,8 @@ export function Top10AlbumsEvolutionPlot({
                     fontWeight: 'bold',
                 }),
                 Plot.text(labelsOdd, {
-                    x: 'year',
-                    y: 'rank',
+                    x: 'stream_year',
+                    y: 'stream_rank',
                     text: 'album',
                     fill: 'album',
                     dx: 10,
@@ -98,10 +98,10 @@ export function Top10AlbumsEvolutionPlot({
                 Plot.tip(
                     sortedData,
                     Plot.pointerX({
-                        x: 'year',
-                        y: 'rank',
+                        x: 'stream_year',
+                        y: 'stream_rank',
                         title: (d) =>
-                            `${d.album} - ${d.artist}\nRank: ${d.rank}\nYear: ${d.year}\nCount: ${d.play_count}`,
+                            `${d.album} - ${d.artist}\nRank: ${d.stream_rank}\nYear: ${d.stream_year}\nCount: ${d.play_count}`,
                     })
                 ),
             ],

--- a/app/src/components/Charts/DetailedCharts/Top10AlbumsEvolution/query.test.ts
+++ b/app/src/components/Charts/DetailedCharts/Top10AlbumsEvolution/query.test.ts
@@ -30,44 +30,44 @@ describe('queryTop10AlbumsEvolution Query', () => {
                     a: Record<string, DuckDBValue>,
                     b: Record<string, DuckDBValue>
                 ) =>
-                    (a.year as number) - (b.year as number) ||
-                    (a.rank as number) - (b.rank as number)
+                    (a.stream_year as number) - (b.stream_year as number) ||
+                    (a.stream_rank as number) - (b.stream_rank as number)
             )
 
         expect(rows).toEqual([
             {
-                year: 2020,
+                stream_year: 2020,
                 album: 'album_a',
                 artist: 'artist_a',
-                rank: 1,
+                stream_rank: 1,
                 play_count: 3,
             },
             {
-                year: 2020,
+                stream_year: 2020,
                 album: 'album_b',
                 artist: 'artist_b',
-                rank: 2,
+                stream_rank: 2,
                 play_count: 2,
             },
             {
-                year: 2020,
+                stream_year: 2020,
                 album: 'album_c',
                 artist: 'artist_c',
-                rank: 3,
+                stream_rank: 3,
                 play_count: 1,
             },
             {
-                year: 2021,
+                stream_year: 2021,
                 album: 'album_b',
                 artist: 'artist_b',
-                rank: 1,
+                stream_rank: 1,
                 play_count: 2,
             },
             {
-                year: 2021,
+                stream_year: 2021,
                 album: 'album_a',
                 artist: 'artist_a',
-                rank: 2,
+                stream_rank: 2,
                 play_count: 1,
             },
         ])

--- a/app/src/components/Charts/DetailedCharts/Top10AlbumsEvolution/query.ts
+++ b/app/src/components/Charts/DetailedCharts/Top10AlbumsEvolution/query.ts
@@ -6,9 +6,9 @@ export function queryTop10AlbumsEvolution() {
 }
 
 export type Top10AlbumsEvolutionQueryResult = {
-    year: number
+    stream_year: number
     album: string
     artist: string
-    rank: number
+    stream_rank: number
     play_count: number
 }

--- a/app/src/components/Charts/DetailedCharts/Top10Evolution/Top10Evolution.sql
+++ b/app/src/components/Charts/DetailedCharts/Top10Evolution/Top10Evolution.sql
@@ -1,11 +1,11 @@
 with artist_yearly_play_counts as (
     select
-        year(ts::datetime)::int as year,
+        year(ts::datetime)::int as stream_year,
         artist_name as artist,
         count(*)::int as play_count
     from ${table}
     where artist_name is not null
-    group by year, artist
+    group by stream_year, artist
 ),
 
 artist_total_play_counts as (
@@ -25,20 +25,20 @@ top_10_global_artists as (
 
 yearly_ranks as (
     select
-        year,
+        stream_year,
         artist,
         play_count,
         row_number()
-            over (partition by year order by play_count desc)
-        ::int as rank
+            over (partition by stream_year order by play_count desc)
+        ::int as stream_rank
     from artist_yearly_play_counts
 )
 
 select
-    yr.year,
+    yr.stream_year,
     yr.artist,
-    yr.rank,
+    yr.stream_rank,
     yr.play_count
 from yearly_ranks as yr
 inner join top_10_global_artists as t10 on yr.artist = t10.artist
-order by yr.year, yr.rank
+order by yr.stream_year, yr.stream_rank

--- a/app/src/components/Charts/DetailedCharts/Top10Evolution/plot.tsx
+++ b/app/src/components/Charts/DetailedCharts/Top10Evolution/plot.tsx
@@ -20,7 +20,7 @@ export function Top10EvolutionPlot({
 
         const sortedData = [...data].sort((a, b) => {
             if (a.artist !== b.artist) return a.artist.localeCompare(b.artist)
-            return a.year - b.year
+            return a.stream_year - b.stream_year
         })
 
         const artistLastPoints = Array.from(
@@ -31,7 +31,7 @@ export function Top10EvolutionPlot({
         })
 
         const sortedLabels = [...artistLastPoints].sort(
-            (a, b) => a.rank - b.rank
+            (a, b) => a.stream_rank - b.stream_rank
         )
         const labelsEven = sortedLabels.filter((_, i) => i % 2 === 0)
         const labelsOdd = sortedLabels.filter((_, i) => i % 2 === 1)
@@ -61,21 +61,21 @@ export function Top10EvolutionPlot({
             },
             marks: [
                 Plot.lineY(sortedData, {
-                    x: 'year',
-                    y: 'rank',
+                    x: 'stream_year',
+                    y: 'stream_rank',
                     stroke: 'artist',
                     strokeWidth: 2.5,
                 }),
                 Plot.dot(sortedData, {
-                    x: 'year',
-                    y: 'rank',
+                    x: 'stream_year',
+                    y: 'stream_rank',
                     fill: 'artist',
                     r: 4,
                 }),
 
                 Plot.text(labelsEven, {
-                    x: 'year',
-                    y: 'rank',
+                    x: 'stream_year',
+                    y: 'stream_rank',
                     text: 'artist',
                     fill: 'artist',
                     dx: 10,
@@ -85,8 +85,8 @@ export function Top10EvolutionPlot({
                     fontWeight: 'bold',
                 }),
                 Plot.text(labelsOdd, {
-                    x: 'year',
-                    y: 'rank',
+                    x: 'stream_year',
+                    y: 'stream_rank',
                     text: 'artist',
                     fill: 'artist',
                     dx: 10,
@@ -98,10 +98,10 @@ export function Top10EvolutionPlot({
                 Plot.tip(
                     sortedData,
                     Plot.pointerX({
-                        x: 'year',
-                        y: 'rank',
+                        x: 'stream_year',
+                        y: 'stream_rank',
                         title: (d) =>
-                            `${d.artist}\nRank: ${d.rank}\nYear: ${d.year}`,
+                            `${d.artist}\nRank: ${d.stream_rank}\nYear: ${d.stream_year}`,
                     })
                 ),
             ],

--- a/app/src/components/Charts/DetailedCharts/Top10Evolution/query.test.ts
+++ b/app/src/components/Charts/DetailedCharts/Top10Evolution/query.test.ts
@@ -30,39 +30,39 @@ describe('Top10Evolution Query', () => {
                     a: Record<string, DuckDBValue>,
                     b: Record<string, DuckDBValue>
                 ) =>
-                    (a.year as number) - (b.year as number) ||
-                    (a.rank as number) - (b.rank as number)
+                    (a.stream_year as number) - (b.stream_year as number) ||
+                    (a.stream_rank as number) - (b.stream_rank as number)
             )
 
         expect(rows).toEqual([
             {
-                year: 2020,
+                stream_year: 2020,
                 artist: 'Artist A',
-                rank: 1,
+                stream_rank: 1,
                 play_count: 3,
             },
             {
-                year: 2020,
+                stream_year: 2020,
                 artist: 'Artist B',
-                rank: 2,
+                stream_rank: 2,
                 play_count: 2,
             },
             {
-                year: 2020,
+                stream_year: 2020,
                 artist: 'Artist C',
-                rank: 3,
+                stream_rank: 3,
                 play_count: 1,
             },
             {
-                year: 2021,
+                stream_year: 2021,
                 artist: 'Artist B',
-                rank: 1,
+                stream_rank: 1,
                 play_count: 2,
             },
             {
-                year: 2021,
+                stream_year: 2021,
                 artist: 'Artist A',
-                rank: 2,
+                stream_rank: 2,
                 play_count: 1,
             },
         ])

--- a/app/src/components/Charts/DetailedCharts/Top10Evolution/query.ts
+++ b/app/src/components/Charts/DetailedCharts/Top10Evolution/query.ts
@@ -6,8 +6,8 @@ export function queryTop10Evolution() {
 }
 
 export type Top10EvolutionQueryResult = {
-    year: number
+    stream_year: number
     artist: string
-    rank: number
+    stream_rank: number
     play_count: number
 }

--- a/app/src/components/Charts/DetailedCharts/Top10TracksEvolution/Top10TracksEvolution.sql
+++ b/app/src/components/Charts/DetailedCharts/Top10TracksEvolution/Top10TracksEvolution.sql
@@ -1,12 +1,12 @@
 with track_yearly_play_counts as (
     select
-        year(ts::datetime)::int as year,
+        year(ts::datetime)::int as stream_year,
         track_name,
         artist_name,
         count(*)::int as play_count
     from ${table}
     where track_name is not null
-    group by year, track_name, artist_name
+    group by stream_year, track_name, artist_name
 ),
 
 track_total_play_counts as (
@@ -29,25 +29,25 @@ top_10_global_tracks as (
 
 yearly_ranks as (
     select
-        year,
+        stream_year,
         track_name,
         artist_name,
         play_count,
         row_number()
-            over (partition by year order by play_count desc)
-        ::int as rank
+            over (partition by stream_year order by play_count desc)
+        ::int as stream_rank
     from track_yearly_play_counts
 )
 
 select
-    yr.year,
+    yr.stream_year,
     yr.track_name as track,
     yr.artist_name as artist,
-    yr.rank,
+    yr.stream_rank,
     yr.play_count
 from yearly_ranks as yr
 inner join
     top_10_global_tracks
 on yr.track_name = top_10_global_tracks.track_name
 and yr.artist_name = top_10_global_tracks.artist_name
-order by yr.year, yr.rank
+order by yr.stream_year, yr.stream_rank

--- a/app/src/components/Charts/DetailedCharts/Top10TracksEvolution/plot.tsx
+++ b/app/src/components/Charts/DetailedCharts/Top10TracksEvolution/plot.tsx
@@ -20,7 +20,7 @@ export function Top10TracksEvolutionPlot({
 
         const sortedData = [...data].sort((a, b) => {
             if (a.track !== b.track) return a.track.localeCompare(b.track)
-            return a.year - b.year
+            return a.stream_year - b.stream_year
         })
 
         const trackLastPoints = Array.from(
@@ -31,7 +31,7 @@ export function Top10TracksEvolutionPlot({
         })
 
         const sortedLabels = [...trackLastPoints].sort(
-            (a, b) => a.rank - b.rank
+            (a, b) => a.stream_rank - b.stream_rank
         )
         const labelsEven = sortedLabels.filter((_, i) => i % 2 === 0)
         const labelsOdd = sortedLabels.filter((_, i) => i % 2 === 1)
@@ -61,21 +61,21 @@ export function Top10TracksEvolutionPlot({
             },
             marks: [
                 Plot.lineY(sortedData, {
-                    x: 'year',
-                    y: 'rank',
+                    x: 'stream_year',
+                    y: 'stream_rank',
                     stroke: 'track',
                     strokeWidth: 2.5,
                 }),
                 Plot.dot(sortedData, {
-                    x: 'year',
-                    y: 'rank',
+                    x: 'stream_year',
+                    y: 'stream_rank',
                     fill: 'track',
                     r: 4,
                 }),
 
                 Plot.text(labelsEven, {
-                    x: 'year',
-                    y: 'rank',
+                    x: 'stream_year',
+                    y: 'stream_rank',
                     text: 'track',
                     fill: 'track',
                     dx: 10,
@@ -85,8 +85,8 @@ export function Top10TracksEvolutionPlot({
                     fontWeight: 'bold',
                 }),
                 Plot.text(labelsOdd, {
-                    x: 'year',
-                    y: 'rank',
+                    x: 'stream_year',
+                    y: 'stream_rank',
                     text: 'track',
                     fill: 'track',
                     dx: 10,
@@ -98,10 +98,10 @@ export function Top10TracksEvolutionPlot({
                 Plot.tip(
                     sortedData,
                     Plot.pointerX({
-                        x: 'year',
-                        y: 'rank',
+                        x: 'stream_year',
+                        y: 'stream_rank',
                         title: (d) =>
-                            `${d.track} - ${d.artist}\nRank: ${d.rank}\nYear: ${d.year}\nCount: ${d.play_count}`,
+                            `${d.track} - ${d.artist}\nRank: ${d.stream_rank}\nYear: ${d.stream_year}\nCount: ${d.play_count}`,
                     })
                 ),
             ],

--- a/app/src/components/Charts/DetailedCharts/Top10TracksEvolution/query.test.ts
+++ b/app/src/components/Charts/DetailedCharts/Top10TracksEvolution/query.test.ts
@@ -30,31 +30,31 @@ describe('queryTop10TracksEvolution Query', () => {
                     a: Record<string, DuckDBValue>,
                     b: Record<string, DuckDBValue>
                 ) =>
-                    (a.year as number) - (b.year as number) ||
-                    (a.rank as number) - (b.rank as number)
+                    (a.stream_year as number) - (b.stream_year as number) ||
+                    (a.stream_rank as number) - (b.stream_rank as number)
             )
 
         expect(rows).toEqual([
             {
                 artist: 'artist_b',
                 play_count: 3,
-                rank: 1,
+                stream_rank: 1,
                 track: 'track_1',
-                year: 2020,
+                stream_year: 2020,
             },
             {
                 artist: 'artist_a',
                 play_count: 2,
-                rank: 2,
+                stream_rank: 2,
                 track: 'track_2',
-                year: 2020,
+                stream_year: 2020,
             },
             {
                 artist: 'artist_a',
                 play_count: 1,
-                rank: 3,
+                stream_rank: 3,
                 track: 'track_1',
-                year: 2020,
+                stream_year: 2020,
             },
         ])
     })

--- a/app/src/components/Charts/DetailedCharts/Top10TracksEvolution/query.ts
+++ b/app/src/components/Charts/DetailedCharts/Top10TracksEvolution/query.ts
@@ -6,9 +6,9 @@ export function queryTop10TracksEvolution() {
 }
 
 export type Top10TracksEvolutionQueryResult = {
-    year: number
+    stream_year: number
     track: string
     artist: string
-    rank: number
+    stream_rank: number
     play_count: number
 }

--- a/app/src/components/Charts/DetailedCharts/TopStreak/TopStreak.sql
+++ b/app/src/components/Charts/DetailedCharts/TopStreak/TopStreak.sql
@@ -1,22 +1,21 @@
 with dates as (
-    select distinct ts::date as date
+    select distinct ts::date as stream_date
     from ${table}
 ),
 
-groups as (
+streak_groups as (
     select
-        date,
-        date_add(
-            date, interval '-1' day * (row_number() over (order by date))
-        ) as grp
+        stream_date,
+        stream_date
+        - (row_number() over (order by stream_date) - 1)::int as grp
     from dates
 )
 
 select
     count(*)::integer as streaks,
-    min(date) as start_ts,
-    max(date) as end_ts
-from groups
+    min(stream_date) as start_ts,
+    max(stream_date) as end_ts
+from streak_groups
 group by grp
 order by ${order_condition}
 limit 1

--- a/app/src/components/Charts/DetailedCharts/TopStreak/query.test.ts
+++ b/app/src/components/Charts/DetailedCharts/TopStreak/query.test.ts
@@ -39,4 +39,29 @@ describe('TopStreak query', () => {
         expect(row.start_ts).toBe('2025-10-17')
         expect(row.end_ts).toBe('2025-10-19')
     })
+
+    it('treats a gap in dates as a streak break', async () => {
+        // Verify the DATE - INTEGER grouping correctly isolates non-consecutive days.
+        // The seed has a 5-day streak (Jan 1–5) and a 3-day streak (Oct 17–19)
+        // with a multi-month gap between them. queryTopStreak must NOT merge them.
+        const result = await conn.runAndReadAll(queryTopStreak())
+        const rows = result.getRowObjectsJson()
+        const top = rows[0]
+        // The top streak is the 5-day Jan block, not a merged 8-day block
+        expect(top.streaks).toBe(5)
+        expect(top.end_ts).toBe('2025-01-05')
+    })
+
+    it('returns streak of 1 when only a single date exists', async () => {
+        await conn.run(
+            `CREATE OR REPLACE TABLE ${TABLE} AS
+             SELECT '2025-06-15T12:00:00Z'::timestamp AS ts`
+        )
+        const result = await conn.runAndReadAll(queryTopStreak())
+        const rows = result.getRowObjectsJson()
+        expect(rows.length).toBe(1)
+        expect(rows[0].streaks).toBe(1)
+        expect(rows[0].start_ts).toBe('2025-06-15')
+        expect(rows[0].end_ts).toBe('2025-06-15')
+    })
 })

--- a/app/src/components/Charts/SimpleCharts/CalendarHeatmap/CalendarHeatmap.sql
+++ b/app/src/components/Charts/SimpleCharts/CalendarHeatmap/CalendarHeatmap.sql
@@ -1,6 +1,6 @@
 select
-    day::varchar as day,
+    stream_date::varchar as stream_date,
     stream_count::double as stream_count
 from ${table}
 where ${year_condition}
-order by day
+order by stream_date

--- a/app/src/components/Charts/SimpleCharts/CalendarHeatmap/CalendarHeatmap.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/CalendarHeatmap/CalendarHeatmap.test.tsx
@@ -21,7 +21,7 @@ describe('CalendarHeatmap', () => {
     })
 
     it('renders cells for the full year including leading/trailing nulls', () => {
-        const data = [{ day: '2025-06-15', stream_count: 5 }]
+        const data = [{ stream_date: '2025-06-15', stream_count: 5 }]
         const { container } = render(
             <CalendarHeatmap data={data} year={2025} />
         )
@@ -31,7 +31,7 @@ describe('CalendarHeatmap', () => {
     })
 
     it('shows tooltip on cell hover', () => {
-        const data = [{ day: '2025-06-15', stream_count: 5 }]
+        const data = [{ stream_date: '2025-06-15', stream_count: 5 }]
         const { container } = render(
             <CalendarHeatmap data={data} year={2025} />
         )

--- a/app/src/components/Charts/SimpleCharts/CalendarHeatmap/buildCells.test.ts
+++ b/app/src/components/Charts/SimpleCharts/CalendarHeatmap/buildCells.test.ts
@@ -18,13 +18,19 @@ describe('buildCells', () => {
     })
 
     it('fills stream_count from the provided data', () => {
-        const cells = buildCells([{ day: '2025-03-15', stream_count: 7 }], 2025)
+        const cells = buildCells(
+            [{ stream_date: '2025-03-15', stream_count: 7 }],
+            2025
+        )
         const target = cells.find((c) => c.date === '2025-03-15')
         expect(target?.stream_count).toBe(7)
     })
 
     it('leaves other days at zero when only one day has data', () => {
-        const cells = buildCells([{ day: '2025-06-01', stream_count: 3 }], 2025)
+        const cells = buildCells(
+            [{ stream_date: '2025-06-01', stream_count: 3 }],
+            2025
+        )
         const others = cells.filter((c) => c.date !== '2025-06-01')
         expect(others.every((c) => c.stream_count === 0)).toBe(true)
     })

--- a/app/src/components/Charts/SimpleCharts/CalendarHeatmap/buildCells.ts
+++ b/app/src/components/Charts/SimpleCharts/CalendarHeatmap/buildCells.ts
@@ -18,7 +18,7 @@ export function buildCells(
     data: CalendarHeatmapQueryResult[],
     year: number
 ): DayCell[] {
-    const countByDay = new Map(data.map((d) => [d.day, d.stream_count]))
+    const countByDay = new Map(data.map((d) => [d.stream_date, d.stream_count]))
     const jan1DayOfWeek = new Date(year, 0, 1).getDay()
 
     const cells: DayCell[] = []

--- a/app/src/components/Charts/SimpleCharts/CalendarHeatmap/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/CalendarHeatmap/query.test.ts
@@ -17,7 +17,7 @@ describe('CalendarHeatmap Query', () => {
     beforeEach(async () => {
         await conn.run(`
             CREATE OR REPLACE TABLE ${DAILY_STREAM_COUNTS_TABLE} (
-                day DATE,
+                stream_date DATE,
                 stream_count BIGINT,
                 ms_played BIGINT
             )
@@ -44,17 +44,17 @@ describe('CalendarHeatmap Query', () => {
         expect(rows).toHaveLength(3)
     })
 
-    it('should return day as a YYYY-MM-DD string and stream_count as a number', async () => {
+    it('should return stream_date as a YYYY-MM-DD string and stream_count as a number', async () => {
         const result = await conn.runAndReadAll(buildCalendarHeatmapQuery(2025))
         const rows = result.getRowObjectsJson()
-        expect(rows[0].day).toBe('2025-01-01')
+        expect(rows[0].stream_date).toBe('2025-01-01')
         expect(rows[0].stream_count).toBe(5)
     })
 
-    it('should order results by day ascending', async () => {
+    it('should order results by stream_date ascending', async () => {
         const result = await conn.runAndReadAll(buildCalendarHeatmapQuery(2025))
         const rows = result.getRowObjectsJson()
-        expect(rows[0].day).toBe('2025-01-01')
-        expect(rows[1].day).toBe('2025-01-15')
+        expect(rows[0].stream_date).toBe('2025-01-01')
+        expect(rows[1].stream_date).toBe('2025-01-15')
     })
 })

--- a/app/src/components/Charts/SimpleCharts/CalendarHeatmap/query.ts
+++ b/app/src/components/Charts/SimpleCharts/CalendarHeatmap/query.ts
@@ -3,12 +3,12 @@ import sqlQueryCalendarHeatmap from './CalendarHeatmap.sql?raw'
 import { DAILY_STREAM_COUNTS_TABLE } from '../../../../db/queries/constants'
 
 export type CalendarHeatmapQueryResult = {
-    day: string
+    stream_date: string
     stream_count: number
 }
 
 export function buildCalendarHeatmapQuery(year: number | undefined): string {
-    const yearCondition = buildYearCondition(year, 'year(day)')
+    const yearCondition = buildYearCondition(year, 'year(stream_date)')
     return sqlQueryCalendarHeatmap
         .replaceAll('${table}', DAILY_STREAM_COUNTS_TABLE)
         .replaceAll('${year_condition}', yearCondition)

--- a/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.sql
+++ b/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.sql
@@ -1,6 +1,6 @@
 select
-    year(ts::date)::integer as year,
-    count(*)::double as streams,
+    year(ts::date)::integer as stream_year,
+    count(*)::double as stream_count,
     sum(ms_played)::double as ms_played
 from ${table}
 group by year(ts::date)

--- a/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.test.tsx
@@ -10,9 +10,9 @@ describe('EvolutionOverTime Component', () => {
 
     it('renders correctly with data', () => {
         const data = [
-            { year: 2020, streams: 100, ms_played: 60 * 60 * 1000 },
-            { year: 2021, streams: 150, ms_played: 60 * 60 * 1000 },
-            { year: 2022, streams: 200, ms_played: 60 * 60 * 1000 },
+            { stream_year: 2020, stream_count: 100, ms_played: 60 * 60 * 1000 },
+            { stream_year: 2021, stream_count: 150, ms_played: 60 * 60 * 1000 },
+            { stream_year: 2022, stream_count: 200, ms_played: 60 * 60 * 1000 },
         ]
         const currentYear = 2022
 
@@ -25,9 +25,17 @@ describe('EvolutionOverTime Component', () => {
 
     it('shows tooltip on bar hover', () => {
         const data = [
-            { year: 2020, streams: 100, ms_played: 60 * 60 * 1000 },
-            { year: 2021, streams: 150, ms_played: 2 * 60 * 60 * 1000 },
-            { year: 2022, streams: 200, ms_played: 3 * 60 * 60 * 1000 },
+            { stream_year: 2020, stream_count: 100, ms_played: 60 * 60 * 1000 },
+            {
+                stream_year: 2021,
+                stream_count: 150,
+                ms_played: 2 * 60 * 60 * 1000,
+            },
+            {
+                stream_year: 2022,
+                stream_count: 200,
+                ms_played: 3 * 60 * 60 * 1000,
+            },
         ]
 
         render(<EvolutionOverTime data={data} year={2022} />)

--- a/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.tsx
+++ b/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.tsx
@@ -8,7 +8,7 @@ type TooltipState = {
     x: number
     y: number
     year: number
-    streams: number
+    count: number
     ms_played: number
 }
 
@@ -21,13 +21,16 @@ type Props = {
 export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
     const [tooltip, setTooltip] = useState<TooltipState | null>(null)
     const maxStreams = data?.length
-        ? Math.max(...data.map((d) => d.streams))
+        ? Math.max(...data.map((d) => d.stream_count))
         : 0
-    const currentYearData = data?.find((d) => d.year === year)
-    const totalStreams = data?.reduce((acc, curr) => acc + curr.streams, 0) ?? 0
+    const currentYearData = data?.find((d) => d.stream_year === year)
+    const totalStreams =
+        data?.reduce((acc, curr) => acc + curr.stream_count, 0) ?? 0
     const totalMsPlayed =
         data?.reduce((acc, curr) => acc + curr.ms_played, 0) ?? 0
-    const startYear = data?.length ? Math.min(...data.map((d) => d.year)) : 0
+    const startYear = data?.length
+        ? Math.min(...data.map((d) => d.stream_year))
+        : 0
 
     return (
         <ChartCard
@@ -46,10 +49,10 @@ export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
                         onMouseLeave={() => setTooltip(null)}
                     >
                         {data.map((d) => {
-                            const height = (d.streams / maxStreams) * 100
+                            const height = (d.stream_count / maxStreams) * 100
                             return (
                                 <div
-                                    key={d.year}
+                                    key={d.stream_year}
                                     className="flex-1 bg-brand-blue dark:bg-brand-blue rounded-t relative"
                                     style={{ height: `${height}%` }}
                                     onMouseEnter={(e) => {
@@ -59,15 +62,15 @@ export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
                                         setTooltip({
                                             x: rect.left + rect.width / 2,
                                             y: rect.top,
-                                            year: d.year,
-                                            streams: d.streams,
+                                            year: d.stream_year,
+                                            count: d.stream_count,
                                             ms_played: d.ms_played,
                                         })
                                     }}
                                 >
                                     <div
                                         className={`absolute bottom-0 left-0 right-0 bg-brand-blue rounded-t transition-all duration-300 ${
-                                            d.year === year
+                                            d.stream_year === year
                                                 ? 'bg-brand-purple'
                                                 : ''
                                         }`}
@@ -79,7 +82,9 @@ export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
                     </div>
                     <div className="flex justify-between text-xs text-gray-600 dark:text-gray-400 px-1">
                         <span>{startYear}</span>
-                        <span>{Math.max(...data.map((d) => d.year))}</span>
+                        <span>
+                            {Math.max(...data.map((d) => d.stream_year))}
+                        </span>
                     </div>
 
                     <ul
@@ -106,7 +111,7 @@ export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
                                     This year
                                 </span>
                                 <span className="font-bold text-brand-purple dark:text-brand-purple">
-                                    {currentYearData.streams.toLocaleString()}
+                                    {currentYearData.stream_count.toLocaleString()}
                                 </span>
                             </li>
                         )}
@@ -117,7 +122,7 @@ export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
                 <ChartTooltip x={tooltip.x} y={tooltip.y}>
                     <div className="font-semibold">{tooltip.year}</div>
                     <div className="text-gray-300 dark:text-gray-400">
-                        {tooltip.streams.toLocaleString()} streams
+                        {tooltip.count.toLocaleString()} streams
                     </div>
                     <div className="text-gray-300 dark:text-gray-400">
                         {formatDuration(tooltip.ms_played)}

--- a/app/src/components/Charts/SimpleCharts/EvolutionOverTime/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/EvolutionOverTime/query.test.ts
@@ -36,10 +36,10 @@ describe('EvolutionOverTime Query', () => {
         const rows = await testQuery(conn, queryEvolutionOverTime())
 
         expect(rows).toEqual([
-            { year: 2006, streams: 1, ms_played: 1 },
-            { year: 2018, streams: 1, ms_played: 2 },
-            { year: 2024, streams: 2, ms_played: 7 },
-            { year: 2025, streams: 1, ms_played: 5 },
+            { stream_year: 2006, stream_count: 1, ms_played: 1 },
+            { stream_year: 2018, stream_count: 1, ms_played: 2 },
+            { stream_year: 2024, stream_count: 2, ms_played: 7 },
+            { stream_year: 2025, stream_count: 1, ms_played: 5 },
         ])
     })
 })

--- a/app/src/components/Charts/SimpleCharts/EvolutionOverTime/query.ts
+++ b/app/src/components/Charts/SimpleCharts/EvolutionOverTime/query.ts
@@ -2,8 +2,8 @@ import { TABLE } from '../../../../db/queries/constants'
 import sqlQueryEvolutionOverTime from './EvolutionOverTime.sql?raw'
 
 export type EvolutionResult = {
-    year: number
-    streams: number
+    stream_year: number
+    stream_count: number
     ms_played: number
 }
 

--- a/app/src/components/Charts/SimpleCharts/FunFacts/AbsoluteLoyalty.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/AbsoluteLoyalty.sql
@@ -35,7 +35,7 @@ artist_loyalty as (
 
 select
     artist_name as main_text,
-    (loyalty_ratio * 100)::integer as value,
+    (loyalty_ratio * 100)::integer as fact_value,
     'absolute_loyalty' as fact_type,
     '%' as unit,
     'of your completed ('
@@ -44,5 +44,5 @@ select
     || skipped_count
     || ')' as context
 from artist_loyalty
-order by value desc
+order by fact_value desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/AfternoonFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/AfternoonFavorite.sql
@@ -1,7 +1,7 @@
 select
     artist_name as main_text,
     'afternoon_favorite' as fact_type,
-    count(*) as value,
+    count(*) as fact_value,
     'streams' as unit,
     'between 12pm and 6pm' as context
 from ${table}
@@ -9,5 +9,5 @@ where
     (hour(ts::datetime) >= 12 and hour(ts::datetime) < 18)
     and artist_name is not null
 group by artist_name
-order by value desc
+order by fact_value desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/BingeListener.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/BingeListener.sql
@@ -1,6 +1,6 @@
 select
     cast(cast(ts as date) as varchar) as main_text,
-    cast((sum(ms_played) / 3600000.0) as integer) as value,
+    cast((sum(ms_played) / 3600000.0) as integer) as fact_value,
     'binge_listener' as fact_type,
     'hours of listening' as unit,
     'your record of listening time in one day' as context

--- a/app/src/components/Charts/SimpleCharts/FunFacts/CurrentObsession.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/CurrentObsession.sql
@@ -6,7 +6,7 @@ recent_date as (
 
 select
     track_name as main_text,
-    count(*)::integer as value,
+    count(*)::integer as fact_value,
     'current_obsession' as fact_type,
     'streams' as unit,
     'in the last 30 days' as context
@@ -15,5 +15,5 @@ where
     ts::date >= max_date - interval 30 day
     and track_name is not null
 group by track_name
-order by value desc
+order by fact_value desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/EveningFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/EveningFavorite.sql
@@ -1,7 +1,7 @@
 select
     artist_name as main_text,
     'evening_favorite' as fact_type,
-    count(*) as value,
+    count(*) as fact_value,
     'streams' as unit,
     'between 6pm and 0am' as context
 from ${table}
@@ -9,5 +9,5 @@ where
     (hour(ts::datetime) >= 18 and hour(ts::datetime) < 24)
     and artist_name is not null
 group by artist_name
-order by value desc
+order by fact_value desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FirstArtist.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FirstArtist.sql
@@ -1,10 +1,10 @@
 select
     artist_name as main_text,
     'first_artist' as fact_type,
-    min(year(ts::date)) as value,
+    min(year(ts::date)) as fact_value,
     'Do you still listen to it?' as context
 from ${table}
 where artist_name is not null
 group by artist_name
-order by value asc
+order by fact_value asc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/ForgottenArtist.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/ForgottenArtist.sql
@@ -52,7 +52,7 @@ select
     artist as main_text,
     date_diff(
         'day', last_listen, (select max_date from recent_date)
-    )::integer as value,
+    )::integer as fact_value,
     'forgotten_artist' as fact_type,
     'days' as unit,
     'without listening to artist with more than '

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
@@ -21,7 +21,7 @@ describe('FunFacts Component', () => {
                 {
                     fact_type: fact.fact_type,
                     main_text: `main_text_for_${fact.fact_type}`,
-                    value: i % 2 === 0 ? 1 : 'one',
+                    fact_value: i % 2 === 0 ? 1 : 'one',
                     context: i % 2 === 0 ? undefined : 'dummy_context',
                 },
             ] as FunFactResult[]

--- a/app/src/components/Charts/SimpleCharts/FunFacts/Marathon.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/Marathon.sql
@@ -22,17 +22,17 @@ group_sizes as (
     select
         artist_name,
         count(*) as stream_count,
-        min(ts::date) as date
+        min(ts::date) as listen_date
     from group_ids
     group by group_id, artist_name
 )
 
 select
     artist_name as main_text,
-    stream_count::double as value,
+    stream_count::double as fact_value,
     'marathon' as fact_type,
     'streams in a row' as unit,
-    'on ' || date::varchar as context
+    'on ' || listen_date::varchar as context
 from group_sizes
 order by stream_count desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/MorningFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/MorningFavorite.sql
@@ -1,7 +1,7 @@
 select
     artist_name as main_text,
     'morning_favorite' as fact_type,
-    count(*) as value,
+    count(*) as fact_value,
     'streams' as unit,
     'between 6am and 12pm' as context
 from ${table}
@@ -9,5 +9,5 @@ where
     (hour(ts::datetime) >= 6 and hour(ts::datetime) < 12)
     and artist_name is not null
 group by artist_name
-order by value desc
+order by fact_value desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/MusicalAnniversary.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/MusicalAnniversary.sql
@@ -37,7 +37,7 @@ artist_years as (
 select
     artist_name as main_text,
     'musical_anniversary' as fact_type,
-    year(max_date) - first_year as value,
+    year(max_date) - first_year as fact_value,
     'years' as unit,
     'with you' as context
 from artist_years, recent_date

--- a/app/src/components/Charts/SimpleCharts/FunFacts/NightFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/NightFavorite.sql
@@ -1,7 +1,7 @@
 select
     artist_name as main_text,
     'night_favorite' as fact_type,
-    count(*) as value,
+    count(*) as fact_value,
     'streams' as unit,
     'between 0am and 6am' as context
 from ${table}
@@ -9,5 +9,5 @@ where
     hour(ts::datetime) < 6
     and artist_name is not null
 group by artist_name
-order by value desc
+order by fact_value desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/NostalgicReturn.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/NostalgicReturn.sql
@@ -51,7 +51,7 @@ artist_gaps as (
 
 select
     artist as main_text,
-    gap::integer as value,
+    gap::integer as fact_value,
     'nostalgic_return' as fact_type,
     'days' as unit,
     'days since last listen ('

--- a/app/src/components/Charts/SimpleCharts/FunFacts/OneHitWonder.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/OneHitWonder.sql
@@ -30,7 +30,7 @@ track_stats as (
 
 select
     track_name as main_text,
-    percentage as value,
+    percentage as fact_value,
     'one_hit_wonder' as fact_type,
     '%' as unit,
     'of total streams of ' || artist_name as context

--- a/app/src/components/Charts/SimpleCharts/FunFacts/RecentDiscovery.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/RecentDiscovery.sql
@@ -15,7 +15,7 @@ artist_first_listen as (
 
 select
     artist_name as main_text,
-    count(*)::integer as value,
+    count(*)::integer as fact_value,
     'recent_discovery' as fact_type,
     'streams' as unit,
     'discovered during the last 3 months' as context
@@ -25,5 +25,5 @@ where
     first_listen >= (select max_date - interval 90 day from recent_date)
     and artist_name is not null
 group by artist_name
-order by value desc
+order by fact_value desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/SubscribedArtist.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/SubscribedArtist.sql
@@ -1,11 +1,11 @@
 select
     artist_name as main_text,
-    count(distinct strftime(ts::date, '%Y-%m'))::integer as value,
+    count(distinct strftime(ts::date, '%Y-%m'))::integer as fact_value,
     'subscribed_artist' as fact_type,
     'months' as unit,
     'of presence' as context
 from ${table}
 where artist_name is not null
 group by artist_name
-order by value desc
+order by fact_value desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/TrackProposition.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/TrackProposition.sql
@@ -1,7 +1,7 @@
 select
     track_name as main_text,
     'track_proposition' as fact_type,
-    'by ' || artist_name as value
+    'by ' || artist_name as fact_value
 from ${table}
 where track_name is not null
 USING SAMPLE 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/UnbeatableStreak.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/UnbeatableStreak.sql
@@ -35,7 +35,7 @@ streak_lengths as (
 )
 
 select
-    streak_length::integer as value,
+    streak_length::integer as fact_value,
     'unbeatable_streak' as fact_type,
     start_date::varchar || ' - ' || end_date::varchar as main_text,
     'days in a row' as unit,

--- a/app/src/components/Charts/SimpleCharts/FunFacts/VarietyDay.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/VarietyDay.sql
@@ -1,10 +1,10 @@
 select
     cast(cast(ts as date) as varchar) as main_text,
-    cast(count(distinct artist_name) as integer) as value,
+    cast(count(distinct artist_name) as integer) as fact_value,
     'variety_day' as fact_type,
     'different artists' as unit,
     'record of diversity in one day' as context
 from ${table}
 group by cast(ts as date)
-order by value desc
+order by fact_value desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/WeekendFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/WeekendFavorite.sql
@@ -1,7 +1,7 @@
 select
     artist_name as main_text,
     'weekend_favorite' as fact_type,
-    count(*) as value,
+    count(*) as fact_value,
     'streams' as unit,
     'during the weekend' as context
 from ${table}
@@ -12,5 +12,5 @@ where
     )
     and artist_name is not null
 group by artist_name
-order by value desc
+order by fact_value desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
@@ -36,10 +36,12 @@ export function FunFacts() {
 
                 seenFactsRef.current.add(factDefinition.fact_type)
                 if (result) {
+                    const { fact_value, ...rest } = result
                     setFact({
                         title: factDefinition.title,
                         emoji: factDefinition.emoji,
-                        ...result,
+                        ...rest,
+                        value: fact_value,
                     })
                     break
                 }

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
@@ -61,7 +61,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('morning_favorite')
             expect(row.main_text).toBe('top_morning_artist')
-            expect(row.value).toBe('2')
+            expect(row.fact_value).toBe('2')
             expect(row.unit).toBe('streams')
             expect(row.context).toBe('between 6am and 12pm')
         })
@@ -75,7 +75,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('afternoon_favorite')
             expect(row.main_text).toBe('top_afternoon_artist')
-            expect(row.value).toBe('2')
+            expect(row.fact_value).toBe('2')
             expect(row.unit).toBe('streams')
             expect(row.context).toBe('between 12pm and 6pm')
         })
@@ -89,7 +89,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('evening_favorite')
             expect(row.main_text).toBe('top_evening_artist')
-            expect(row.value).toBe('2')
+            expect(row.fact_value).toBe('2')
             expect(row.unit).toBe('streams')
             expect(row.context).toBe('between 6pm and 0am')
         })
@@ -103,7 +103,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('night_favorite')
             expect(row.main_text).toBe('top_night_artist')
-            expect(row.value).toBe('2')
+            expect(row.fact_value).toBe('2')
             expect(row.unit).toBe('streams')
             expect(row.context).toBe('between 0am and 6am')
         })
@@ -128,7 +128,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('marathon')
             expect(row.main_text).toBe('consecutive_stream_artist')
-            expect(row.value).toBe(3)
+            expect(row.fact_value).toBe(3)
             expect(row.unit).toBe('streams in a row')
             expect(row.context).toBe('on 2024-01-01')
         })
@@ -149,7 +149,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('one_hit_wonder')
             expect(row.main_text).toBe('hit_track')
-            expect(row.value).toBe(100)
+            expect(row.fact_value).toBe(100)
             expect(row.unit).toBe('%')
             expect(row.context).toBe(
                 'of total streams of one_hit_wonder_artist'
@@ -179,7 +179,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('weekend_favorite')
             expect(row.main_text).toBe('weekend_artist')
-            expect(row.value).toBe('2')
+            expect(row.fact_value).toBe('2')
             expect(row.unit).toBe('streams')
             expect(row.context).toBe('during the weekend')
         })
@@ -207,7 +207,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('absolute_loyalty')
             expect(row.main_text).toBe('loyal_artist')
-            expect(row.value).toBe(75)
+            expect(row.fact_value).toBe(75)
             expect(row.unit).toBe('%')
             expect(row.context).toBe('of your completed (3) vs skipped (1)')
         })
@@ -232,7 +232,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('nostalgic_return')
             expect(row.main_text).toBe('nostalgic_artist')
-            expect(row.value).toBe(366)
+            expect(row.fact_value).toBe(366)
             expect(row.unit).toBe('days')
             expect(row.context).toBe(
                 'days since last listen (2024-01-01 - 2025-01-01)'
@@ -260,7 +260,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('variety_day')
             expect(row.main_text).toBe('2024-01-01')
-            expect(row.value).toBe(3)
+            expect(row.fact_value).toBe(3)
             expect(row.unit).toBe('different artists')
             expect(row.context).toBe('record of diversity in one day')
         })
@@ -283,7 +283,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('binge_listener')
             expect(row.main_text).toBe('2024-01-03')
-            expect(row.value).toBe(1)
+            expect(row.fact_value).toBe(1)
             expect(row.unit).toBe('hours of listening')
             expect(row.context).toBe('your record of listening time in one day')
         })
@@ -312,7 +312,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('current_obsession')
             expect(row.main_text).toBe('current_hit')
-            expect(row.value).toBe(2)
+            expect(row.fact_value).toBe(2)
             expect(row.unit).toBe('streams')
             expect(row.context).toBe('in the last 30 days')
         })
@@ -338,7 +338,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('recent_discovery')
             expect(row.main_text).toBe('recent_discovery_artist')
-            expect(row.value).toBe(1)
+            expect(row.fact_value).toBe(1)
             expect(row.unit).toBe('streams')
             expect(row.context).toBe('discovered during the last 3 months')
         })
@@ -365,7 +365,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('subscribed_artist')
             expect(row.main_text).toBe('subscribed_artist')
-            expect(row.value).toBe(3)
+            expect(row.fact_value).toBe(3)
             expect(row.unit).toBe('months')
             expect(row.context).toBe('of presence')
         })
@@ -389,7 +389,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('first_artist')
             expect(row.main_text).toBe('first_artist')
-            expect(row.value).toBe('2006')
+            expect(row.fact_value).toBe('2006')
             expect(row.unit).toBeUndefined()
             expect(row.context).toBe('Do you still listen to it?')
         })
@@ -403,7 +403,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('musical_anniversary')
             expect(row.main_text).toBeDefined()
-            expect(row.value).toBeDefined()
+            expect(row.fact_value).toBeDefined()
             expect(row.unit).toBe('years')
             expect(row.context).toBe('with you')
         })
@@ -431,7 +431,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('unbeatable_streak')
             expect(row.main_text).toBe('2024-01-03 - 2024-01-05')
-            expect(row.value).toBe(3)
+            expect(row.fact_value).toBe(3)
             expect(row.unit).toBe('days in a row')
             expect(row.context).toBe('your longest streak')
         })
@@ -458,7 +458,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('forgotten_artist')
             expect(row.main_text).toBe('forgotten_artist')
-            expect(row.value).toBe(366)
+            expect(row.fact_value).toBe(366)
             expect(row.unit).toBe('days')
             expect(row.context).toBe(
                 'without listening to artist with more than 1 streams'
@@ -482,7 +482,7 @@ describe('FunFacts queries', () => {
             const row = rows[0]
             expect(row.fact_type).toBe('track_proposition')
             expect(row.main_text).toBeOneOf(['track1', 'track2'])
-            expect(row.value).toBeOneOf(['by artist1', 'by artist2'])
+            expect(row.fact_value).toBeOneOf(['by artist1', 'by artist2'])
             expect(row.unit).toBeUndefined()
             expect(row.context).toBeUndefined()
         })
@@ -517,7 +517,7 @@ describe('FunFacts queries', () => {
                 expect(rows[0].fact_type).toBe('cozy_album')
                 expect(rows[0].main_text).toBe('album1')
                 expect(rows[0].second_text).toBe('artist1')
-                expect(rows[0].value).toBeUndefined()
+                expect(rows[0].fact_value).toBeUndefined()
                 expect(rows[0].unit).toBeUndefined()
                 expect(rows[0].context).toBe(
                     'the album that wraps your Sundays in musical coziness'
@@ -631,7 +631,7 @@ describe('FunFacts queries', () => {
                 expect(rows[0].second_text).toBe(
                     'This fun fact is unfortunately unavailable'
                 )
-                expect(rows[0].value).toBeUndefined()
+                expect(rows[0].fact_value).toBeUndefined()
                 expect(rows[0].unit).toBeUndefined()
                 expect(rows[0].context).toBe(
                     'feel like listening to an album today?'

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.tsx
@@ -24,7 +24,7 @@ export type FunFactResult = {
     fact_type: string
     main_text: string
     second_text?: string
-    value: number | string
+    fact_value: number | string
     unit?: string
     context?: string
 }

--- a/app/src/components/Charts/SimpleCharts/HourlyStreams/HourlyStreams.sql
+++ b/app/src/components/Charts/SimpleCharts/HourlyStreams/HourlyStreams.sql
@@ -1,15 +1,15 @@
 select
-    hour::int as hour,
+    play_hour::int as play_hour,
     coalesce(count_streams, 0)::double as count_streams,
     coalesce(ms_played, 0)::double as ms_played
-from (select unnest(range(24)) as hour)
+from (select unnest(range(24)) as play_hour)
 left join (
     select
-        hour(ts::datetime) as hour,
+        hour(ts::datetime) as play_hour,
         count(*) as count_streams,
         sum(ms_played) as ms_played
     from ${table}
     where ${year_condition}
     group by hour(ts::datetime)
-) using (hour)
-order by hour
+) using (play_hour)
+order by play_hour

--- a/app/src/components/Charts/SimpleCharts/HourlyStreams/HourlyStreams.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/HourlyStreams/HourlyStreams.test.tsx
@@ -6,7 +6,7 @@ import type { HourlyStreamsQueryResult } from './query'
 const fixture: HourlyStreamsQueryResult[] = Array.from(
     { length: 24 },
     (_, h) => ({
-        hour: h,
+        play_hour: h,
         count_streams: h === 8 ? 42 : h === 14 ? 25 : h === 22 ? 10 : 0,
         ms_played:
             h === 8 ? 5400000 : h === 14 ? 3000000 : h === 22 ? 1200000 : 0,

--- a/app/src/components/Charts/SimpleCharts/HourlyStreams/HourlyStreams.tsx
+++ b/app/src/components/Charts/SimpleCharts/HourlyStreams/HourlyStreams.tsx
@@ -64,12 +64,12 @@ export const HourlyStreams: FC<Props> = ({
               )
             : undefined
 
-    const peakHour = peakRow?.hour ?? -1
+    const peakHour = peakRow?.play_hour ?? -1
 
     return (
         <ChartCard
             title="Around the Clock"
-            emoji={peakRow ? clockEmoji(peakRow.hour) : '🕐'}
+            emoji={peakRow ? clockEmoji(peakRow.play_hour) : '🕐'}
             isLoading={isLoading}
             question="When do you listen to music?"
             className="h-full w-full"
@@ -78,7 +78,7 @@ export const HourlyStreams: FC<Props> = ({
                 <>
                     {peakRow && (
                         <ChartHero
-                            label={`${String(peakRow.hour).padStart(2, '0')}h`}
+                            label={`${String(peakRow.play_hour).padStart(2, '0')}h`}
                             sublabel={`${peakRow.count_streams.toLocaleString()} streams`}
                             labelColor="text-teal-600"
                         />
@@ -112,12 +112,12 @@ export const HourlyStreams: FC<Props> = ({
                                       )
                                     : 0
                             if (r === 0) return null
-                            const isHovered = tooltip?.hour === row.hour
-                            const isPeak = row.hour === peakHour
+                            const isHovered = tooltip?.hour === row.play_hour
+                            const isPeak = row.play_hour === peakHour
                             return (
                                 <path
-                                    key={row.hour}
-                                    d={wedgePath(row.hour, r, CX, CY)}
+                                    key={row.play_hour}
+                                    d={wedgePath(row.play_hour, r, CX, CY)}
                                     className={
                                         isHovered
                                             ? 'fill-teal-300 stroke-white dark:stroke-slate-900'
@@ -133,7 +133,7 @@ export const HourlyStreams: FC<Props> = ({
                                             .closest('svg')!
                                             .getBoundingClientRect()
                                         const aCenter =
-                                            ((row.hour + 0.5) / 24) *
+                                            ((row.play_hour + 0.5) / 24) *
                                                 2 *
                                                 Math.PI -
                                             Math.PI / 2
@@ -151,7 +151,7 @@ export const HourlyStreams: FC<Props> = ({
                                                 (CY +
                                                     rMid * Math.sin(aCenter)) *
                                                     (svgH / 300),
-                                            hour: row.hour,
+                                            hour: row.play_hour,
                                             count: row.count_streams,
                                             ms: row.ms_played,
                                         })

--- a/app/src/components/Charts/SimpleCharts/HourlyStreams/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/HourlyStreams/query.test.ts
@@ -46,8 +46,8 @@ describe('HourlyStreams Query', () => {
             buildHourlyStreamsQuery(2025)
         )) as unknown as HourlyStreamsQueryResult[]
 
-        const hour8 = rows.find((r) => r.hour === 8)
-        const hour14 = rows.find((r) => r.hour === 14)
+        const hour8 = rows.find((r) => r.play_hour === 8)
+        const hour14 = rows.find((r) => r.play_hour === 14)
 
         expect(hour8?.count_streams).toBe(2)
         expect(hour14?.count_streams).toBe(1)
@@ -59,7 +59,7 @@ describe('HourlyStreams Query', () => {
             buildHourlyStreamsQuery(2025)
         )) as unknown as HourlyStreamsQueryResult[]
 
-        const hour0 = rows.find((r) => r.hour === 0)
+        const hour0 = rows.find((r) => r.play_hour === 0)
         expect(hour0?.count_streams).toBe(0)
         expect(hour0?.ms_played).toBe(0)
     })

--- a/app/src/components/Charts/SimpleCharts/HourlyStreams/query.ts
+++ b/app/src/components/Charts/SimpleCharts/HourlyStreams/query.ts
@@ -3,7 +3,7 @@ import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryHourlyStreams from './HourlyStreams.sql?raw'
 
 export type HourlyStreamsQueryResult = {
-    hour: number
+    play_hour: number
     count_streams: number
     ms_played: number
 }

--- a/app/src/components/Charts/SimpleCharts/PrincipalPlatform/PrincipalPlatform.sql
+++ b/app/src/components/Charts/SimpleCharts/PrincipalPlatform/PrincipalPlatform.sql
@@ -65,7 +65,9 @@ top_platforms as (
         platform,
         stream_count,
         pct,
-        row_number() over (order by stream_count desc, platform desc) as rank
+        row_number()
+            over (order by stream_count desc, platform desc)
+        as stream_rank
     from platform_counts
     where platform != 'Others'
 ),
@@ -78,13 +80,13 @@ other_platforms as (
     from (
         select *
         from top_platforms
-        where rank > 3
+        where stream_rank > 3
         union all
         select
             platform,
             stream_count,
             pct,
-            999 as rank
+            999 as stream_rank
         from platform_counts
         where platform = 'Others'
     )
@@ -100,7 +102,7 @@ from (
         stream_count,
         pct
     from top_platforms
-    where rank <= 3
+    where stream_rank <= 3
     union all
     select
         platform,

--- a/app/src/components/Charts/SimpleCharts/Regularity/Regularity.sql
+++ b/app/src/components/Charts/SimpleCharts/Regularity/Regularity.sql
@@ -31,15 +31,20 @@ listening_days_count as (
 ),
 
 listening_days as (
-    (select distinct ts::date as day from selected_tracks)
+    (select distinct ts::date as stream_date from selected_tracks)
     union
-    (select '${ year}-01-01'::date - 1 as day)
+    (select '${ year}-01-01'::date - 1 as stream_date)
     union
-    (select max_date + 1 as day from max_date)
+    (select max_date + 1 as stream_date from max_date)
 ),
 
 gaps as (
-    select date_diff('day', lag(day) over (order by day), day) - 1 as gap
+    select
+        date_diff(
+            'day',
+            lag(stream_date) over (order by stream_date),
+            stream_date
+        ) - 1 as gap
     from listening_days
 ),
 

--- a/app/src/components/Charts/SimpleView.test.tsx
+++ b/app/src/components/Charts/SimpleView.test.tsx
@@ -158,8 +158,8 @@ const regularityMock: RegularityResult[] = [
 
 const evolutionOverTimeMock: EvolutionResult[] = [
     {
-        year: 2024,
-        streams: 100,
+        stream_year: 2024,
+        stream_count: 100,
         ms_played: 1000,
     },
 ]

--- a/app/src/db/daily_stream_counts.sql
+++ b/app/src/db/daily_stream_counts.sql
@@ -1,8 +1,8 @@
 select
-    ts::date as day,
+    ts::date as stream_date,
     count(*)::double as stream_count,
     sum(ms_played)::double as ms_played
 from ${table}
 where ts is not null
 group by ts::date
-order by day
+order by stream_date


### PR DESCRIPTION
## Summary

Closes #293

Enables the `RF04` sqruff linter rule ("Keywords should not be used as identifiers") across all SQL files. Reserved SQL keywords used as column aliases are replaced with domain-specific names, and all corresponding TypeScript types, components, and tests are updated.

**Renames applied:**
- `value` → `fact_value` — all FunFacts SQL files and `FunFactResult` type
- `year` → `stream_year` — evolution and discovery charts
- `day` / `date` → `stream_date` — streaks, calendar heatmap, regularity, top streak
- `hour` → `play_hour` — hourly streams and day-of-week charts
- `rank` → `stream_rank` — Top10 evolution charts and PrincipalPlatform
- `month` → `month_start` — internal CTE alias in StreamPerMonth
- `streams` → `stream_count` — EvolutionOverTime
- `groups` CTE → `streak_groups` — TopStreak (`GROUPS` is a window frame keyword)

**Config:**
- `app/.sqruff`: RF04 removed from `exclude_rules`
- `app/.sqruff`: placeholder values added so `${table}` resolves to `listen_history` (non-keyword) during linting

**TopStreak SQL rewrite:** The `interval '-1' day * row_number()` expression (which sqruff flagged) is replaced with the equivalent `stream_date - (row_number() - 1)::int` using DuckDB's native `DATE - INTEGER` arithmetic.

## Test plan

- [x] `moon run app:lint-sql` passes with zero RF04 violations
- [x] `moon run app:pnpm -- exec tsc --noEmit` — zero TypeScript errors
- [x] `moon run app:test` — all 392 tests pass (30 pre-existing DuckDB WASM file-level failures unchanged from `main`)
- [x] New TopStreak tests added: gap-breaks streak isolation and single-date edge case

🤖 Generated with [Claude Code](https://claude.com/claude-code)