### PR TITLE
fix(app): restore libarchive.wasm flat path broken by vite-plugin-static-copy v4

### DIFF
--- a/app/astro.config.mjs
+++ b/app/astro.config.mjs
@@ -34,6 +34,7 @@ export default defineConfig({
                     {
                         src: 'node_modules/libarchive.js/dist/libarchive.wasm',
                         dest: './_astro/',
+                        rename: { stripBase: true },
                     },
                 ],
             }),

--- a/app/src/components/Dropzone/DropzoneWrapper.tsx
+++ b/app/src/components/Dropzone/DropzoneWrapper.tsx
@@ -37,8 +37,10 @@ export function DropzoneWrapper({ handleValidatedFiles }: Props) {
         event.preventDefault()
     }
 
-    const contentTypeAccepted =
-        STREAM_PROVIDERS_CONTENT_TYPES.join(',') + zipContentFile
+    const contentTypeAccepted = [
+        ...STREAM_PROVIDERS_CONTENT_TYPES,
+        zipContentFile,
+    ].join(',')
 
     return (
         <Dropzone


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Closes #331

ZIP archive uploads (the standard Spotify export format) broke in PR preview deployments after `vite-plugin-static-copy` was bumped from v3.4.0 → v4.1.0 (commit `90037d2`).

**Root cause:** v4 introduced a [breaking change](https://github.com/sapphi-red/vite-plugin-static-copy/releases/tag/vite-plugin-static-copy%404.0.0) — directory structure is now always preserved in the output (the old `structured: false` default was removed). With the previous config:

```js
{ src: 'node_modules/libarchive.js/dist/libarchive.wasm', dest: './_astro/' }
```

- **v3**: copies to `dist/_astro/libarchive.wasm` ✅
- **v4**: copies to `dist/_astro/node_modules/libarchive.js/dist/libarchive.wasm` ❌

The libarchive.js worker resolves the WASM via `new URL("libarchive.wasm", import.meta.url)`, so it always expects the file at the same level as the worker script (`_astro/libarchive.wasm`). With v4 the WASM is deep in a sub-path, causing a 404 when the worker tries to load it.

**Why production kept working:** The live deploy uses `keep_files: true` in `peaceiris/actions-gh-pages`, so the old `libarchive.wasm` at the correct path (`gh-pages/_astro/libarchive.wasm`) was silently preserved from before the bump. Previews use a fresh directory per PR, so no old file existed there.

**Why the demo button kept working:** The demo loads a pre-hosted JSON file — no ZIP extraction, no libarchive.js involved.

## 🎹 Proposal

Add `rename: { stripBase: true }` to the `viteStaticCopy` target. This is the v4 equivalent of the old v3 flat-copy behaviour, stripping all leading directory segments from the matched path:

```js
viteStaticCopy({
    targets: [
        {
            src: 'node_modules/libarchive.js/dist/libarchive.wasm',
            dest: './_astro/',
            rename: { stripBase: true },   // ← added
        },
    ],
}),
```

Also fixes a secondary cosmetic bug in `DropzoneWrapper.tsx`: a missing comma before `zipContentFile` was producing an invalid `accept` attribute that prevented ZIP and XLSX files from appearing in the file picker dialog (though drag-and-drop and actual file validation were unaffected).

## 🎶 Comments

Verified that after the fix `app/dist/_astro/libarchive.wasm` is at the expected flat path, and all 541 tests continue to pass.

## 🎤 Test

1. Checkout this branch
2. `moon run app:build` — confirm build passes
3. Check `app/dist/_astro/libarchive.wasm` exists (not nested under `node_modules/…`)
4. Open a preview of this PR and upload a Spotify ZIP archive — should load data successfully