### PR TITLE
feat(app): show user-facing error on upload failure

### DIFF
--- a/app/src/components/Dropzone/Dropzone.test.tsx
+++ b/app/src/components/Dropzone/Dropzone.test.tsx
@@ -1,5 +1,5 @@
 import { render, fireEvent, screen } from '@testing-library/react'
-import { it, vi, expect } from 'vitest'
+import { it, describe, vi, expect } from 'vitest'
 
 import { Dropzone } from './Dropzone'
 
@@ -69,4 +69,45 @@ it('should call handleFileUpload when a file is uploaded', () => {
     })
 
     expect(handleFileUpload).toHaveBeenCalled()
+})
+
+describe('contentTypeAcceptedMessage', () => {
+    it('renders a string message', () => {
+        const { container } = render(
+            <Dropzone
+                handleDragOver={vi.fn()}
+                handleDrop={vi.fn()}
+                handleFileUpload={vi.fn()}
+                contentTypeAcceptedMessage="Only ZIP/JSON are accepted"
+            />
+        )
+        expect(container.textContent).toContain('Only ZIP/JSON are accepted')
+    })
+
+    it('renders a ReactNode message', () => {
+        const { container } = render(
+            <Dropzone
+                handleDragOver={vi.fn()}
+                handleDrop={vi.fn()}
+                handleFileUpload={vi.fn()}
+                contentTypeAcceptedMessage={
+                    <>
+                        Only <strong>Spotify</strong> are accepted
+                    </>
+                }
+            />
+        )
+        expect(container.textContent).toContain('Spotify')
+    })
+
+    it('renders nothing when omitted', () => {
+        const { container } = render(
+            <Dropzone
+                handleDragOver={vi.fn()}
+                handleDrop={vi.fn()}
+                handleFileUpload={vi.fn()}
+            />
+        )
+        expect(container.textContent).not.toContain('accepted')
+    })
 })

