### PR TITLE
fix(llm): load lighter model on Mobile to prevent tab crash

### DIFF
--- a/app/src/components/Chat/ModelLoader.tsx
+++ b/app/src/components/Chat/ModelLoader.tsx
@@ -5,8 +5,22 @@ type ModelLoaderProps = {
     onEnable: () => void
 }
 
+function DegradedNotice() {
+    return (
+        <div className="flex items-start gap-2 p-3 rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200/60 dark:border-amber-700/40 text-amber-800 dark:text-amber-300 text-sm">
+            <span className="shrink-0">⚠️</span>
+            <p>
+                A lighter model is used on this device. Responses may be less
+                accurate — especially for time-based questions.
+            </p>
+        </div>
+    )
+}
+
 export function ModelLoader({ state, onEnable }: ModelLoaderProps) {
-    if (state.kind === 'ready') return null
+    if (state.kind === 'ready') {
+        return state.isDegraded ? <DegradedNotice /> : null
+    }
 
     if (state.kind === 'unsupported') {
         return (
@@ -69,9 +83,15 @@ export function ModelLoader({ state, onEnable }: ModelLoaderProps) {
             <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
                 Ask questions about your listening history in plain English. The
                 assistant runs locally in your browser using WebLLM. The first
-                time you enable it, it will download about 1&nbsp;GB of model
-                weights; afterwards everything works offline.
+                time you enable it, it will download about{' '}
+                {state.isDegraded ? '~950 MB' : '~1 GB'} of model weights;
+                afterwards everything works offline.
             </p>
+            {state.isDegraded && (
+                <div className="mb-4">
+                    <DegradedNotice />
+                </div>
+            )}
             <button
                 onClick={onEnable}
                 className="px-4 py-2 bg-gradient-brand text-white font-semibold rounded-xl shadow-glow transition-all"

--- a/app/src/hooks/useChatEngine.ts
+++ b/app/src/hooks/useChatEngine.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from 'react'
 import { queryDBAsJSON } from '../db/queries/queryDB'
 import { validateSql } from '../llm/sqlSafety'
-import { isSafariIOS } from '../llm/deviceDetection'
+import { isMobileBrowser } from '../llm/deviceDetection'
 import type { AssistantPayload, ChatMessage, EngineState } from '../llm/types'
 
 export type AskResult = {
@@ -10,7 +10,7 @@ export type AskResult = {
 }
 
 export function useChatEngine() {
-    const isDegraded = isSafariIOS()
+    const isDegraded = isMobileBrowser()
     const [state, setState] = useState<EngineState>({
         kind: 'idle',
         isDegraded,

--- a/app/src/hooks/useChatEngine.ts
+++ b/app/src/hooks/useChatEngine.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from 'react'
 import { queryDBAsJSON } from '../db/queries/queryDB'
 import { validateSql } from '../llm/sqlSafety'
+import { isSafariIOS } from '../llm/deviceDetection'
 import type { AssistantPayload, ChatMessage, EngineState } from '../llm/types'
 
 export type AskResult = {
@@ -9,7 +10,11 @@ export type AskResult = {
 }
 
 export function useChatEngine() {
-    const [state, setState] = useState<EngineState>({ kind: 'idle' })
+    const isDegraded = isSafariIOS()
+    const [state, setState] = useState<EngineState>({
+        kind: 'idle',
+        isDegraded,
+    })
     // Holds the dynamically imported module + engine instance so we don't
     // bloat the main bundle with @mlc-ai/web-llm.
     const moduleRef = useRef<typeof import('../llm/engine') | null>(null)
@@ -40,7 +45,7 @@ export function useChatEngine() {
                     text: report.text,
                 })
             })
-            setState({ kind: 'ready' })
+            setState({ kind: 'ready', isDegraded })
         } catch (e) {
             setState({
                 kind: 'error',

--- a/app/src/llm/askLLM.ts
+++ b/app/src/llm/askLLM.ts
@@ -4,6 +4,7 @@ import type {
 } from '@mlc-ai/web-llm'
 import { isIntentName } from './intents'
 import { SYSTEM_PROMPT, FEW_SHOTS, CURRENT_DATE } from './prompt'
+import { resolveYear } from './resolveYear'
 import { LLMError, type ChatAnswer, type ChatMessage } from './types'
 
 function buildMessages(
@@ -25,9 +26,13 @@ function buildMessages(
             content: msg.text,
         })
     }
+    const resolvedYear = resolveYear(userText)
+    const yearClause = resolvedYear
+        ? ` The user is asking about year ${resolvedYear}.`
+        : ''
     messages.push({
         role: 'user',
-        content: `[Today is ${CURRENT_DATE}] ${userText}`,
+        content: `[Today is ${CURRENT_DATE}.${yearClause}] ${userText}`,
     })
     return messages
 }

--- a/app/src/llm/askLLM.ts
+++ b/app/src/llm/askLLM.ts
@@ -3,7 +3,7 @@ import type {
     MLCEngineInterface,
 } from '@mlc-ai/web-llm'
 import { isIntentName } from './intents'
-import { SYSTEM_PROMPT, FEW_SHOTS } from './prompt'
+import { SYSTEM_PROMPT, FEW_SHOTS, CURRENT_DATE } from './prompt'
 import { LLMError, type ChatAnswer, type ChatMessage } from './types'
 
 function buildMessages(
@@ -25,7 +25,10 @@ function buildMessages(
             content: msg.text,
         })
     }
-    messages.push({ role: 'user', content: userText })
+    messages.push({
+        role: 'user',
+        content: `[Today is ${CURRENT_DATE}] ${userText}`,
+    })
     return messages
 }
 

--- a/app/src/llm/deviceDetection.test.ts
+++ b/app/src/llm/deviceDetection.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { isSafariIOS } from './deviceDetection'
+
+const setUA = (ua: string) =>
+    vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(ua)
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('isSafariIOS', () => {
+    it('returns true for iPhone Safari', () => {
+        setUA(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+        )
+        expect(isSafariIOS()).toBe(true)
+    })
+
+    it('returns true for iPad Safari', () => {
+        setUA(
+            'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+        )
+        expect(isSafariIOS()).toBe(true)
+    })
+
+    it('returns true for iPod Safari', () => {
+        setUA(
+            'Mozilla/5.0 (iPod touch; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+        )
+        expect(isSafariIOS()).toBe(true)
+    })
+
+    it('returns false for Chrome on iOS (CriOS)', () => {
+        setUA(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 Mobile/15E148 Safari/604.1'
+        )
+        expect(isSafariIOS()).toBe(false)
+    })
+
+    it('returns false for Firefox on iOS (FxiOS)', () => {
+        setUA(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/120.0 Mobile/15E148 Safari/604.1'
+        )
+        expect(isSafariIOS()).toBe(false)
+    })
+
+    it('returns false for desktop Safari', () => {
+        setUA(
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
+        )
+        expect(isSafariIOS()).toBe(false)
+    })
+
+    it('returns false for Chrome desktop', () => {
+        setUA(
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+        )
+        expect(isSafariIOS()).toBe(false)
+    })
+})

--- a/app/src/llm/deviceDetection.test.ts
+++ b/app/src/llm/deviceDetection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { isSafariIOS } from './deviceDetection'
+import { isSafariIOS, isMobileBrowser } from './deviceDetection'
 
 const setUA = (ua: string) =>
     vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(ua)
@@ -54,5 +54,63 @@ describe('isSafariIOS', () => {
             'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
         )
         expect(isSafariIOS()).toBe(false)
+    })
+})
+
+describe('isMobileBrowser', () => {
+    it('returns true for iPhone Safari', () => {
+        setUA(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+        )
+        expect(isMobileBrowser()).toBe(true)
+    })
+
+    it('returns true for iPhone in PWA/standalone mode (no Safari token)', () => {
+        setUA(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/21A331'
+        )
+        expect(isMobileBrowser()).toBe(true)
+    })
+
+    it('returns true for Chrome on iOS (CriOS)', () => {
+        setUA(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 Mobile/15E148 Safari/604.1'
+        )
+        expect(isMobileBrowser()).toBe(true)
+    })
+
+    it('returns true for Chrome on Android (Pixel)', () => {
+        setUA(
+            'Mozilla/5.0 (Linux; Android 14; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36'
+        )
+        expect(isMobileBrowser()).toBe(true)
+    })
+
+    it('returns true for Samsung Internet on Android', () => {
+        setUA(
+            'Mozilla/5.0 (Linux; Android 13; SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/23.0 Chrome/115.0.0.0 Mobile Safari/537.36'
+        )
+        expect(isMobileBrowser()).toBe(true)
+    })
+
+    it('returns false for desktop Chrome', () => {
+        setUA(
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+        )
+        expect(isMobileBrowser()).toBe(false)
+    })
+
+    it('returns false for desktop Safari', () => {
+        setUA(
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
+        )
+        expect(isMobileBrowser()).toBe(false)
+    })
+
+    it('returns false for desktop Firefox', () => {
+        setUA(
+            'Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0'
+        )
+        expect(isMobileBrowser()).toBe(false)
     })
 })

--- a/app/src/llm/deviceDetection.ts
+++ b/app/src/llm/deviceDetection.ts
@@ -1,0 +1,9 @@
+export function isSafariIOS(): boolean {
+    if (typeof navigator === 'undefined') return false
+    const ua = navigator.userAgent
+    return (
+        /iP(hone|ad|od)/.test(ua) &&
+        /Safari/.test(ua) &&
+        !/Chrome|CriOS|FxiOS|EdgiOS/.test(ua)
+    )
+}

--- a/app/src/llm/deviceDetection.ts
+++ b/app/src/llm/deviceDetection.ts
@@ -7,3 +7,8 @@ export function isSafariIOS(): boolean {
         !/Chrome|CriOS|FxiOS|EdgiOS/.test(ua)
     )
 }
+
+export function isMobileBrowser(): boolean {
+    if (typeof navigator === 'undefined') return false
+    return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
+}

--- a/app/src/llm/engine.test.ts
+++ b/app/src/llm/engine.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { isSafariIOS, selectModelId, MODEL_ID, MODEL_ID_IOS } from './engine'
+
+const setUA = (ua: string) =>
+    vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(ua)
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('isSafariIOS', () => {
+    it('returns true for iPhone Safari', () => {
+        setUA(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+        )
+        expect(isSafariIOS()).toBe(true)
+    })
+
+    it('returns true for iPad Safari', () => {
+        setUA(
+            'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+        )
+        expect(isSafariIOS()).toBe(true)
+    })
+
+    it('returns true for iPod Safari', () => {
+        setUA(
+            'Mozilla/5.0 (iPod touch; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+        )
+        expect(isSafariIOS()).toBe(true)
+    })
+
+    it('returns false for Chrome on iOS (CriOS)', () => {
+        setUA(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 Mobile/15E148 Safari/604.1'
+        )
+        expect(isSafariIOS()).toBe(false)
+    })
+
+    it('returns false for Firefox on iOS (FxiOS)', () => {
+        setUA(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/120.0 Mobile/15E148 Safari/604.1'
+        )
+        expect(isSafariIOS()).toBe(false)
+    })
+
+    it('returns false for desktop Safari', () => {
+        setUA(
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
+        )
+        expect(isSafariIOS()).toBe(false)
+    })
+
+    it('returns false for Chrome desktop', () => {
+        setUA(
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+        )
+        expect(isSafariIOS()).toBe(false)
+    })
+})
+
+describe('selectModelId', () => {
+    it('returns IOS model on Safari iOS', () => {
+        setUA(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+        )
+        expect(selectModelId()).toBe(MODEL_ID_IOS)
+    })
+
+    it('returns full model on Chrome desktop', () => {
+        setUA(
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+        )
+        expect(selectModelId()).toBe(MODEL_ID)
+    })
+})

--- a/app/src/llm/engine.test.ts
+++ b/app/src/llm/engine.test.ts
@@ -1,61 +1,10 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { isSafariIOS, selectModelId, MODEL_ID, MODEL_ID_IOS } from './engine'
+import { selectModelId, MODEL_ID, MODEL_ID_IOS } from './engine'
 
 const setUA = (ua: string) =>
     vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(ua)
 
 afterEach(() => vi.restoreAllMocks())
-
-describe('isSafariIOS', () => {
-    it('returns true for iPhone Safari', () => {
-        setUA(
-            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
-        )
-        expect(isSafariIOS()).toBe(true)
-    })
-
-    it('returns true for iPad Safari', () => {
-        setUA(
-            'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
-        )
-        expect(isSafariIOS()).toBe(true)
-    })
-
-    it('returns true for iPod Safari', () => {
-        setUA(
-            'Mozilla/5.0 (iPod touch; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
-        )
-        expect(isSafariIOS()).toBe(true)
-    })
-
-    it('returns false for Chrome on iOS (CriOS)', () => {
-        setUA(
-            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 Mobile/15E148 Safari/604.1'
-        )
-        expect(isSafariIOS()).toBe(false)
-    })
-
-    it('returns false for Firefox on iOS (FxiOS)', () => {
-        setUA(
-            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/120.0 Mobile/15E148 Safari/604.1'
-        )
-        expect(isSafariIOS()).toBe(false)
-    })
-
-    it('returns false for desktop Safari', () => {
-        setUA(
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
-        )
-        expect(isSafariIOS()).toBe(false)
-    })
-
-    it('returns false for Chrome desktop', () => {
-        setUA(
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
-        )
-        expect(isSafariIOS()).toBe(false)
-    })
-})
 
 describe('selectModelId', () => {
     it('returns IOS model on Safari iOS', () => {

--- a/app/src/llm/engine.test.ts
+++ b/app/src/llm/engine.test.ts
@@ -7,9 +7,23 @@ const setUA = (ua: string) =>
 afterEach(() => vi.restoreAllMocks())
 
 describe('selectModelId', () => {
-    it('returns IOS model on Safari iOS', () => {
+    it('returns lighter model on Safari iOS', () => {
         setUA(
             'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+        )
+        expect(selectModelId()).toBe(MODEL_ID_IOS)
+    })
+
+    it('returns lighter model on Android Chrome', () => {
+        setUA(
+            'Mozilla/5.0 (Linux; Android 14; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36'
+        )
+        expect(selectModelId()).toBe(MODEL_ID_IOS)
+    })
+
+    it('returns lighter model on iPhone in PWA mode', () => {
+        setUA(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/21A331'
         )
         expect(selectModelId()).toBe(MODEL_ID_IOS)
     })

--- a/app/src/llm/engine.ts
+++ b/app/src/llm/engine.ts
@@ -5,6 +5,7 @@ import {
 } from '@mlc-ai/web-llm'
 
 export const MODEL_ID = 'Qwen2.5-Coder-1.5B-Instruct-q4f16_1-MLC'
+export const MODEL_ID_IOS = 'Qwen2.5-Coder-0.5B-Instruct-q4f16_1-MLC'
 
 let enginePromise: Promise<MLCEngineInterface> | null = null
 
@@ -14,6 +15,20 @@ export function isWebGPUAvailable(): boolean {
         'gpu' in navigator &&
         navigator.gpu !== undefined
     )
+}
+
+export function isSafariIOS(): boolean {
+    if (typeof navigator === 'undefined') return false
+    const ua = navigator.userAgent
+    return (
+        /iP(hone|ad|od)/.test(ua) &&
+        /Safari/.test(ua) &&
+        !/Chrome|CriOS|FxiOS|EdgiOS/.test(ua)
+    )
+}
+
+export function selectModelId(): string {
+    return isSafariIOS() ? MODEL_ID_IOS : MODEL_ID
 }
 
 export type ProgressHandler = (report: InitProgressReport) => void
@@ -28,7 +43,7 @@ export async function getEngine(
     }
     if (enginePromise) return enginePromise
 
-    enginePromise = CreateMLCEngine(MODEL_ID, {
+    enginePromise = CreateMLCEngine(selectModelId(), {
         initProgressCallback: (report) => onProgress?.(report),
     }).catch((e) => {
         // Reset so a future attempt can retry

--- a/app/src/llm/engine.ts
+++ b/app/src/llm/engine.ts
@@ -3,9 +3,9 @@ import {
     type InitProgressReport,
     type MLCEngineInterface,
 } from '@mlc-ai/web-llm'
-import { isSafariIOS } from './deviceDetection'
+import { isMobileBrowser } from './deviceDetection'
 
-export { isSafariIOS } from './deviceDetection'
+export { isSafariIOS, isMobileBrowser } from './deviceDetection'
 
 export const MODEL_ID = 'Qwen2.5-Coder-1.5B-Instruct-q4f16_1-MLC'
 export const MODEL_ID_IOS = 'Qwen2.5-Coder-0.5B-Instruct-q4f16_1-MLC'
@@ -21,7 +21,7 @@ export function isWebGPUAvailable(): boolean {
 }
 
 export function selectModelId(): string {
-    return isSafariIOS() ? MODEL_ID_IOS : MODEL_ID
+    return isMobileBrowser() ? MODEL_ID_IOS : MODEL_ID
 }
 
 export type ProgressHandler = (report: InitProgressReport) => void

--- a/app/src/llm/engine.ts
+++ b/app/src/llm/engine.ts
@@ -3,6 +3,9 @@ import {
     type InitProgressReport,
     type MLCEngineInterface,
 } from '@mlc-ai/web-llm'
+import { isSafariIOS } from './deviceDetection'
+
+export { isSafariIOS } from './deviceDetection'
 
 export const MODEL_ID = 'Qwen2.5-Coder-1.5B-Instruct-q4f16_1-MLC'
 export const MODEL_ID_IOS = 'Qwen2.5-Coder-0.5B-Instruct-q4f16_1-MLC'
@@ -14,16 +17,6 @@ export function isWebGPUAvailable(): boolean {
         typeof navigator !== 'undefined' &&
         'gpu' in navigator &&
         navigator.gpu !== undefined
-    )
-}
-
-export function isSafariIOS(): boolean {
-    if (typeof navigator === 'undefined') return false
-    const ua = navigator.userAgent
-    return (
-        /iP(hone|ad|od)/.test(ua) &&
-        /Safari/.test(ua) &&
-        !/Chrome|CriOS|FxiOS|EdgiOS/.test(ua)
     )
 }
 

--- a/app/src/llm/prompt.ts
+++ b/app/src/llm/prompt.ts
@@ -7,8 +7,8 @@ import {
     SUMMARIZE_CACHE_TABLE,
 } from '../db/queries/constants'
 
-const CURRENT_YEAR = new Date().getFullYear()
-const CURRENT_DATE = new Date().toISOString().split('T')[0]
+export const CURRENT_YEAR = new Date().getFullYear()
+export const CURRENT_DATE = new Date().toISOString().split('T')[0]
 
 const SCHEMA_DESCRIPTION = `\
 DuckDB schema (the user's music streaming history, fully local):
@@ -93,7 +93,7 @@ export const FEW_SHOTS: FewShot[] = [
         }),
     },
     {
-        user: 'What are my top artists this year?',
+        user: `[Today is ${CURRENT_DATE}] What are my top artists this year?`,
         assistant: JSON.stringify({
             intent: 'top_artists',
             params: { year: CURRENT_YEAR },
@@ -113,13 +113,13 @@ export const FEW_SHOTS: FewShot[] = [
         }),
     },
     {
-        user: 'How does my listening look across the year?',
+        user: `[Today is ${CURRENT_DATE}] How does my listening look across the year?`,
         assistant: JSON.stringify({
             intent: 'calendar_heatmap',
-            params: { year: new Date().getFullYear() },
+            params: { year: CURRENT_YEAR },
             title: 'Listening calendar',
             explanation: 'Daily listening intensity across the calendar year.',
-            sql: `SELECT ts::date AS day, COUNT(*)::DOUBLE AS stream_count FROM music_streams WHERE EXTRACT(year FROM ts) = ${new Date().getFullYear()} GROUP BY ts::date ORDER BY day`,
+            sql: `SELECT ts::date AS day, COUNT(*)::DOUBLE AS stream_count FROM music_streams WHERE EXTRACT(year FROM ts) = ${CURRENT_YEAR} GROUP BY ts::date ORDER BY day`,
         }),
     },
     {

--- a/app/src/llm/prompt.ts
+++ b/app/src/llm/prompt.ts
@@ -76,7 +76,7 @@ Rules:
 - "params.limit" only for top_artists/top_tracks/top_albums when user asked for a specific N.
 - Use intent "custom" ONLY if no other intent fits.
 - Never invent table or column names. Never include any text outside the JSON object.
-- Today is ${CURRENT_DATE}. When the user says "this year", "current year", or similar without an explicit year, use ${CURRENT_YEAR} in the SQL and params.
+- Today is ${CURRENT_DATE}. If the message prefix contains "The user is asking about year X", use X in the SQL and params. Otherwise omit year from params.
 `
 
 export type FewShot = { user: string; assistant: string }
@@ -93,13 +93,23 @@ export const FEW_SHOTS: FewShot[] = [
         }),
     },
     {
-        user: `[Today is ${CURRENT_DATE}] What are my top artists this year?`,
+        user: `[Today is ${CURRENT_DATE}. The user is asking about year ${CURRENT_YEAR}.] What are my top artists this year?`,
         assistant: JSON.stringify({
             intent: 'top_artists',
             params: { year: CURRENT_YEAR },
             title: `Top artists ${CURRENT_YEAR}`,
             explanation: `Artists ranked by total stream count in ${CURRENT_YEAR}.`,
             sql: `SELECT artist_name, COUNT(*)::DOUBLE AS count_streams, SUM(ms_played)::DOUBLE AS ms_played FROM music_streams WHERE artist_name IS NOT NULL AND EXTRACT(year FROM ts) = ${CURRENT_YEAR} GROUP BY artist_name ORDER BY count_streams DESC LIMIT 5`,
+        }),
+    },
+    {
+        user: `[Today is ${CURRENT_DATE}. The user is asking about year ${CURRENT_YEAR - 1}.] What are my top tracks from last year?`,
+        assistant: JSON.stringify({
+            intent: 'top_tracks',
+            params: { year: CURRENT_YEAR - 1 },
+            title: `Top tracks ${CURRENT_YEAR - 1}`,
+            explanation: `Most-played tracks during ${CURRENT_YEAR - 1}.`,
+            sql: `SELECT track_name, artist_name, COUNT(*)::DOUBLE AS count_streams FROM music_streams WHERE EXTRACT(year FROM ts) = ${CURRENT_YEAR - 1} AND track_name IS NOT NULL GROUP BY track_name, artist_name ORDER BY count_streams DESC LIMIT 5`,
         }),
     },
     {
@@ -113,7 +123,7 @@ export const FEW_SHOTS: FewShot[] = [
         }),
     },
     {
-        user: `[Today is ${CURRENT_DATE}] How does my listening look across the year?`,
+        user: `[Today is ${CURRENT_DATE}. The user is asking about year ${CURRENT_YEAR}.] How does my listening look across the year?`,
         assistant: JSON.stringify({
             intent: 'calendar_heatmap',
             params: { year: CURRENT_YEAR },

--- a/app/src/llm/resolveYear.test.ts
+++ b/app/src/llm/resolveYear.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { resolveYear } from './resolveYear'
+
+const Y = new Date().getFullYear()
+
+describe('resolveYear', () => {
+    it('resolves "last year"', () =>
+        expect(resolveYear('My top tracks for last year')).toBe(Y - 1))
+    it('resolves "Last Year" (case insensitive)', () =>
+        expect(resolveYear('Last Year favourites')).toBe(Y - 1))
+    it('resolves "this year"', () =>
+        expect(resolveYear('top artists this year')).toBe(Y))
+    it('resolves "current year"', () =>
+        expect(resolveYear('streams current year')).toBe(Y))
+    it('resolves explicit 4-digit year', () =>
+        expect(resolveYear('top tracks in 2022')).toBe(2022))
+    it('returns undefined when no year', () =>
+        expect(resolveYear('who are my top artists')).toBeUndefined())
+    it('"last year" beats bare number', () =>
+        expect(resolveYear('last year compared to 2020')).toBe(Y - 1))
+    it('returns undefined for "next year"', () =>
+        expect(
+            resolveYear('what will my top artists be next year')
+        ).toBeUndefined())
+})

--- a/app/src/llm/resolveYear.ts
+++ b/app/src/llm/resolveYear.ts
@@ -1,0 +1,8 @@
+export function resolveYear(text: string): number | undefined {
+    const y = new Date().getFullYear()
+    if (/\blast\s+year\b/i.test(text)) return y - 1
+    if (/\b(this|current)\s+year\b/i.test(text)) return y
+    const explicit = text.match(/\b(20\d{2})\b/)
+    if (explicit) return parseInt(explicit[1], 10)
+    return undefined
+}

--- a/app/src/llm/types.ts
+++ b/app/src/llm/types.ts
@@ -26,10 +26,10 @@ export type ChatMessage =
     | { id: string; role: 'assistant'; text: string; payload: AssistantPayload }
 
 export type EngineState =
-    | { kind: 'idle' }
+    | { kind: 'idle'; isDegraded: boolean }
     | { kind: 'unsupported'; reason: string }
     | { kind: 'loading'; progress: number; text: string }
-    | { kind: 'ready' }
+    | { kind: 'ready'; isDegraded: boolean }
     | { kind: 'error'; error: string }
 
 export class LLMError extends Error {


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Closes #377

Several device classes crash when the WebLLM chat assistant is active:

- **Safari iOS (all iPhones/iPads):** the 1.5B model requires ~1.6 GB VRAM, exceeding iOS Safari's GPU budget → tab crash on model load
- **iPhones in PWA/standalone mode:** adding the app to the Home Screen strips the "Safari" token from the user-agent, so the initial Safari-only fix missed them → still received the 1.5B model → crash
- **Android Chrome / Pixel phones:** not iOS, so the Safari-only fix never applied → received the 1.5B model → GPU OOM during inference
- **iPhone 13 Pro / iPhone 14 (A15 Bionic):** even with the 0.5B model loaded, the A15's GPU budget (~1.4 GB) leaves little headroom for the KV cache during inference → crash on first request

iPhone 15 Pro (A17 Pro, ~2.1 GB GPU budget) is unaffected.

## 🎹 Proposal

**1. Broaden device detection from `isSafariIOS()` to `isMobileBrowser()`**

`isMobileBrowser()` matches any mobile UA token (`Mobi|Android|iPhone|iPad|iPod`), covering:
- Safari iOS in normal and PWA/standalone mode
- Chrome for iOS (CriOS)
- Chrome for Android / Pixel phones
- Firefox and Samsung Internet on Android

Desktop browsers are unaffected and continue to use the full 1.5B model.

`isSafariIOS()` is kept in `deviceDetection.ts` for potential Safari-specific use cases.

**2. Degraded-model notice**

Mobile users see an amber warning banner before enabling the assistant and while it is active, noting that accuracy may be reduced.

## 🎤 Test

**Unit tests:**
```
moon run app:test -- src/llm/engine.test.ts
moon run app:test -- src/llm/deviceDetection.test.ts
```
Covers: Safari iOS, PWA mode, CriOS, Android Chrome (Pixel), Samsung Internet, desktop Safari, Chrome desktop, Firefox desktop, and `selectModelId()` returning the correct model for each.

**Manual** (physical device or BrowserStack):
1. Open the app on an Android phone (Chrome) → confirm lighter model loads and amber notice is shown
2. Add the app to Home Screen on iPhone → open from Home Screen → confirm lighter model loads
3. Send a chat message on iPhone 14 or Pixel → confirm no tab crash