### PR TITLE
refactor(sql): enable RF02 linter rule and qualify column references

### DIFF
--- a/app/.sqruff
+++ b/app/.sqruff
@@ -4,10 +4,7 @@ dialect = duckdb
 templater = placeholder
 rules = all
 # ST07: Found USING statement. Expected only ON statements.
-# RF02: Unqualified reference <reference> found in select with more than one referenced table/view.
-#       Too many warnings; to be corrected in separate PR
-#       https://github.com/Gudsfile/tracksy/issues/294
-exclude_rules = ST07, RF02
+exclude_rules = ST07
 warn_unused_ignores = True
 max_line_length = 80
 
@@ -47,3 +44,4 @@ order_condition = streaks desc
 # ${year} only appears inside SQL string literals (e.g. '${ year}-01-01'),
 # so this substitution is a no-op for linting but documents the expected type.
 year = 2024
+year_for_new = 2024

--- a/app/src/components/Charts/DetailedCharts/Top10AlbumsEvolution/Top10AlbumsEvolution.sql
+++ b/app/src/components/Charts/DetailedCharts/Top10AlbumsEvolution/Top10AlbumsEvolution.sql
@@ -6,15 +6,15 @@ max_date as (
 
 album_listening as (
     select
-        album_name,
-        artist_name,
-        year(ts::date)::int as stream_year,
+        t.album_name,
+        t.artist_name,
+        year(t.ts::date)::int as stream_year,
         count(*) as playing_days_count
-    from ${table}, max_date
-    group by album_name, artist_name, ts::date
+    from ${table} as t, max_date
+    group by t.album_name, t.artist_name, t.ts::date
     -- arbitrary threshold: an album listen is counted from 7 distinct tracks
     -- conservative lower bound of average album length
-    having count(distinct track_name) >= 7
+    having count(distinct t.track_name) >= 7
 ),
 
 album_yearly_play_counts as (

--- a/app/src/components/Charts/SimpleCharts/FunFacts/CozyAlbum.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/CozyAlbum.sql
@@ -5,18 +5,18 @@ with max_date as (
 
 sunday_album_listening as (
     select
-        album_name,
-        artist_name,
-        sum(ms_played) as total_ms_played
-    from ${table}, max_date
+        t.album_name,
+        t.artist_name,
+        sum(t.ms_played) as total_ms_played
+    from ${table} as t, max_date
     where
         (
-            dayofweek(ts::date) = 0
-            or (dayofweek(ts::date) = 1 and hour(ts::datetime) <= 4)
+            dayofweek(t.ts::date) = 0
+            or (dayofweek(t.ts::date) = 1 and hour(t.ts::datetime) <= 4)
         )
-        and ts::date >= (max_date.last_date - interval 1 YEARS)
-    group by album_name, artist_name
-    having count(distinct track_name) >= 7
+        and t.ts::date >= (max_date.last_date - interval 1 YEARS)
+    group by t.album_name, t.artist_name
+    having count(distinct t.track_name) >= 7
     order by total_ms_played desc
     limit 1
 )

--- a/app/src/components/Charts/SimpleCharts/FunFacts/CurrentObsession.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/CurrentObsession.sql
@@ -5,15 +5,15 @@ recent_date as (
 )
 
 select
-    track_name as main_text,
+    t.track_name as main_text,
     count(*)::integer as fact_value,
     'current_obsession' as fact_type,
     'streams' as unit,
     'in the last 30 days' as context
-from ${table}, recent_date
+from ${table} as t, recent_date
 where
-    ts::date >= max_date - interval 30 day
-    and track_name is not null
-group by track_name
+    t.ts::date >= recent_date.max_date - interval 30 day
+    and t.track_name is not null
+group by t.track_name
 order by fact_value desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/ForgottenArtist.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/ForgottenArtist.sql
@@ -5,22 +5,22 @@ recent_date as (
 ),
 
 recent_artists as (
-    select distinct artist_name as artist
-    from ${table}, recent_date
+    select distinct t.artist_name as artist
+    from ${table} as t, recent_date
     where
-        artist_name is not null
-        and ts::date >= max_date - interval 90 day
+        t.artist_name is not null
+        and t.ts::date >= recent_date.max_date - interval 90 day
 ),
 
 forgotten as (
     select
-        artist_name as artist,
-        ts::date as listen_date
-    from ${table}, recent_date
+        t.artist_name as artist,
+        t.ts::date as listen_date
+    from ${table} as t, recent_date
     where
-        artist_name is not null
-        and ts::date < max_date - interval 90 day
-        and artist_name not in (select artist from recent_artists)
+        t.artist_name is not null
+        and t.ts::date < recent_date.max_date - interval 90 day
+        and t.artist_name not in (select artist from recent_artists)
 ),
 
 counts as (

--- a/app/src/components/Charts/SimpleCharts/FunFacts/MusicalAnniversary.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/MusicalAnniversary.sql
@@ -14,11 +14,11 @@ threshold as (
 ),
 
 recent_artists as (
-    select distinct artist_name as artist
-    from ${table}, recent_date
+    select distinct t.artist_name as artist
+    from ${table} as t, recent_date
     where
-        artist_name is not null
-        and ts::date >= max_date - interval 90 day
+        t.artist_name is not null
+        and t.ts::date >= recent_date.max_date - interval 90 day
 ),
 
 artist_years as (
@@ -35,9 +35,9 @@ artist_years as (
 )
 
 select
-    artist_name as main_text,
+    artist_years.artist_name as main_text,
     'musical_anniversary' as fact_type,
-    year(max_date) - first_year as fact_value,
+    year(recent_date.max_date) - artist_years.first_year as fact_value,
     'years' as unit,
     'with you' as context
 from artist_years, recent_date

--- a/app/src/components/Charts/SimpleCharts/FunFacts/NostalgicReturn.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/NostalgicReturn.sql
@@ -6,13 +6,13 @@ recent_date as (
 
 recent_artists as (
     select
-        artist_name as artist,
-        min(ts::date) as last_listen
-    from ${table}, recent_date
+        t.artist_name as artist,
+        min(t.ts::date) as last_listen
+    from ${table} as t, recent_date
     where
-        ts::date >= max_date - interval 90 day
-        and artist_name is not null
-    group by artist_name
+        t.ts::date >= recent_date.max_date - interval 90 day
+        and t.artist_name is not null
+    group by t.artist_name
 ),
 
 threshold as (
@@ -26,23 +26,25 @@ threshold as (
 
 previous_listens as (
     select
-        artist_name as artist,
-        max(ts::date) as previous_listen
-    from ${table}, recent_date
+        t.artist_name as artist,
+        max(t.ts::date) as previous_listen
+    from ${table} as t, recent_date
     where
-        artist_name is not null
-        and ts::date < max_date - interval 90 day
-        and artist_name in (select artist from recent_artists)
-    group by artist_name
+        t.artist_name is not null
+        and t.ts::date < recent_date.max_date - interval 90 day
+        and t.artist_name in (select artist from recent_artists)
+    group by t.artist_name
     having count(*) > (select limit_streams from threshold)
 ),
 
 artist_gaps as (
     select
         artist,
-        last_listen,
-        previous_listen,
-        date_diff('day', previous_listen, last_listen) as gap
+        recent_artists.last_listen,
+        previous_listens.previous_listen,
+        date_diff(
+            'day', previous_listens.previous_listen, recent_artists.last_listen
+        ) as gap
     from recent_artists
     inner join previous_listens using (artist)
     order by gap desc

--- a/app/src/components/Charts/SimpleCharts/FunFacts/RecentDiscovery.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/RecentDiscovery.sql
@@ -22,7 +22,8 @@ select
 from ${table}
 inner join artist_first_listen using (artist_name)
 where
-    first_listen >= (select max_date - interval 90 day from recent_date)
+    artist_first_listen.first_listen
+    >= (select max_date - interval 90 day from recent_date)
     and artist_name is not null
 group by artist_name
 order by fact_value desc

--- a/app/src/components/Charts/SimpleCharts/NewVsOld/NewVsOld.sql
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/NewVsOld.sql
@@ -11,7 +11,7 @@ streams_classified as (
     select
         artist_name as artist,
         case
-            when first_year = ${year_for_new} then 'new'
+            when artist_first_listen.first_year = ${year_for_new} then 'new'
             else 'old'
         end as category
     from ${table}


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The RF02 sqruff linter rule ("Unqualified reference found in select with more than one referenced table/view") was intentionally disabled in `app/.sqruff` because of too many violations, pending a dedicated fix (tracked in #294).

## 🎹 Proposal

- Removed `RF02` from `exclude_rules` in `app/.sqruff` and deleted the associated TODO comment.
- Added a missing `year_for_new = 2024` placeholder to the sqruff config (used in `NewVsOld.sql` but was undefined, causing the linter to treat it as a column name).
- Fixed all 8 violating SQL files by qualifying unqualified column references:
  - **Implicit cross-join pattern** (`from ${table}, max_date/recent_date`): aliased `${table}` as `t` and prefixed all column references with `t.` or the CTE name.
    - `CurrentObsession.sql`, `CozyAlbum.sql`, `ForgottenArtist.sql`, `MusicalAnniversary.sql`, `NostalgicReturn.sql`, `Top10AlbumsEvolution.sql`
  - **Explicit JOIN pattern**: qualified ambiguous column references with their source CTE name.
    - `RecentDiscovery.sql` → `artist_first_listen.first_listen`
    - `NewVsOld.sql` → `artist_first_listen.first_year`
    - `NostalgicReturn.sql` (artist_gaps CTE) → `recent_artists.last_listen`, `previous_listens.previous_listen`

No output column names were changed, so no TypeScript types or component code required updates.

## 🎶 Comments

All 56 SQL files now pass `moon run app:lint-sql` with RF02 enabled.

## 🎤 Test

1. Run `moon run app:lint-sql` — should report 0 violations across 56 files.
2. Run `moon run app:test` — all tests pass (SQL output column names are unchanged).
3. Start the dev server with `moon run app:dev`, upload a Spotify or Deezer dataset, and verify all charts and fun facts render correctly.

Closes #294