### PR TITLE
feat(app): add dedicated Query view for DuckDB Shell

### DIFF
--- a/app/src/components/Charts/LabView.tsx
+++ b/app/src/components/Charts/LabView.tsx
@@ -22,7 +22,6 @@ import { Top10TracksEvolution } from './LabCharts/Top10TracksEvolution'
 import { StreamPerDayOfWeek } from './LabCharts/StreamPerDayOfWeek'
 import { ArtistDiscovery } from './LabCharts/ArtistDiscovery'
 import { SessionAnalysis as SessionAnalysisDetailed } from './LabCharts/SessionAnalysis'
-import { DuckDBShell } from '../DuckDBShell/DuckDBShell'
 
 export function LabView() {
     const [year, setYear] = useState<number | undefined>(2006)
@@ -109,7 +108,6 @@ export function LabView() {
                 <Top10TracksEvolution />
                 <SessionAnalysisDetailed year={debouncedYear} />
             </section>
-            <DuckDBShell />
         </>
     )
 }

--- a/app/src/components/Charts/QueryView.test.tsx
+++ b/app/src/components/Charts/QueryView.test.tsx
@@ -1,0 +1,17 @@
+import { it, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryView } from './QueryView'
+import * as db from '../../db/getDB'
+
+beforeEach(() => {
+    vi.spyOn(db, 'getDB').mockResolvedValue({
+        db: vi.fn(),
+        conn: { query: vi.fn() },
+    } as unknown as Awaited<ReturnType<typeof db.getDB>>)
+})
+
+it('renders DuckDB Shell', () => {
+    render(<QueryView />)
+    screen.getByText('⌨️ DuckDB Shell')
+    screen.getByRole('button', { name: /Run query/i })
+})

--- a/app/src/components/Charts/QueryView.tsx
+++ b/app/src/components/Charts/QueryView.tsx
@@ -1,0 +1,9 @@
+import { DuckDBShell } from '../DuckDBShell/DuckDBShell'
+
+export function QueryView() {
+    return (
+        <>
+            <DuckDBShell />
+        </>
+    )
+}

--- a/app/src/components/Charts/QueryView.tsx
+++ b/app/src/components/Charts/QueryView.tsx
@@ -2,8 +2,8 @@ import { DuckDBShell } from '../DuckDBShell/DuckDBShell'
 
 export function QueryView() {
     return (
-        <>
+        <div className="flex flex-col gap-4 py-4">
             <DuckDBShell />
-        </>
+        </div>
     )
 }

--- a/app/src/components/DuckDBShell/DuckDBShell.tsx
+++ b/app/src/components/DuckDBShell/DuckDBShell.tsx
@@ -50,7 +50,7 @@ export function DuckDBShell() {
     }, [query])
 
     return (
-        <div className="group p-6 my-4 bg-white dark:bg-slate-900/80 backdrop-blur-md rounded-2xl border border-gray-300/60 dark:border-slate-700/50 text-gray-900 dark:text-gray-100">
+        <div className="p-6 bg-white dark:bg-slate-900/80 backdrop-blur-md rounded-2xl border border-gray-300/60 dark:border-slate-700/50 text-gray-900 dark:text-gray-100">
             <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
                 ⌨️ DuckDB Shell
             </h3>
@@ -73,7 +73,7 @@ export function DuckDBShell() {
                     <button
                         type="submit"
                         disabled={loading}
-                        className="col-start-2 mt-2 bg-brand-purple rounded-lg text-gray-100 px-4 py-2"
+                        className="col-start-2 mt-2 bg-gradient-brand text-white font-semibold rounded-xl shadow-glow disabled:opacity-50 disabled:cursor-not-allowed transition-all px-4 py-2"
                     >
                         Run query
                     </button>

--- a/app/src/components/Results/Results.test.tsx
+++ b/app/src/components/Results/Results.test.tsx
@@ -21,6 +21,7 @@ describe('Results Component', () => {
         // Check that both buttons are rendered
         screen.getByRole('tab', { name: '✨ Simple' })
         screen.getByRole('tab', { name: '🔬 Lab' })
+        screen.getByRole('tab', { name: '⌨️ Query' })
 
         // Simple default to Simple view
         // Simple View contains specific charts like "Concentration Score" or just checking absent Lab content
@@ -40,6 +41,14 @@ describe('Results Component', () => {
         screen.queryByText(/Work in Progress/i)
 
         // We can check if RangeSlider is present (common) but distinguishing is key.
+    })
+
+    it('switches to query view when Query button is clicked', async () => {
+        render(<Results />)
+
+        fireEvent.click(screen.getByRole('tab', { name: '⌨️ Query' }))
+
+        screen.getByText('⌨️ DuckDB Shell')
     })
 
     it('switches to lab view when Lab View button is clicked', async () => {

--- a/app/src/components/Results/Results.tsx
+++ b/app/src/components/Results/Results.tsx
@@ -1,14 +1,16 @@
 import { LabView } from '../Charts/LabView'
 import { SimpleView } from '../Charts/SimpleView'
 import { ChatView } from '../Charts/ChatView'
+import { QueryView } from '../Charts/QueryView'
 import { useState } from 'react'
 
-type Tab = 'simple' | 'lab' | 'chat'
+type Tab = 'simple' | 'lab' | 'chat' | 'query'
 
 const TABS: { id: Tab; label: string }[] = [
     { id: 'simple', label: '✨ Simple' },
     { id: 'lab', label: '🔬 Lab' },
     { id: 'chat', label: '💬 Chat (beta)' },
+    { id: 'query', label: '⌨️ Query' },
 ]
 
 export function Results() {
@@ -19,8 +21,9 @@ export function Results() {
         <div className="py-8 animate-slide-up">
             <div className="relative mb-8 bg-gray-100 dark:bg-slate-800/50 backdrop-blur-md p-1.5 rounded-2xl shadow-lg border border-gray-300/60 dark:border-slate-700/50 max-w-xl mx-auto">
                 <div
-                    className="absolute top-1.5 left-1.5 h-[calc(100%-0.75rem)] w-[calc(33.3333%-0.25rem)] bg-gradient-brand rounded-xl shadow-glow transition-transform duration-300 ease-out"
+                    className="absolute top-1.5 left-1.5 h-[calc(100%-0.75rem)] bg-gradient-brand rounded-xl shadow-glow transition-transform duration-300 ease-out"
                     style={{
+                        width: `calc(${(100 / TABS.length).toFixed(4)}% - 0.25rem)`,
                         transform: `translateX(calc(${tabIndex} * (100% + 0.125rem)))`,
                     }}
                 />
@@ -49,6 +52,8 @@ export function Results() {
                     <SimpleView />
                 ) : activeTab === 'lab' ? (
                     <LabView />
+                ) : activeTab === 'query' ? (
+                    <QueryView />
                 ) : (
                     <ChatView />
                 )}


### PR DESCRIPTION


## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem
Closes #397 

## 🎹 Proposal
Move DuckDB Shell out of Lab view into its own Query tab. 

## 🎶 Comments
Fix tab indicator width to be computed from tab count instead of hardcoded for 3 tabs.

## 🎤 Test

<!-- Instructions for reproducing the problem and how you tested the fix. -->
