### PR TITLE
fix(app): keep year slider working when data is not yet available

### DIFF
--- a/app/src/components/Charts/DetailedView.tsx
+++ b/app/src/components/Charts/DetailedView.tsx
@@ -32,9 +32,13 @@ export function DetailedView() {
     const debouncedYear = useDebouncedValue(year, 250)
 
     const initDataSummarize = useCallback(async () => {
-        const results =
-            await queryDBAsJSON<SummarizeDataQueryResult>(summarizeQuery)
-        setSummarize(results[0] || undefined)
+        try {
+            const results =
+                await queryDBAsJSON<SummarizeDataQueryResult>(summarizeQuery)
+            setSummarize(results[0] || undefined)
+        } catch {
+            // DB not ready yet (no data loaded), year stays at default
+        }
     }, [])
 
     useEffect(() => {

--- a/app/src/components/Charts/SimpleView.test.tsx
+++ b/app/src/components/Charts/SimpleView.test.tsx
@@ -280,3 +280,16 @@ it('renders all SimpleView', async () => {
     await screen.findByRole('heading', { name: '📅Your Power Day' })
     await screen.findByRole('heading', { name: '🕐Around the Clock' })
 })
+
+it('renders without crashing when queryDBAsJSON throws', async () => {
+    vi.spyOn(db, 'queryDBAsJSON').mockRejectedValue(
+        new Error('DB not ready yet')
+    )
+
+    render(<SimpleView />)
+
+    // Year slider must not appear (summarize stays undefined when DB throws)
+    await waitFor(() => {
+        expect(screen.queryByRole('slider')).toBeNull()
+    })
+})

--- a/app/src/components/Charts/SimpleView.tsx
+++ b/app/src/components/Charts/SimpleView.tsx
@@ -37,9 +37,13 @@ export function SimpleView() {
     const debouncedYear = useDebouncedValue(year, 250)
 
     const initDataSummarize = useCallback(async () => {
-        const results =
-            await queryDBAsJSON<SummarizeDataQueryResult>(summarizeQuery)
-        setSummarize(results[0] || undefined)
+        try {
+            const results =
+                await queryDBAsJSON<SummarizeDataQueryResult>(summarizeQuery)
+            setSummarize(results[0] || undefined)
+        } catch {
+            // DB not ready yet (no data loaded), year stays at default
+        }
     }, [])
 
     useEffect(() => {


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

When no streaming data has been loaded yet, the year initialization query throws. Both SimpleView and DetailedView silently swallow the error, leaving the year slider stuck at its default with no feedback.

## 🎹 Proposal

Wraps the initialization query in a try/catch in both views. On failure, the year slider stays at its default value and the rest of the UI continues to render normally.

Adds a test verifying SimpleView renders without crashing when the query throws.

## 🎶 Comments

DetailedView defaults to year 2006 so its slider always renders regardless of the query result. Only SimpleView has a meaningful empty-state to assert against in tests.

## 🎤 Test

Upload a file, confirm the year slider appears. Reload before uploading, confirm no errors in the console and the UI still renders.