### PR TITLE
feat(app): add tooltips on navigation tabs

### DIFF
--- a/app/src/components/Results/Results.tsx
+++ b/app/src/components/Results/Results.tsx
@@ -6,11 +6,27 @@ import { useState } from 'react'
 
 type Tab = 'simple' | 'lab' | 'chat' | 'query'
 
-const TABS: { id: Tab; label: string }[] = [
-    { id: 'simple', label: '✨ Simple' },
-    { id: 'lab', label: '🔬 Lab' },
-    { id: 'chat', label: '💬 Chat (beta)' },
-    { id: 'query', label: '⌨️ Query' },
+const TABS: { id: Tab; label: string; tooltip: string }[] = [
+    {
+        id: 'simple',
+        label: '✨ Simple',
+        tooltip: 'Curated and guided overview of your listening data',
+    },
+    {
+        id: 'lab',
+        label: '🔬 Lab',
+        tooltip: 'Experimental insights and advanced visualizations',
+    },
+    {
+        id: 'chat',
+        label: '💬 Chat (beta)',
+        tooltip: 'Conversational exploration using a built-in LLM',
+    },
+    {
+        id: 'query',
+        label: '⌨️ Query',
+        tooltip: 'Direct SQL-based exploration of the dataset',
+    },
 ]
 
 export function Results() {
@@ -34,14 +50,21 @@ export function Results() {
                             key={tab.id}
                             role="tab"
                             aria-selected={activeTab === tab.id}
+                            title={tab.tooltip}
                             onClick={() => setActiveTab(tab.id)}
-                            className={`relative z-10 flex-1 px-4 py-3 text-sm font-semibold rounded-xl transition-all duration-300 ${
+                            className={`group relative z-10 flex-1 px-4 py-3 text-sm font-semibold rounded-xl transition-all duration-300 ${
                                 activeTab === tab.id
                                     ? 'text-white'
                                     : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
                             }`}
                         >
                             {tab.label}
+                            <span
+                                aria-hidden="true"
+                                className="pointer-events-none absolute left-1/2 top-full mt-2 -translate-x-1/2 whitespace-nowrap rounded-lg bg-gray-900 px-2 py-1 text-xs font-normal text-white opacity-0 transition-opacity duration-200 group-hover:opacity-100 dark:bg-slate-700"
+                            >
+                                {tab.tooltip}
+                            </span>
                         </button>
                     ))}
                 </div>


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem
Closes #401 

## 🎹 Proposal
Add hover tooltips to each tab describing its purpose. 

## 🎶 Comments
Tooltip text is hidden from the accessibility tree via aria-hidden to preserve existing tab accessible names.

## 🎤 Test

<!-- Instructions for reproducing the problem and how you tested the fix. -->
