### PR TITLE
test(funfacts): assert empty fallback renders in SimpleView

### DIFF
--- a/app/src/components/Charts/SimpleView.test.tsx
+++ b/app/src/components/Charts/SimpleView.test.tsx
@@ -263,7 +263,9 @@ it('renders all SimpleView', async () => {
         expect(slider.getAttribute('value')).toBe('2024')
     })
 
-    // TODO: test funfact rendering
+    await screen.findByText(
+        'Not enough data for this fun fact — keep listening!'
+    )
     await screen.findByRole('heading', { name: '🎵Top Tracks' })
     await screen.findByRole('heading', { name: '🎤Top Artists' })
     await screen.findByRole('heading', { name: '💿Top Albums' })


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The SimpleView integration test had a `// TODO: test funfact rendering` comment that was never addressed. The FunFacts empty state was not asserted anywhere in the test suite.

## 🎹 Proposal

Replaces the TODO comment with an assertion that the FunFacts empty state message is visible when no data is returned. Covered by the existing `renders all SimpleView` test.

## 🎶 Comments

Testing the populated FunFacts state in a SimpleView integration context is not practical: FunFacts picks a query at random from ~20 candidates, making deterministic mocking require importing all FunFacts SQL modules. The empty state path is sufficient coverage at this level; the FunFacts component itself has its own unit tests.

## 🎤 Test

`moon run app:test -- src/components/Charts/SimpleView.test.tsx` passes.