### PR TITLE
fix(chat): ground LLM in current date so "this year" resolves correctly

### DIFF
--- a/app/src/components/Chat/ChatInput.tsx
+++ b/app/src/components/Chat/ChatInput.tsx
@@ -42,7 +42,7 @@ export function ChatInput({ disabled, placeholder, onSubmit }: ChatInputProps) {
                 rows={2}
                 placeholder={
                     placeholder ??
-                    'Ask about your listening (e.g. top tracks in 2023)'
+                    `Ask about your listening (e.g. top tracks in ${new Date().getFullYear()})`
                 }
                 className="flex-1 resize-none bg-transparent outline-none text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 disabled:opacity-50"
             />

--- a/app/src/llm/askLLM.test.ts
+++ b/app/src/llm/askLLM.test.ts
@@ -1,6 +1,23 @@
 import { describe, it, expect } from 'vitest'
 import { extractJsonObject, parseChatAnswer } from './askLLM'
+import { SYSTEM_PROMPT, FEW_SHOTS } from './prompt'
 import { LLMError } from './types'
+
+describe('prompt date context', () => {
+    const currentYear = new Date().getFullYear()
+
+    it('includes the current year in SYSTEM_PROMPT', () => {
+        expect(SYSTEM_PROMPT).toContain(String(currentYear))
+    })
+
+    it('has a few-shot that maps "this year" to the current year', () => {
+        const shot = FEW_SHOTS.find((s) =>
+            s.user.toLowerCase().includes('this year')
+        )
+        expect(shot).toBeDefined()
+        expect(shot!.assistant).toContain(String(currentYear))
+    })
+})
 
 describe('extractJsonObject', () => {
     it('returns the object as-is when not wrapped', () => {

--- a/app/src/llm/prompt.ts
+++ b/app/src/llm/prompt.ts
@@ -7,6 +7,9 @@ import {
     SUMMARIZE_CACHE_TABLE,
 } from '../db/queries/constants'
 
+const CURRENT_YEAR = new Date().getFullYear()
+const CURRENT_DATE = new Date().toISOString().split('T')[0]
+
 const SCHEMA_DESCRIPTION = `\
 DuckDB schema (the user's music streaming history, fully local):
 
@@ -73,6 +76,7 @@ Rules:
 - "params.limit" only for top_artists/top_tracks/top_albums when user asked for a specific N.
 - Use intent "custom" ONLY if no other intent fits.
 - Never invent table or column names. Never include any text outside the JSON object.
+- Today is ${CURRENT_DATE}. When the user says "this year", "current year", or similar without an explicit year, use ${CURRENT_YEAR} in the SQL and params.
 `
 
 export type FewShot = { user: string; assistant: string }
@@ -86,6 +90,16 @@ export const FEW_SHOTS: FewShot[] = [
             title: 'Top artists',
             explanation: 'Artists ranked by total stream count.',
             sql: 'SELECT artist_name, COUNT(*)::DOUBLE AS count_streams, SUM(ms_played)::DOUBLE AS ms_played FROM music_streams WHERE artist_name IS NOT NULL GROUP BY artist_name ORDER BY count_streams DESC LIMIT 5',
+        }),
+    },
+    {
+        user: 'What are my top artists this year?',
+        assistant: JSON.stringify({
+            intent: 'top_artists',
+            params: { year: CURRENT_YEAR },
+            title: `Top artists ${CURRENT_YEAR}`,
+            explanation: `Artists ranked by total stream count in ${CURRENT_YEAR}.`,
+            sql: `SELECT artist_name, COUNT(*)::DOUBLE AS count_streams, SUM(ms_played)::DOUBLE AS ms_played FROM music_streams WHERE artist_name IS NOT NULL AND EXTRACT(year FROM ts) = ${CURRENT_YEAR} GROUP BY artist_name ORDER BY count_streams DESC LIMIT 5`,
         }),
     },
     {


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

When a user types a relative time query like "what's my top artists this year?", the chat feature generates SQL with a stale year (e.g. `EXTRACT(year FROM ts) = 2023`) instead of the current year (2026). The root cause is that the system prompt sent to the local WebLLM model contained no current-date context, so the model defaulted to the years present in the few-shot examples (2023, 2022).

## 🎹 Proposal

- Added `CURRENT_YEAR` and `CURRENT_DATE` constants (evaluated at module load time) to `app/src/llm/prompt.ts`
- Injected a rule into `SYSTEM_PROMPT`: *"Today is `<date>`. When the user says 'this year', 'current year', or similar without an explicit year, use `<year>` in the SQL and params."*
- Added a new few-shot example (`"What are my top artists this year?"`) that explicitly demonstrates the current-year resolution, removing the bias toward stale example years
- Updated the `ChatInput` placeholder from the hardcoded `"2023"` to the current year dynamically

## 🎶 Comments

No changes to `askLLM.ts` were needed — the module-level constants are evaluated at page load time, which is the same pattern already used for the calendar heatmap few-shot (line 105/108 of the original `prompt.ts`).

## 🎤 Test

1. Run `moon run app:test -- src/llm/askLLM.test.ts` — 14 tests pass, including 2 new assertions:
   - `SYSTEM_PROMPT` contains the current year
   - A "this year" few-shot exists and its `assistant` payload contains the current year
2. Run `moon run app:lint` — no errors
3. Manual reproduction: upload a streaming history file → open Chat view → type *"what are my top artists this year?"* → confirm the generated SQL uses `EXTRACT(year FROM ts) = 2026`