### PR TITLE
test(theme-toggle): control context via ThemeContext.Provider

### DIFF
--- a/app/src/components/ThemeToggle/ThemeToggle.test.tsx
+++ b/app/src/components/ThemeToggle/ThemeToggle.test.tsx
@@ -1,16 +1,8 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { ThemeToggle } from './ThemeToggle'
-import { ThemeProvider } from '../../hooks/ThemeContext'
-
-// Mock the useTheme hook
-// FIXME: Remove this when refactoring the ThemeToggle component
-// eslint-disable-next-line no-restricted-syntax
-vi.mock('../../hooks/useTheme', () => ({
-    useTheme: vi.fn(),
-}))
-
-import { useTheme } from '../../hooks/useTheme'
+import { ThemeContext } from '../../hooks/ThemeContext'
+import type { Theme } from '../../hooks/theme.constants'
 
 describe('ThemeToggle', () => {
     const mockSetTheme = vi.fn()
@@ -19,124 +11,50 @@ describe('ThemeToggle', () => {
         vi.clearAllMocks()
     })
 
-    it('should render with system theme by default', () => {
-        vi.mocked(useTheme).mockReturnValue({
-            theme: 'system',
-            setTheme: mockSetTheme,
-            effectiveTheme: 'light',
-        })
-
+    const renderWithTheme = (theme: Theme, effectiveTheme: 'light' | 'dark') =>
         render(
-            <ThemeProvider>
+            <ThemeContext.Provider
+                value={{ theme, setTheme: mockSetTheme, effectiveTheme }}
+            >
                 <ThemeToggle />
-            </ThemeProvider>
+            </ThemeContext.Provider>
         )
 
+    it('should render with system theme by default', () => {
+        renderWithTheme('system', 'light')
         screen.getByTitle('System (light)')
     })
 
     it('should render with light theme', () => {
-        vi.mocked(useTheme).mockReturnValue({
-            theme: 'light',
-            setTheme: mockSetTheme,
-            effectiveTheme: 'light',
-        })
-
-        render(
-            <ThemeProvider>
-                <ThemeToggle />
-            </ThemeProvider>
-        )
-
+        renderWithTheme('light', 'light')
         screen.getByTitle('Light')
     })
 
     it('should render with dark theme', () => {
-        vi.mocked(useTheme).mockReturnValue({
-            theme: 'dark',
-            setTheme: mockSetTheme,
-            effectiveTheme: 'dark',
-        })
-
-        render(
-            <ThemeProvider>
-                <ThemeToggle />
-            </ThemeProvider>
-        )
-
+        renderWithTheme('dark', 'dark')
         screen.getByTitle('Dark')
     })
 
     it('should cycle from light to dark when clicked', () => {
-        vi.mocked(useTheme).mockReturnValue({
-            theme: 'light',
-            setTheme: mockSetTheme,
-            effectiveTheme: 'light',
-        })
-
-        render(
-            <ThemeProvider>
-                <ThemeToggle />
-            </ThemeProvider>
-        )
-
-        const button = screen.getByRole('button')
-        fireEvent.click(button)
-
+        renderWithTheme('light', 'light')
+        fireEvent.click(screen.getByRole('button'))
         expect(mockSetTheme).toHaveBeenCalledWith('dark')
     })
 
     it('should cycle from dark to system when clicked', () => {
-        vi.mocked(useTheme).mockReturnValue({
-            theme: 'dark',
-            setTheme: mockSetTheme,
-            effectiveTheme: 'dark',
-        })
-
-        render(
-            <ThemeProvider>
-                <ThemeToggle />
-            </ThemeProvider>
-        )
-
-        const button = screen.getByRole('button')
-        fireEvent.click(button)
-
+        renderWithTheme('dark', 'dark')
+        fireEvent.click(screen.getByRole('button'))
         expect(mockSetTheme).toHaveBeenCalledWith('system')
     })
 
     it('should cycle from system to light when clicked', () => {
-        vi.mocked(useTheme).mockReturnValue({
-            theme: 'system',
-            setTheme: mockSetTheme,
-            effectiveTheme: 'light',
-        })
-
-        render(
-            <ThemeProvider>
-                <ThemeToggle />
-            </ThemeProvider>
-        )
-
-        const button = screen.getByRole('button')
-        fireEvent.click(button)
-
+        renderWithTheme('system', 'light')
+        fireEvent.click(screen.getByRole('button'))
         expect(mockSetTheme).toHaveBeenCalledWith('light')
     })
 
     it('should have accessible label', () => {
-        vi.mocked(useTheme).mockReturnValue({
-            theme: 'light',
-            setTheme: mockSetTheme,
-            effectiveTheme: 'light',
-        })
-
-        render(
-            <ThemeProvider>
-                <ThemeToggle />
-            </ThemeProvider>
-        )
-
+        renderWithTheme('light', 'light')
         const button = screen.getByRole('button')
         expect(button.getAttribute('aria-label')).toBe(
             'Current theme: Light. Click to change theme.'


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

ThemeToggle reads `useContext(ThemeContext)`, not `useTheme()` directly. The tests mocked `useTheme` — first via `vi.mock`, then via `vi.spyOn` — which had no effect on the component. Tests were passing against jsdom defaults (empty localStorage → `system`, matchMedia false → `light`), not against the mocked values.

## 🎹 Proposal

Replace `ThemeProvider` + `useTheme` spy with `ThemeContext.Provider` supplying controlled values directly in each test. `mockSetTheme` now actually intercepts `setTheme` calls from the component. Removes the unused `useTheme` import and the `useThemeModule` spy entirely.

## 🎶 Comments

No behavior change to the component. Tests now verify what they claim to verify.

## 🎤 Test

`moon run app:test -- src/components/ThemeToggle/ThemeToggle.test.tsx` passes.