### PR TITLE
test(e2e): fix simple view label assertion

### DIFF
--- a/e2e/tests/main.spec.ts
+++ b/e2e/tests/main.spec.ts
@@ -18,7 +18,7 @@ test("has title and can upload dataset", async ({ page }) => {
   await fileInput.setInputFiles(path.join(__dirname, "../datasets/spotify/streamings_1000.zip"));
 
   // Simple view assertions
-  const simpleViewTab = page.getByRole("tab", { name: /Simple View/ });
+  const simpleViewTab = page.getByRole("tab", { name: /✨ Simple/ });
   await expect(simpleViewTab).toBeVisible();
 
   // Assert it is active (selected)


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem
After #399 E2E tests [fail](https://github.com/Gudsfile/tracksy/actions/runs/26136063871):
```
e2e:test |       20 |   // Simple view assertions
e2e:test |       21 |   const simpleViewTab = page.getByRole("tab", { name: /Simple View/ });
e2e:test |     > 22 |   await expect(simpleViewTab).toBeVisible();
e2e:test |          |                               ^

e2e:test |   3 failed
e2e:test |     [chromium] › tests/main.spec.ts:6:5 › has title and can upload dataset ─────────────────────────
e2e:test |     [firefox] › tests/main.spec.ts:6:5 › has title and can upload dataset ──────────────────────────
e2e:test |     [webkit] › tests/main.spec.ts:6:5 › has title and can upload dataset ───────────────────────────
```

## 🎹 Proposal

Remove the removed `View` suffix.

## 🎶 Comments

<!-- Additional information, tips or problems encountered. -->

## 🎤 Test

<!-- Instructions for reproducing the problem and how you tested the fix. -->