--- a/app/src/components/Dropzone/Dropzone.tsx
+++ b/app/src/components/Dropzone/Dropzone.tsx
@@ -3,6 +3,7 @@ type Props = {
     handleDragOver: (event: React.DragEvent<HTMLDivElement>) => void
     handleFileUpload: (event: React.ChangeEvent<HTMLInputElement>) => void
     contentTypeAccepted: string
+    contentTypeAcceptedMessage?: React.ReactNode
 }
 
 export function Dropzone({
@@ -10,6 +11,7 @@ export function Dropzone({
     handleDragOver,
     handleFileUpload,
     contentTypeAccepted,
+    contentTypeAcceptedMessage,
 }: Props) {
     return (
         <div>
@@ -34,9 +36,7 @@ export function Dropzone({
                     Drag and drop or click to upload your music streaming data
                     files
                     <br />
-                    Only <strong>ZIP archive</strong>, a{' '}
-                    <strong>JSON file</strong>, or an <strong>XLSX file</strong>{' '}
-                    are accepted
+                    {contentTypeAcceptedMessage}
                 </label>
             </div>
         </div>

--- a/app/src/components/Dropzone/DropzoneWrapper.test.tsx
+++ b/app/src/components/Dropzone/DropzoneWrapper.test.tsx
@@ -1,8 +1,50 @@
 import { render } from '@testing-library/react'
-import { it, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
+import * as useFileUploadModule from './useFileUpload'
 import { DropzoneWrapper } from './DropzoneWrapper'
+
+beforeEach(() => {
+    vi.restoreAllMocks()
+})
 
 it('should render', () => {
     render(<DropzoneWrapper handleValidatedFiles={vi.fn()} />)
+})
+
+describe('DropzoneWrapper', () => {
+    it('renders supported provider names in the message', () => {
+        const { container } = render(
+            <DropzoneWrapper handleValidatedFiles={vi.fn()} />
+        )
+        expect(container.textContent).toContain('Spotify')
+        expect(container.textContent).toContain('Deezer')
+    })
+
+    it('forwards onFail prop to useFileUpload', () => {
+        const useFileUploadSpy = vi
+            .spyOn(useFileUploadModule, 'useFileUpload')
+            .mockReturnValue({ uploadFiles: vi.fn() })
+
+        const onFail = vi.fn()
+        render(
+            <DropzoneWrapper handleValidatedFiles={vi.fn()} onFail={onFail} />
+        )
+
+        expect(useFileUploadSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ onFail })
+        )
+    })
+
+    it('uses a no-op as default onFail when prop is omitted', () => {
+        const useFileUploadSpy = vi
+            .spyOn(useFileUploadModule, 'useFileUpload')
+            .mockReturnValue({ uploadFiles: vi.fn() })
+
+        render(<DropzoneWrapper handleValidatedFiles={vi.fn()} />)
+
+        expect(useFileUploadSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ onFail: expect.any(Function) })
+        )
+    })
 })

--- a/app/src/components/Dropzone/DropzoneWrapper.tsx
+++ b/app/src/components/Dropzone/DropzoneWrapper.tsx
@@ -5,12 +5,16 @@ import { useFileUpload } from './useFileUpload'
 
 interface Props {
     handleValidatedFiles: (files: FileList | null) => void
+    onFail?: (error: unknown) => void
 }
 
-export function DropzoneWrapper({ handleValidatedFiles }: Props) {
+export function DropzoneWrapper({
+    handleValidatedFiles,
+    onFail = () => {},
+}: Props) {
     const { uploadFiles } = useFileUpload({
         onSuccess: (validatedFiles) => handleValidatedFiles(validatedFiles),
-        onFail: () => console.error('Upload failed'),
+        onFail,
     })
 
     const handleFileUpload = async (

--- a/app/src/components/Dropzone/DropzoneWrapper.tsx
+++ b/app/src/components/Dropzone/DropzoneWrapper.tsx
@@ -2,6 +2,7 @@ import { STREAM_PROVIDERS_CONTENT_TYPES } from '../../streamProvider'
 import { zipContentFile } from '../../utils/isZipArchive'
 import { Dropzone } from './Dropzone'
 import { useFileUpload } from './useFileUpload'
+import { getSupportedProviderNames } from '../../streamProvider'
 
 interface Props {
     handleValidatedFiles: (files: FileList | null) => void
@@ -46,12 +47,20 @@ export function DropzoneWrapper({
         zipContentFile,
     ].join(',')
 
+    const names = getSupportedProviderNames()
+    const contentTypeAcceptedMessage = (
+        <>
+            Only <strong>{names.join(', ')}</strong> are accepted
+        </>
+    )
+
     return (
         <Dropzone
             handleDrop={handleDrop}
             handleDragOver={handleDragOver}
             handleFileUpload={handleFileUpload}
             contentTypeAccepted={contentTypeAccepted}
+            contentTypeAcceptedMessage={contentTypeAcceptedMessage}
         />
     )
 }

--- a/app/src/components/Dropzone/useFileUpload.test.tsx
+++ b/app/src/components/Dropzone/useFileUpload.test.tsx
@@ -1,0 +1,111 @@
+import { renderHook } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import * as streamProvider from '../../streamProvider'
+import * as isZipArchiveModule from '../../utils/isZipArchive'
+import * as openArchiveModule from '../../utils/openArchive'
+import { UPLOAD_ERROR } from '../../utils/uploadErrorMessages'
+import { useFileUpload } from './useFileUpload'
+
+beforeEach(() => {
+    vi.restoreAllMocks()
+})
+
+describe('useFileUpload', () => {
+    it('calls onFail with the error when a file has an unsupported content type', async () => {
+        vi.spyOn(streamProvider, 'isAllowedFileContentType').mockReturnValue(
+            false
+        )
+        vi.spyOn(isZipArchiveModule, 'isZipArchive').mockReturnValue(false)
+
+        const onFail = vi.fn()
+        const { result } = renderHook(() =>
+            useFileUpload({ onSuccess: vi.fn(), onFail })
+        )
+
+        const file = new File(['{}'], 'random.json', {
+            type: 'application/json',
+        })
+        const fileList = Object.assign([file], { item: () => file })
+        await result.current.uploadFiles(fileList as unknown as FileList)
+
+        expect(onFail).toHaveBeenCalledOnce()
+        const error = onFail.mock.calls[0][0]
+        expect(error).toBeInstanceOf(Error)
+        expect((error as Error).message).toBe(
+            UPLOAD_ERROR.UNSUPPORTED_CONTENT_TYPE
+        )
+    })
+
+    it('calls onSuccess and does not call onFail when files are valid', async () => {
+        vi.spyOn(streamProvider, 'isAllowedFileContentType').mockReturnValue(
+            true
+        )
+        vi.spyOn(isZipArchiveModule, 'isZipArchive').mockReturnValue(false)
+
+        const onSuccess = vi.fn()
+        const onFail = vi.fn()
+        const { result } = renderHook(() =>
+            useFileUpload({ onSuccess, onFail })
+        )
+
+        const file = new File(['{}'], 'valid.json', {
+            type: 'application/json',
+        })
+        const fileList = Object.assign([file], { item: () => file, length: 1 })
+        await result.current.uploadFiles(fileList as unknown as FileList)
+
+        expect(onSuccess).toHaveBeenCalledOnce()
+        expect(onFail).not.toHaveBeenCalled()
+    })
+
+    it('calls onFail with the thrown value when a non-Error is thrown', async () => {
+        vi.spyOn(streamProvider, 'isAllowedFileContentType').mockImplementation(
+            () => {
+                throw 'unexpected string error'
+            }
+        )
+        vi.spyOn(isZipArchiveModule, 'isZipArchive').mockReturnValue(false)
+
+        const onFail = vi.fn()
+        const { result } = renderHook(() =>
+            useFileUpload({ onSuccess: vi.fn(), onFail })
+        )
+
+        const file = new File(['{}'], 'test.json', { type: 'application/json' })
+        const fileList = Object.assign([file], { item: () => file })
+        await result.current.uploadFiles(fileList as unknown as FileList)
+
+        expect(onFail).toHaveBeenCalledOnce()
+        expect(onFail.mock.calls[0][0]).toBe('unexpected string error')
+    })
+
+    it('calls onFail with the error when a ZIP archive contains no files', async () => {
+        vi.spyOn(streamProvider, 'isAllowedFileContentType').mockReturnValue(
+            true
+        )
+        vi.spyOn(isZipArchiveModule, 'isZipArchive').mockReturnValue(true)
+        vi.spyOn(openArchiveModule, 'openArchive').mockResolvedValue({
+            extractFiles: async () => ({}),
+        } as unknown as Awaited<
+            ReturnType<typeof openArchiveModule.openArchive>
+        >)
+
+        const onFail = vi.fn()
+        const { result } = renderHook(() =>
+            useFileUpload({ onSuccess: vi.fn(), onFail })
+        )
+
+        const file = new File([''], 'empty.zip', { type: 'application/zip' })
+        const fileList = Object.assign([file], {
+            item: (i: number) => [file][i],
+            length: 1,
+        })
+        await result.current.uploadFiles(fileList as unknown as FileList)
+
+        expect(onFail).toHaveBeenCalledOnce()
+        const error = onFail.mock.calls[0][0]
+        expect(error).toBeInstanceOf(Error)
+        expect((error as Error).message).toBe(UPLOAD_ERROR.NO_FILES_IN_ARCHIVE)
+    })
+})

--- a/app/src/components/Dropzone/useFileUpload.tsx
+++ b/app/src/components/Dropzone/useFileUpload.tsx
@@ -2,6 +2,7 @@ import { convertArrayToFileList } from '../../utils/convertArrayToFileList'
 import { isAllowedFileContentType } from '../../streamProvider'
 import { isZipArchive } from '../../utils/isZipArchive'
 import { openArchive } from '../../utils/openArchive'
+import { UPLOAD_ERROR } from '../../utils/uploadErrorMessages'
 
 const HIDDEN_FILE_PREFIX = ['__MACOSX']
 
@@ -21,7 +22,7 @@ export function useFileUpload({
     onFail,
 }: {
     onSuccess: (validatedFiles: FileList) => void
-    onFail: () => void
+    onFail: (error: unknown) => void
 }) {
     /**
      * Filters the provided FileList to only include files with allowed content types.
@@ -40,9 +41,7 @@ export function useFileUpload({
         )
 
         if (allowedFiles.length !== files.length) {
-            throw new Error(
-                'One or more files have an unsupported content type'
-            )
+            throw new Error(UPLOAD_ERROR.UNSUPPORTED_CONTENT_TYPE)
         }
     }
 
@@ -69,7 +68,7 @@ export function useFileUpload({
             })
 
         if (filteredFiles.length === 0) {
-            throw new Error('No files found in the archive')
+            throw new Error(UPLOAD_ERROR.NO_FILES_IN_ARCHIVE)
         }
 
         return convertArrayToFileList(filteredFiles)
@@ -102,7 +101,7 @@ export function useFileUpload({
             onSuccess(validatedFiles)
         } catch (error) {
             console.error('Error while processing files:', error)
-            onFail()
+            onFail(error)
         }
     }
 

--- a/app/src/components/TracksyWrapper.test.tsx
+++ b/app/src/components/TracksyWrapper.test.tsx
@@ -2,11 +2,16 @@ import { it, expect, vi, beforeEach } from 'vitest'
 import {
     render,
     screen,
+    act,
     waitFor,
     waitForElementToBeRemoved,
+    fireEvent,
 } from '@testing-library/react'
 import { TracksyWrapper } from './TracksyWrapper'
 import * as db from '../db/getDB'
+import * as insertQueries from '../db/queries/insertFilesInDatabase'
+import * as streamProvider from '../streamProvider'
+import * as isZipArchiveModule from '../utils/isZipArchive'
 
 beforeEach(() => {
     vi.clearAllMocks()
@@ -61,6 +66,40 @@ it('should render the Dropzone and Buttons when DB is initialized', async () => 
             .getByRole<HTMLAnchorElement>('button', { name: '↓' })
             .getAttribute('title')
     ).toEqual('Load demo data')
+})
+
+it('should show error banner when insertFilesInDatabase rejects', async () => {
+    vi.spyOn(db, 'getDB').mockResolvedValue({
+        db: vi.fn(),
+        conn: vi.fn(),
+    } as unknown as Awaited<ReturnType<typeof db.getDB>>)
+    vi.spyOn(insertQueries, 'insertFilesInDatabase').mockRejectedValue(
+        new Error('No valid stream records found')
+    )
+    vi.spyOn(streamProvider, 'isAllowedFileContentType').mockReturnValue(true)
+    vi.spyOn(isZipArchiveModule, 'isZipArchive').mockReturnValue(false)
+
+    render(
+        <TracksyWrapper
+            initialDb={undefined}
+            initialIsDataDropped={false}
+            initialIsDataReady={false}
+        />
+    )
+    await waitForElementToBeRemoved(() =>
+        screen.queryByText('Initializing the database engine (DuckDB-WASM)...')
+    )
+
+    const input = screen.getByLabelText('upload file')
+    const file = new File(['{}'], 'test.json', { type: 'application/json' })
+    fireEvent.change(input, { target: { files: [file] } })
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('No streaming export recognized.')
+    // dismiss to clear the auto-dismiss timer
+    await act(async () => {
+        fireEvent.click(alert)
+    })
 })
 
 it("shouldn't render the 'how to' button if no URL is defined", async () => {

--- a/app/src/components/TracksyWrapper.tsx
+++ b/app/src/components/TracksyWrapper.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { getDB } from '../db/getDB'
 import { DropzoneWrapper } from './Dropzone/DropzoneWrapper'
 import { insertFilesInDatabase } from '../db/queries/insertFilesInDatabase'
@@ -8,6 +8,8 @@ import { DemoButton } from './DemoButton/DemoButton'
 import { HowToButton } from './HowToButton/HowToButton'
 import { useDemo } from '../hooks/useDemo'
 import { Results } from './Results/Results'
+import { UploadError } from './UploadError'
+import { getUserMessage } from '../utils/uploadErrorMessages'
 
 interface TracksyWrapperProps {
     initialDb?: DuckdbAppType | null
@@ -23,6 +25,8 @@ export function TracksyWrapper({
     const [db, setDb] = useState<DuckdbAppType | null>(initialDb)
     const [isDataDropped, setIsDataDropped] = useState(initialIsDataDropped)
     const [isDataReady, setIsDataReady] = useState(initialIsDataReady)
+    const [uploadError, setUploadError] = useState<string | null>(null)
+    const dismissUploadError = useCallback(() => setUploadError(null), [])
     const { isDemoReady, handleDemoButtonClick, demoJsonUrl } = useDemo()
 
     useEffect(() => {
@@ -44,6 +48,7 @@ export function TracksyWrapper({
             console.error('Failed to upload files:', error)
             setIsDataReady(false)
             setIsDataDropped(false)
+            setUploadError(getUserMessage(error))
         }
     }
 
@@ -64,6 +69,9 @@ export function TracksyWrapper({
                     <div className="flex-grow transition-all duration-300">
                         <DropzoneWrapper
                             handleValidatedFiles={handleFileUpload}
+                            onFail={(error) =>
+                                setUploadError(getUserMessage(error))
+                            }
                         />
                     </div>
                     <div className="flex flex-col justify-center gap-4">
@@ -83,6 +91,12 @@ export function TracksyWrapper({
             )}
             {isDataDropped && !isDataReady && <Spinner />}
             {(isDataReady || isDemoReady) && <Results />}
+            {uploadError && (
+                <UploadError
+                    message={uploadError}
+                    onDismiss={dismissUploadError}
+                />
+            )}
         </>
     )
 }

--- a/app/src/components/UploadError.test.tsx
+++ b/app/src/components/UploadError.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { UploadError } from './UploadError'
+
+describe('UploadError', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it('renders with role="alert" and displays the message', () => {
+        render(<UploadError message="Upload failed" onDismiss={vi.fn()} />)
+        const alert = screen.getByRole('alert')
+        expect(alert.textContent).toBe('Upload failed')
+    })
+
+    it('calls onDismiss when clicked', () => {
+        const onDismiss = vi.fn()
+        render(<UploadError message="Error" onDismiss={onDismiss} />)
+        fireEvent.click(screen.getByRole('alert'))
+        expect(onDismiss).toHaveBeenCalledOnce()
+    })
+
+    it('calls onDismiss when Enter is pressed', () => {
+        const onDismiss = vi.fn()
+        render(<UploadError message="Error" onDismiss={onDismiss} />)
+        fireEvent.keyDown(screen.getByRole('alert'), { key: 'Enter' })
+        expect(onDismiss).toHaveBeenCalledOnce()
+    })
+
+    it('does not call onDismiss for non-Enter key presses', () => {
+        const onDismiss = vi.fn()
+        render(<UploadError message="Error" onDismiss={onDismiss} />)
+        fireEvent.keyDown(screen.getByRole('alert'), { key: 'Escape' })
+        expect(onDismiss).not.toHaveBeenCalled()
+    })
+
+    it('calls onDismiss automatically after DISMISS_DELAY_MS', () => {
+        const onDismiss = vi.fn()
+        render(<UploadError message="Error" onDismiss={onDismiss} />)
+        expect(onDismiss).not.toHaveBeenCalled()
+        act(() => {
+            vi.advanceTimersByTime(8000)
+        })
+        expect(onDismiss).toHaveBeenCalledOnce()
+    })
+
+    it('does not call onDismiss before DISMISS_DELAY_MS elapses', () => {
+        const onDismiss = vi.fn()
+        render(<UploadError message="Error" onDismiss={onDismiss} />)
+        act(() => {
+            vi.advanceTimersByTime(7999)
+        })
+        expect(onDismiss).not.toHaveBeenCalled()
+    })
+})

--- a/app/src/components/UploadError.tsx
+++ b/app/src/components/UploadError.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+
+const DISMISS_DELAY_MS = 8000
+
+interface UploadErrorProps {
+    message: string
+    onDismiss: () => void
+}
+
+export function UploadError({ message, onDismiss }: UploadErrorProps) {
+    useEffect(() => {
+        const t = setTimeout(onDismiss, DISMISS_DELAY_MS)
+        return () => clearTimeout(t)
+    }, [message, onDismiss])
+
+    return (
+        <div
+            role="alert"
+            aria-label="Dismiss error"
+            tabIndex={0}
+            onClick={onDismiss}
+            onKeyDown={(e) => e.key === 'Enter' && onDismiss()}
+            className="fixed top-6 left-1/2 -translate-x-1/2 z-50 cursor-pointer rounded-lg bg-rose-700 px-5 py-3 text-white shadow-lg hover:bg-red-700 transition-colors"
+        >
+            {message}
+        </div>
+    )
+}

--- a/app/src/db/queries/__tests__/test-utils.ts
+++ b/app/src/db/queries/__tests__/test-utils.ts
@@ -24,6 +24,7 @@ export function mockStreamProviderWithSpy(records: StreamRecord[]) {
     const provider = new (class extends StreamProvider {
         readonly name = 'test'
         readonly displayName = 'Test Provider'
+        readonly acceptedFormats = 'TestFormat'
         readonly filePattern = /test\.json$/
         readonly fileContentType = 'application/json'
 

--- a/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.test.ts
+++ b/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.test.ts
@@ -42,6 +42,7 @@ describe('DeezerStreamProvider', () => {
         expect(provider.displayName).toBe('Deezer')
         expect(provider.fileContentType).toBe(XLSX_TYPE)
         expect(provider.filePattern).toBeInstanceOf(RegExp)
+        expect(provider.acceptedFormats).toBe('XLSX')
     })
 
     describe('validateFile', () => {

--- a/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.ts
+++ b/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.ts
@@ -9,6 +9,7 @@ const TMP_FILE_NAME = '_deezer_tmp.xlsx'
 export class DeezerStreamProvider extends StreamProvider<DeezerRawStreamRecord> {
     name = 'deezer'
     displayName = 'Deezer'
+    acceptedFormats = 'XLSX'
     filePattern = /^deezer-data_\d{10}\.xlsx$/i
     fileContentType =
         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'

--- a/app/src/streamProvider/SpotifyStreamProvider/SpotifyStreamProvider.ts
+++ b/app/src/streamProvider/SpotifyStreamProvider/SpotifyStreamProvider.ts
@@ -8,6 +8,7 @@ import type { SpotifyRawStreamRecord } from './types'
 export class SpotifyStreamProvider extends StreamProvider<SpotifyRawStreamRecord> {
     name = 'spotify'
     displayName = 'Spotify'
+    acceptedFormats = 'ZIP/JSON'
     filePattern = /^Streaming_History_Audio_\d{4}(-\d{4})?(_\d+)?\.json$/i
     fileContentType = 'application/json'
 

--- a/app/src/streamProvider/SpotifyStreamProvider/SpotifyStreamingProvider.test.ts
+++ b/app/src/streamProvider/SpotifyStreamProvider/SpotifyStreamingProvider.test.ts
@@ -25,6 +25,7 @@ describe('SpotifyStreamProvider', () => {
         expect(provider.displayName).toBe('Spotify')
         expect(provider.fileContentType).toBe('application/json')
         expect(provider.filePattern).toBeInstanceOf(RegExp)
+        expect(provider.acceptedFormats).toBe('ZIP/JSON')
     })
 
     describe('validateFile', () => {

--- a/app/src/streamProvider/StreamProvider.test.ts
+++ b/app/src/streamProvider/StreamProvider.test.ts
@@ -10,6 +10,7 @@ type TestRawData = {
 class TestProvider extends StreamProvider<TestRawData> {
     name = 'test'
     displayName = 'Test Provider'
+    acceptedFormats = 'TestFormat'
     filePattern = /.*/
     fileContentType = 'application/json'
 

--- a/app/src/streamProvider/StreamProvider.ts
+++ b/app/src/streamProvider/StreamProvider.ts
@@ -17,6 +17,8 @@ export abstract class StreamProvider<TRawData = unknown> {
 
     abstract readonly displayName: string
 
+    abstract readonly acceptedFormats: string
+
     abstract readonly fileContentType: string
 
     /**

--- a/app/src/streamProvider/index.test.ts
+++ b/app/src/streamProvider/index.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import {
     detectProvider,
-    isFileSupported,
+    getSupportedProviderNames,
     isAllowedFileContentType,
+    isFileSupported,
 } from './index'
 
 describe('StreamProvider Factory', () => {
@@ -28,6 +29,23 @@ describe('StreamProvider Factory', () => {
             const streamProvider = detectProvider(file)
 
             expect(streamProvider).toBeUndefined()
+        })
+    })
+
+    describe('getSupportedProviderNames', () => {
+        it('returns a non-empty array of display names', () => {
+            const names = getSupportedProviderNames()
+            expect(names.length).toBeGreaterThan(0)
+            expect(
+                names.every((n) => typeof n === 'string' && n.length > 0)
+            ).toBe(true)
+        })
+
+        it('returns one entry per registered provider with format hint', () => {
+            const names = getSupportedProviderNames()
+            expect(names.length).toBe(2)
+            expect(names).toContain('Spotify (ZIP/JSON)')
+            expect(names).toContain('Deezer (XLSX)')
         })
     })
 

--- a/app/src/streamProvider/index.ts
+++ b/app/src/streamProvider/index.ts
@@ -30,3 +30,9 @@ export const isAllowedFileContentType = (file: File) => {
         (contentType) => contentType === file.type
     )
 }
+
+export function getSupportedProviderNames(): string[] {
+    return STREAM_PROVIDERS.map(
+        (p) => `${p.displayName} (${p.acceptedFormats})`
+    )
+}

--- a/app/src/utils/uploadErrorMessages.test.ts
+++ b/app/src/utils/uploadErrorMessages.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { getUserMessage, UPLOAD_ERROR } from './uploadErrorMessages'
+
+describe('getUserMessage', () => {
+    it('returns unsupported file type message for unsupported content type error', () => {
+        const error = new Error(UPLOAD_ERROR.UNSUPPORTED_CONTENT_TYPE)
+        expect(getUserMessage(error)).toBe(
+            'Unsupported file type. Upload a Spotify ZIP or JSON, or a Deezer XLSX.'
+        )
+    })
+
+    it('returns empty archive message for no files found in archive error', () => {
+        const error = new Error(UPLOAD_ERROR.NO_FILES_IN_ARCHIVE)
+        expect(getUserMessage(error)).toBe(
+            'The ZIP archive is empty or unreadable.'
+        )
+    })
+
+    it('returns unrecognized export message for no valid stream records error', () => {
+        const error = new Error(UPLOAD_ERROR.NO_VALID_RECORDS)
+        expect(getUserMessage(error)).toBe(
+            'No streaming export recognized. Supported: Spotify (ZIP/JSON), Deezer (XLSX).'
+        )
+    })
+
+    it('returns no file received message for no file to process error', () => {
+        const error = new Error(UPLOAD_ERROR.NO_FILE_TO_PROCESS)
+        expect(getUserMessage(error)).toBe('No file received. Try again.')
+    })
+
+    it('returns generic fallback message for unknown errors', () => {
+        const error = new Error('Something unexpected happened')
+        expect(getUserMessage(error)).toBe(
+            'Upload failed. Check the file and try again.'
+        )
+    })
+
+    it('returns generic fallback message for non-Error values', () => {
+        expect(getUserMessage('some string error')).toBe(
+            'Upload failed. Check the file and try again.'
+        )
+        expect(getUserMessage(null)).toBe(
+            'Upload failed. Check the file and try again.'
+        )
+        expect(getUserMessage(undefined)).toBe(
+            'Upload failed. Check the file and try again.'
+        )
+    })
+})

--- a/app/src/utils/uploadErrorMessages.test.ts
+++ b/app/src/utils/uploadErrorMessages.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
+import { getSupportedProviderNames } from '../streamProvider'
 import { getUserMessage, UPLOAD_ERROR } from './uploadErrorMessages'
 
 describe('getUserMessage', () => {
     it('returns unsupported file type message for unsupported content type error', () => {
         const error = new Error(UPLOAD_ERROR.UNSUPPORTED_CONTENT_TYPE)
-        expect(getUserMessage(error)).toBe(
-            'Unsupported file type. Upload a Spotify ZIP or JSON, or a Deezer XLSX.'
-        )
+        const expected = `Unsupported file type. Supported: ${getSupportedProviderNames().join(', ')}.`
+        expect(getUserMessage(error)).toBe(expected)
     })
 
     it('returns empty archive message for no files found in archive error', () => {
@@ -19,9 +19,8 @@ describe('getUserMessage', () => {
 
     it('returns unrecognized export message for no valid stream records error', () => {
         const error = new Error(UPLOAD_ERROR.NO_VALID_RECORDS)
-        expect(getUserMessage(error)).toBe(
-            'No streaming export recognized. Supported: Spotify (ZIP/JSON), Deezer (XLSX).'
-        )
+        const expected = `No streaming export recognized. Supported: ${getSupportedProviderNames().join(', ')}.`
+        expect(getUserMessage(error)).toBe(expected)
     })
 
     it('returns no file received message for no file to process error', () => {

--- a/app/src/utils/uploadErrorMessages.ts
+++ b/app/src/utils/uploadErrorMessages.ts
@@ -1,0 +1,20 @@
+export const UPLOAD_ERROR = {
+    UNSUPPORTED_CONTENT_TYPE:
+        'One or more files have an unsupported content type',
+    NO_FILES_IN_ARCHIVE: 'No files found in the archive',
+    NO_VALID_RECORDS: 'No valid stream records found',
+    NO_FILE_TO_PROCESS: 'No file to process',
+} as const
+
+export function getUserMessage(error: unknown): string {
+    const msg = error instanceof Error ? error.message : ''
+    if (msg === UPLOAD_ERROR.UNSUPPORTED_CONTENT_TYPE)
+        return 'Unsupported file type. Upload a Spotify ZIP or JSON, or a Deezer XLSX.'
+    if (msg === UPLOAD_ERROR.NO_FILES_IN_ARCHIVE)
+        return 'The ZIP archive is empty or unreadable.'
+    if (msg === UPLOAD_ERROR.NO_VALID_RECORDS)
+        return 'No streaming export recognized. Supported: Spotify (ZIP/JSON), Deezer (XLSX).'
+    if (msg === UPLOAD_ERROR.NO_FILE_TO_PROCESS)
+        return 'No file received. Try again.'
+    return 'Upload failed. Check the file and try again.'
+}

--- a/app/src/utils/uploadErrorMessages.ts
+++ b/app/src/utils/uploadErrorMessages.ts
@@ -1,3 +1,5 @@
+import { getSupportedProviderNames } from '../streamProvider'
+
 export const UPLOAD_ERROR = {
     UNSUPPORTED_CONTENT_TYPE:
         'One or more files have an unsupported content type',
@@ -9,11 +11,11 @@ export const UPLOAD_ERROR = {
 export function getUserMessage(error: unknown): string {
     const msg = error instanceof Error ? error.message : ''
     if (msg === UPLOAD_ERROR.UNSUPPORTED_CONTENT_TYPE)
-        return 'Unsupported file type. Upload a Spotify ZIP or JSON, or a Deezer XLSX.'
+        return `Unsupported file type. Supported: ${getSupportedProviderNames().join(', ')}.`
     if (msg === UPLOAD_ERROR.NO_FILES_IN_ARCHIVE)
         return 'The ZIP archive is empty or unreadable.'
     if (msg === UPLOAD_ERROR.NO_VALID_RECORDS)
-        return 'No streaming export recognized. Supported: Spotify (ZIP/JSON), Deezer (XLSX).'
+        return `No streaming export recognized. Supported: ${getSupportedProviderNames().join(', ')}.`
     if (msg === UPLOAD_ERROR.NO_FILE_TO_PROCESS)
         return 'No file received. Try again.'
     return 'Upload failed. Check the file and try again.'


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Fixes #151.

When a user uploads an unsupported or unrecognized file, the app silently resets to the dropzone. Errors only appear in the browser console. No user-facing feedback is shown.

## 🎹 Proposal

Introduce clear, user-facing error messages when something goes wrong during file upload.
Users now receive immediate feedback explaining why their upload failed, instead of the app failing silently.

Render provider name and format hints in dropzone message.

## 🎶 Comments

Pure `getUserMessage(error)` function that maps internal error strings to human-readable messages; generic fallback for unknown errors. Error messages shown:
| Scenario | Message |
|---|---|
| Wrong MIME type | "Unsupported file type. Upload a Spotify ZIP or JSON, or a Deezer XLSX." |
| Empty ZIP | "The ZIP archive is empty or unreadable." |
| No provider match / no records | "No streaming export recognized. Supported: Spotify (ZIP/JSON), Deezer (XLSX)." |
| No file | "No file received. Try again." |
| Unknown error | "Upload failed. Check the file and try again." |

Stateless error banner (`role="alert"`), auto-dismisses after 8s or on click. 
The toast component is intentionally homemade (no new dependency). Swapping to a library like `sonner` later requires changing one file (`UploadError.tsx` + the two `toast.error()` call sites).

## 🎤 Test

1. Run `moon run app:dev`
2. Upload any random `.json` file -> error banner appears at top of screen
3. Upload a `.pdf` -> error banner appears
4. Upload a valid Spotify export / or demo -> processes normally, no banner
5. Banner auto-dismisses after 8s or on click