### PR TITLE
refactor(funfacts): remove unused fact_type from SQL results

### DIFF
--- a/app/src/components/Charts/SimpleCharts/FunFacts/AbsoluteLoyalty.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/AbsoluteLoyalty.sql
@@ -36,7 +36,6 @@ artist_loyalty as (
 select
     artist_name as main_text,
     (loyalty_ratio * 100)::integer as fact_value,
-    'absolute_loyalty' as fact_type,
     '%' as unit,
     'of your completed ('
     || completed_count

--- a/app/src/components/Charts/SimpleCharts/FunFacts/AfternoonFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/AfternoonFavorite.sql
@@ -1,6 +1,5 @@
 select
     artist_name as main_text,
-    'afternoon_favorite' as fact_type,
     count(*) as fact_value,
     'streams' as unit,
     'between 12pm and 6pm' as context

--- a/app/src/components/Charts/SimpleCharts/FunFacts/BingeListener.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/BingeListener.sql
@@ -1,7 +1,6 @@
 select
     cast(cast(ts as date) as varchar) as main_text,
     cast((sum(ms_played) / 3600000.0) as integer) as fact_value,
-    'binge_listener' as fact_type,
     'hours of listening' as unit,
     'your record of listening time in one day' as context
 from ${table}

--- a/app/src/components/Charts/SimpleCharts/FunFacts/CozyAlbum.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/CozyAlbum.sql
@@ -24,6 +24,5 @@ sunday_album_listening as (
 select
     album_name as main_text,
     artist_name as second_text,
-    'cozy_album' as fact_type,
     'the album that wraps your Sundays in musical coziness' as context
 from sunday_album_listening

--- a/app/src/components/Charts/SimpleCharts/FunFacts/CurrentObsession.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/CurrentObsession.sql
@@ -7,7 +7,6 @@ recent_date as (
 select
     t.track_name as main_text,
     count(*)::integer as fact_value,
-    'current_obsession' as fact_type,
     'streams' as unit,
     'in the last 30 days' as context
 from ${table} as t, recent_date

--- a/app/src/components/Charts/SimpleCharts/FunFacts/EveningFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/EveningFavorite.sql
@@ -1,6 +1,5 @@
 select
     artist_name as main_text,
-    'evening_favorite' as fact_type,
     count(*) as fact_value,
     'streams' as unit,
     'between 6pm and 0am' as context

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FirstArtist.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FirstArtist.sql
@@ -1,6 +1,5 @@
 select
     artist_name as main_text,
-    'first_artist' as fact_type,
     min(year(ts::date)) as fact_value,
     'Do you still listen to it?' as context
 from ${table}

--- a/app/src/components/Charts/SimpleCharts/FunFacts/ForgottenArtist.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/ForgottenArtist.sql
@@ -53,7 +53,6 @@ select
     date_diff(
         'day', last_listen, (select max_date from recent_date)
     )::integer as fact_value,
-    'forgotten_artist' as fact_type,
     'days' as unit,
     'without listening to artist with more than '
     || (

--- a/app/src/components/Charts/SimpleCharts/FunFacts/Marathon.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/Marathon.sql
@@ -30,7 +30,6 @@ group_sizes as (
 select
     artist_name as main_text,
     stream_count::double as fact_value,
-    'marathon' as fact_type,
     'streams in a row' as unit,
     'on ' || listen_date::varchar as context
 from group_sizes

--- a/app/src/components/Charts/SimpleCharts/FunFacts/MorningFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/MorningFavorite.sql
@@ -1,6 +1,5 @@
 select
     artist_name as main_text,
-    'morning_favorite' as fact_type,
     count(*) as fact_value,
     'streams' as unit,
     'between 6am and 12pm' as context

--- a/app/src/components/Charts/SimpleCharts/FunFacts/MusicalAnniversary.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/MusicalAnniversary.sql
@@ -36,7 +36,6 @@ artist_years as (
 
 select
     artist_years.artist_name as main_text,
-    'musical_anniversary' as fact_type,
     year(recent_date.max_date) - artist_years.first_year as fact_value,
     'years' as unit,
     'with you' as context

--- a/app/src/components/Charts/SimpleCharts/FunFacts/NightFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/NightFavorite.sql
@@ -1,6 +1,5 @@
 select
     artist_name as main_text,
-    'night_favorite' as fact_type,
     count(*) as fact_value,
     'streams' as unit,
     'between 0am and 6am' as context

--- a/app/src/components/Charts/SimpleCharts/FunFacts/NostalgicReturn.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/NostalgicReturn.sql
@@ -54,7 +54,6 @@ artist_gaps as (
 select
     artist as main_text,
     gap::integer as fact_value,
-    'nostalgic_return' as fact_type,
     'days' as unit,
     'days since last listen ('
     || previous_listen

--- a/app/src/components/Charts/SimpleCharts/FunFacts/OneHitWonder.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/OneHitWonder.sql
@@ -31,7 +31,6 @@ track_stats as (
 select
     track_name as main_text,
     percentage as fact_value,
-    'one_hit_wonder' as fact_type,
     '%' as unit,
     'of total streams of ' || artist_name as context
 from track_stats

--- a/app/src/components/Charts/SimpleCharts/FunFacts/RecentDiscovery.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/RecentDiscovery.sql
@@ -16,7 +16,6 @@ artist_first_listen as (
 select
     artist_name as main_text,
     count(*)::integer as fact_value,
-    'recent_discovery' as fact_type,
     'streams' as unit,
     'discovered during the last 3 months' as context
 from ${table}

--- a/app/src/components/Charts/SimpleCharts/FunFacts/SubscribedArtist.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/SubscribedArtist.sql
@@ -1,7 +1,6 @@
 select
     artist_name as main_text,
     count(distinct strftime(ts::date, '%Y-%m'))::integer as fact_value,
-    'subscribed_artist' as fact_type,
     'months' as unit,
     'of presence' as context
 from ${table}

--- a/app/src/components/Charts/SimpleCharts/FunFacts/TrackProposition.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/TrackProposition.sql
@@ -1,6 +1,5 @@
 select
     track_name as main_text,
-    'track_proposition' as fact_type,
     'by ' || artist_name as fact_value
 from ${table}
 where track_name is not null

--- a/app/src/components/Charts/SimpleCharts/FunFacts/UnbeatableStreak.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/UnbeatableStreak.sql
@@ -36,7 +36,6 @@ streak_lengths as (
 
 select
     streak_length::integer as fact_value,
-    'unbeatable_streak' as fact_type,
     start_date::varchar || ' - ' || end_date::varchar as main_text,
     'days in a row' as unit,
     'your longest streak' as context

--- a/app/src/components/Charts/SimpleCharts/FunFacts/VarietyDay.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/VarietyDay.sql
@@ -1,7 +1,6 @@
 select
     cast(cast(ts as date) as varchar) as main_text,
     cast(count(distinct artist_name) as integer) as fact_value,
-    'variety_day' as fact_type,
     'different artists' as unit,
     'record of diversity in one day' as context
 from ${table}

--- a/app/src/components/Charts/SimpleCharts/FunFacts/WeekendFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/WeekendFavorite.sql
@@ -1,6 +1,5 @@
 select
     artist_name as main_text,
-    'weekend_favorite' as fact_type,
     count(*) as fact_value,
     'streams' as unit,
     'during the weekend' as context

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
@@ -59,7 +59,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('morning_favorite').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('morning_favorite')
             expect(row.main_text).toBe('top_morning_artist')
             expect(row.fact_value).toBe('2')
             expect(row.unit).toBe('streams')
@@ -73,7 +72,6 @@ describe('FunFacts queries', () => {
             )
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('afternoon_favorite')
             expect(row.main_text).toBe('top_afternoon_artist')
             expect(row.fact_value).toBe('2')
             expect(row.unit).toBe('streams')
@@ -87,7 +85,6 @@ describe('FunFacts queries', () => {
             const rows = result.getRowObjectsJson()
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('evening_favorite')
             expect(row.main_text).toBe('top_evening_artist')
             expect(row.fact_value).toBe('2')
             expect(row.unit).toBe('streams')
@@ -101,7 +98,6 @@ describe('FunFacts queries', () => {
             const rows = result.getRowObjectsJson()
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('night_favorite')
             expect(row.main_text).toBe('top_night_artist')
             expect(row.fact_value).toBe('2')
             expect(row.unit).toBe('streams')
@@ -126,7 +122,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('marathon').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('marathon')
             expect(row.main_text).toBe('consecutive_stream_artist')
             expect(row.fact_value).toBe(3)
             expect(row.unit).toBe('streams in a row')
@@ -147,7 +142,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('one_hit_wonder').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('one_hit_wonder')
             expect(row.main_text).toBe('hit_track')
             expect(row.fact_value).toBe(100)
             expect(row.unit).toBe('%')
@@ -177,7 +171,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('weekend_favorite').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('weekend_favorite')
             expect(row.main_text).toBe('weekend_artist')
             expect(row.fact_value).toBe('2')
             expect(row.unit).toBe('streams')
@@ -205,7 +198,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('absolute_loyalty').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('absolute_loyalty')
             expect(row.main_text).toBe('loyal_artist')
             expect(row.fact_value).toBe(75)
             expect(row.unit).toBe('%')
@@ -230,7 +222,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('nostalgic_return').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('nostalgic_return')
             expect(row.main_text).toBe('nostalgic_artist')
             expect(row.fact_value).toBe(366)
             expect(row.unit).toBe('days')
@@ -258,7 +249,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('variety_day').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('variety_day')
             expect(row.main_text).toBe('2024-01-01')
             expect(row.fact_value).toBe(3)
             expect(row.unit).toBe('different artists')
@@ -281,7 +271,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('binge_listener').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('binge_listener')
             expect(row.main_text).toBe('2024-01-03')
             expect(row.fact_value).toBe(1)
             expect(row.unit).toBe('hours of listening')
@@ -310,7 +299,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('current_obsession').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('current_obsession')
             expect(row.main_text).toBe('current_hit')
             expect(row.fact_value).toBe(2)
             expect(row.unit).toBe('streams')
@@ -336,7 +324,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('recent_discovery').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('recent_discovery')
             expect(row.main_text).toBe('recent_discovery_artist')
             expect(row.fact_value).toBe(1)
             expect(row.unit).toBe('streams')
@@ -363,7 +350,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('subscribed_artist').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('subscribed_artist')
             expect(row.main_text).toBe('subscribed_artist')
             expect(row.fact_value).toBe(3)
             expect(row.unit).toBe('months')
@@ -387,7 +373,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('first_artist').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('first_artist')
             expect(row.main_text).toBe('first_artist')
             expect(row.fact_value).toBe('2006')
             expect(row.unit).toBeUndefined()
@@ -401,7 +386,6 @@ describe('FunFacts queries', () => {
             )
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('musical_anniversary')
             expect(row.main_text).toBeDefined()
             expect(row.fact_value).toBeDefined()
             expect(row.unit).toBe('years')
@@ -429,7 +413,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('unbeatable_streak').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('unbeatable_streak')
             expect(row.main_text).toBe('2024-01-03 - 2024-01-05')
             expect(row.fact_value).toBe(3)
             expect(row.unit).toBe('days in a row')
@@ -456,7 +439,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('forgotten_artist').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('forgotten_artist')
             expect(row.main_text).toBe('forgotten_artist')
             expect(row.fact_value).toBe(366)
             expect(row.unit).toBe('days')
@@ -480,7 +462,6 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('track_proposition').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.fact_type).toBe('track_proposition')
             expect(row.main_text).toBeOneOf(['track1', 'track2'])
             expect(row.fact_value).toBeOneOf(['by artist1', 'by artist2'])
             expect(row.unit).toBeUndefined()
@@ -514,7 +495,6 @@ describe('FunFacts queries', () => {
 
                 const rows = await testQuery(conn, getFact('cozy_album').sql)
                 expect(rows.length).toBe(1)
-                expect(rows[0].fact_type).toBe('cozy_album')
                 expect(rows[0].main_text).toBe('album1')
                 expect(rows[0].second_text).toBe('artist1')
                 expect(rows[0].fact_value).toBeUndefined()

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.tsx
@@ -21,7 +21,6 @@ import sqlQueryTrackProposition from './TrackProposition.sql?raw'
 import sqlQueryCozyAlbum from './CozyAlbum.sql?raw'
 
 export type FunFactResult = {
-    fact_type: string
     main_text: string | undefined
     second_text?: string
     fact_value?: number | string


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

`fact_type` was selected in every fun fact SQL query but became dead code after the `index.tsx` refactor in #365 — `factDefinition.fact_type` from the definitions array is used for fact identity, not the query result.

## 🎹 Proposal

- Remove `fact_type` from `FunFactResult` type
- Remove `'xxx' as fact_type` from all 20 SQL SELECT statements
- Remove the corresponding `expect(row.fact_type).toBe(...)` assertions from `queries.test.ts`

## 🎶 Comments

Follow-up to #365.

## 🎤 Test

All 39 existing tests pass. Typecheck clean.