### PR TITLE
feat(providers): add experimental Apple Music support

### DIFF
--- a/.github/workflows/datasets-generate-synthetic.yml
+++ b/.github/workflows/datasets-generate-synthetic.yml
@@ -40,6 +40,7 @@ jobs:
           moon run synthetic-datasets:generate -- 1000 --provider deezer
           moon run synthetic-datasets:generate -- 25000 --provider deezer
           moon run synthetic-datasets:generate -- 500000 --provider deezer
+          moon run synthetic-datasets:generate -- 25000 --provider apple-music
 
       - name: Clone HF repo and move datasets into it
         env:

--- a/README.md
+++ b/README.md
@@ -59,8 +59,11 @@ Or bring your own data:
 
 
 <details>
-<summary>Apple Music</summary>
+<summary>Apple Music ⚠️ Experimental</summary>
 <br>
+
+> **Warning**
+> Apple Music support is experimental. The export format has significant limitations: artist name is not included in the data, which means artist-based charts will not populate. Some data quality issues may affect visualizations. Use at your own discretion.
 
 1. Sign in at [privacy.apple.com](https://privacy.apple.com) and request a copy of your data.
   - Click "_Request a copy of your data_"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ Or bring your own data:
 
 </details>
 
+
+<details>
+<summary>Apple Music</summary>
+<br>
+
+1. Sign in at [privacy.apple.com](https://privacy.apple.com) and request a copy of your data.
+  - Click "_Request a copy of your data_"
+  - Select "_Apple Media Services information_" in the data categories
+  - Submit the request
+2. Wait a few days
+3. Download and extract the ZIP you receive by email
+4. Inside the archive, navigate to `Apple Music Activity/` and find `Apple Music Play Activity.csv`.
+5. If the data is in a nested ZIP (e.g. `Apple_Media_Services.zip`), upload the outer ZIP directly, Tracksy extracts it automatically.
+
+</details>
+
 ### 🚀 Upload your data
 
 Go to [Tracksy](https://gudsfile.github.io/tracksy/) and upload your file, or hit the demo button.

--- a/app/src/components/Charts/SimpleCharts/PrincipalPlatform/PrincipalPlatform.sql
+++ b/app/src/components/Charts/SimpleCharts/PrincipalPlatform/PrincipalPlatform.sql
@@ -23,10 +23,14 @@ normalized_platforms as (
             when
                 lower(platform) like 'ios%'
                 or lower(platform) like '%partner ios%'
+                or lower(platform) = 'iphone'
                 then 'iOS'
             when
-                lower(platform) like 'osx%' or lower(platform) like 'os x%'
+                lower(platform) like 'osx%'
+                or lower(platform) like 'os x%'
+                or lower(platform) = 'macintosh'
                 then 'MacOS'
+            when lower(platform) = 'homepod' then 'HomePod'
             when
                 lower(platform) like 'sonos_%'
                 or lower(platform) like '%partner sonos%'

--- a/app/src/components/Dropzone/useFileUpload.tsx
+++ b/app/src/components/Dropzone/useFileUpload.tsx
@@ -1,10 +1,8 @@
 import { convertArrayToFileList } from '../../utils/convertArrayToFileList'
+import { extractFilesRecursively } from '../../utils/extractFilesRecursively'
 import { isAllowedFileContentType } from '../../streamProvider'
 import { isZipArchive } from '../../utils/isZipArchive'
-import { openArchive } from '../../utils/openArchive'
 import { UPLOAD_ERROR } from '../../utils/uploadErrorMessages'
-
-const HIDDEN_FILE_PREFIX = ['__MACOSX']
 
 /**
  * Custom hook for handling file uploads with validation and processing.
@@ -54,24 +52,13 @@ export function useFileUpload({
      * @throws {Error} - Throws an error if no files are found in the archive.
      */
     const manageZipArchive = async (file: File): Promise<FileList> => {
-        const archive = await openArchive(file)
-        const extractedFiles: Record<string, File | Record<string, File>> =
-            await archive.extractFiles()
+        const extractedFiles = await extractFilesRecursively(file)
 
-        const filteredFiles = Object.entries(extractedFiles)
-            .filter(
-                ([key]) =>
-                    !HIDDEN_FILE_PREFIX.some((prefix) => key.startsWith(prefix))
-            )
-            .flatMap(([, value]) => {
-                return value instanceof File ? [value] : Object.values(value)
-            })
-
-        if (filteredFiles.length === 0) {
+        if (extractedFiles.length === 0) {
             throw new Error(UPLOAD_ERROR.NO_FILES_IN_ARCHIVE)
         }
 
-        return convertArrayToFileList(filteredFiles)
+        return convertArrayToFileList(extractedFiles)
     }
 
     /**

--- a/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.test.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.test.ts
@@ -82,8 +82,8 @@ describe('AppleMusicStreamProvider', () => {
             const expected: StreamRecord = {
                 track_uri: 'apple-music:Never Gonna Give You Up',
                 track_name: 'Never Gonna Give You Up',
-                artist_name: '',
-                album_name: '',
+                artist_name: 'Unknown Artist',
+                album_name: 'Unknown Album',
                 ts: '2024-03-15T14:30:00.000Z',
                 ms_played: 213000,
                 platform: 'IPHONE',
@@ -98,14 +98,23 @@ describe('AppleMusicStreamProvider', () => {
             expect(result[0].track_name).toBe('Never Gonna Give You Up')
         })
 
-        it('should set artist_name to empty string', () => {
+        it('should set artist_name to Unknown Artist', () => {
             const result = provider.transform([RAW_AUDIO])
-            expect(result[0].artist_name).toBe('')
+            expect(result[0].artist_name).toBe('Unknown Artist')
         })
 
-        it('should set album_name to empty string', () => {
+        it('should set album_name to Unknown Album when Album Name is null', () => {
             const result = provider.transform([RAW_AUDIO])
-            expect(result[0].album_name).toBe('')
+            expect(result[0].album_name).toBe('Unknown Album')
+        })
+
+        it('should set album_name when Album Name is present', () => {
+            const record: AppleMusicRawRecord = {
+                ...RAW_AUDIO,
+                'Album Name': 'Whenever You Need Somebody',
+            }
+            const result = provider.transform([record])
+            expect(result[0].album_name).toBe('Whenever You Need Somebody')
         })
 
         it('should guard against negative Play Duration Milliseconds', () => {

--- a/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.test.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.test.ts
@@ -25,7 +25,7 @@ const RAW_AUDIO: AppleMusicRawRecord = {
     'Media Type': 'AUDIO',
     'Event Start Timestamp': new Date('2024-03-15T14:30:00.000Z'),
     'Play Duration Milliseconds': 213000,
-    'Client Platform': 'FUSE',
+    'Device Type': 'IPHONE',
     'Container Origin Type': null,
 }
 
@@ -36,7 +36,7 @@ const RAW_VIDEO: AppleMusicRawRecord = {
     'Media Type': 'VIDEO',
     'Event Start Timestamp': new Date('2024-03-15T15:00:00.000Z'),
     'Play Duration Milliseconds': 120000,
-    'Client Platform': 'FUSE',
+    'Device Type': 'IPHONE',
     'Container Origin Type': null,
 }
 
@@ -86,7 +86,7 @@ describe('AppleMusicStreamProvider', () => {
                 album_name: '',
                 ts: '2024-03-15T14:30:00.000Z',
                 ms_played: 213000,
-                platform: 'FUSE',
+                platform: 'IPHONE',
             }
             expect(result).toHaveLength(1)
             expect(result[0]).toEqual(expected)

--- a/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.test.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { AppleMusicStreamProvider } from './AppleMusicStreamProvider'
+import type { AppleMusicRawRecord } from './types'
+import type { StreamRecord } from '../types'
+
+function mockFile(
+    buffer: ArrayBuffer,
+    name: string,
+    options: { type: string }
+) {
+    return {
+        name,
+        arrayBuffer: async () => buffer,
+        type: options.type,
+        size: buffer.byteLength,
+    } as unknown as File
+}
+
+const CSV_TYPE = 'text/csv'
+
+const RAW_AUDIO: AppleMusicRawRecord = {
+    'Song Name': 'Never Gonna Give You Up',
+    'Album Name': null,
+    'Container Artist Name': null,
+    'Media Type': 'AUDIO',
+    'Event Start Timestamp': new Date('2024-03-15T14:30:00.000Z'),
+    'Play Duration Milliseconds': 213000,
+    'Client Platform': 'FUSE',
+}
+
+const RAW_VIDEO: AppleMusicRawRecord = {
+    'Song Name': 'Some Video',
+    'Album Name': null,
+    'Container Artist Name': null,
+    'Media Type': 'VIDEO',
+    'Event Start Timestamp': new Date('2024-03-15T15:00:00.000Z'),
+    'Play Duration Milliseconds': 120000,
+    'Client Platform': 'FUSE',
+}
+
+describe('AppleMusicStreamProvider', () => {
+    const provider = new AppleMusicStreamProvider()
+
+    it('should return correct metadata', () => {
+        expect(provider.name).toBe('apple-music')
+        expect(provider.displayName).toBe('Apple Music')
+        expect(provider.fileContentType).toBe(CSV_TYPE)
+        expect(provider.filePattern).toBeInstanceOf(RegExp)
+        expect(provider.acceptedFormats).toBe('ZIP/CSV')
+    })
+
+    describe('validateFile', () => {
+        it.each([
+            'Apple Music Play Activity.csv',
+            'apple music play activity.csv',
+            'APPLE MUSIC PLAY ACTIVITY.CSV',
+        ])('should return true for %s', (filename) => {
+            const file = mockFile(new ArrayBuffer(0), filename, {
+                type: CSV_TYPE,
+            })
+            expect(provider.validateFile(file)).toBe(true)
+        })
+
+        it.each([
+            'AppleMusicPlayActivity.csv',
+            'Apple Music.csv',
+            'Apple Music Play Activity.json',
+            'play_activity.csv',
+        ])('should return false for %s', (filename) => {
+            const file = mockFile(new ArrayBuffer(0), filename, {
+                type: CSV_TYPE,
+            })
+            expect(provider.validateFile(file)).toBe(false)
+        })
+    })
+
+    describe('transform', () => {
+        it('should map AUDIO record to StreamRecord', () => {
+            const result = provider.transform([RAW_AUDIO])
+            const expected: StreamRecord = {
+                track_uri: 'apple-music:Never Gonna Give You Up',
+                track_name: 'Never Gonna Give You Up',
+                artist_name: '',
+                album_name: '',
+                ts: '2024-03-15T14:30:00.000Z',
+                ms_played: 213000,
+                platform: 'FUSE',
+            }
+            expect(result).toHaveLength(1)
+            expect(result[0]).toEqual(expected)
+        })
+
+        it('should filter out non-AUDIO records', () => {
+            const result = provider.transform([RAW_AUDIO, RAW_VIDEO])
+            expect(result).toHaveLength(1)
+            expect(result[0].track_name).toBe('Never Gonna Give You Up')
+        })
+
+        it('should set artist_name to empty string', () => {
+            const result = provider.transform([RAW_AUDIO])
+            expect(result[0].artist_name).toBe('')
+        })
+
+        it('should set album_name to empty string', () => {
+            const result = provider.transform([RAW_AUDIO])
+            expect(result[0].album_name).toBe('')
+        })
+
+        it('should guard against negative Play Duration Milliseconds', () => {
+            const record: AppleMusicRawRecord = {
+                ...RAW_AUDIO,
+                'Play Duration Milliseconds': -140027,
+            }
+            const result = provider.transform([record])
+            expect(result[0].ms_played).toBe(0)
+        })
+
+        it('should guard against null Play Duration Milliseconds', () => {
+            const record: AppleMusicRawRecord = {
+                ...RAW_AUDIO,
+                'Play Duration Milliseconds': null,
+            }
+            const result = provider.transform([record])
+            expect(result[0].ms_played).toBe(0)
+        })
+
+        it('should handle string-typed Event Start Timestamp', () => {
+            const record: AppleMusicRawRecord = {
+                ...RAW_AUDIO,
+                'Event Start Timestamp': '2024-03-15T14:30:00.000Z',
+            }
+            const result = provider.transform([record])
+            expect(result[0].ts).toBe('2024-03-15T14:30:00.000Z')
+        })
+
+        it('should handle null Event Start Timestamp gracefully', () => {
+            const record: AppleMusicRawRecord = {
+                ...RAW_AUDIO,
+                'Event Start Timestamp': null,
+            }
+            const result = provider.transform([record])
+            expect(result[0].ts).toBe('')
+        })
+
+        it('should build track_uri with apple-music prefix', () => {
+            const result = provider.transform([RAW_AUDIO])
+            expect(result[0].track_uri).toBe(
+                'apple-music:Never Gonna Give You Up'
+            )
+        })
+
+        it('should handle empty input array', () => {
+            expect(provider.transform([])).toEqual([])
+        })
+    })
+
+    describe('readFile', () => {
+        let mockConn: {
+            query: ReturnType<typeof vi.fn>
+        }
+        let mockDb: {
+            registerFileBuffer: ReturnType<typeof vi.fn>
+            dropFile: ReturnType<typeof vi.fn>
+        }
+
+        beforeEach(() => {
+            mockConn = {
+                query: vi.fn(),
+            }
+            mockDb = {
+                registerFileBuffer: vi.fn(),
+                dropFile: vi.fn(),
+            }
+        })
+
+        it('should register, query, and drop the temp file', async () => {
+            const mockRow = {
+                toJSON: () => ({ ...RAW_AUDIO }),
+            }
+            mockConn.query.mockResolvedValue({
+                toArray: () => [mockRow],
+            })
+
+            const getDB = await import('../../db/getDB')
+            vi.spyOn(getDB, 'getDB').mockResolvedValue({
+                db: mockDb as never,
+                conn: mockConn as never,
+            })
+
+            const file = mockFile(
+                new ArrayBuffer(8),
+                'Apple Music Play Activity.csv',
+                {
+                    type: CSV_TYPE,
+                }
+            )
+
+            const result = await provider.readFile(file)
+
+            expect(mockDb.registerFileBuffer).toHaveBeenCalledWith(
+                '_apple_music_tmp.csv',
+                expect.any(Uint8Array)
+            )
+            expect(mockConn.query).toHaveBeenCalledWith(
+                expect.stringContaining('read_csv')
+            )
+            expect(mockDb.dropFile).toHaveBeenCalledWith('_apple_music_tmp.csv')
+            expect(result).toHaveLength(1)
+        })
+
+        it('should drop temp file even if query fails', async () => {
+            mockConn.query.mockRejectedValue(new Error('query failed'))
+
+            const getDB = await import('../../db/getDB')
+            vi.spyOn(getDB, 'getDB').mockResolvedValue({
+                db: mockDb as never,
+                conn: mockConn as never,
+            })
+
+            const file = mockFile(
+                new ArrayBuffer(8),
+                'Apple Music Play Activity.csv',
+                {
+                    type: CSV_TYPE,
+                }
+            )
+
+            await expect(provider.readFile(file)).rejects.toThrow(
+                'query failed'
+            )
+            expect(mockDb.dropFile).toHaveBeenCalledWith('_apple_music_tmp.csv')
+        })
+    })
+})

--- a/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.test.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.test.ts
@@ -26,6 +26,7 @@ const RAW_AUDIO: AppleMusicRawRecord = {
     'Event Start Timestamp': new Date('2024-03-15T14:30:00.000Z'),
     'Play Duration Milliseconds': 213000,
     'Client Platform': 'FUSE',
+    'Container Origin Type': null,
 }
 
 const RAW_VIDEO: AppleMusicRawRecord = {
@@ -36,6 +37,7 @@ const RAW_VIDEO: AppleMusicRawRecord = {
     'Event Start Timestamp': new Date('2024-03-15T15:00:00.000Z'),
     'Play Duration Milliseconds': 120000,
     'Client Platform': 'FUSE',
+    'Container Origin Type': null,
 }
 
 describe('AppleMusicStreamProvider', () => {
@@ -147,6 +149,16 @@ describe('AppleMusicStreamProvider', () => {
             expect(result[0].track_uri).toBe(
                 'apple-music:Never Gonna Give You Up'
             )
+        })
+
+        it('should filter out STREAM_RADIO_STATION records', () => {
+            const radioRecord: AppleMusicRawRecord = {
+                ...RAW_AUDIO,
+                'Container Origin Type': 'STREAM_RADIO_STATION',
+            }
+            const result = provider.transform([RAW_AUDIO, radioRecord])
+            expect(result).toHaveLength(1)
+            expect(result[0].track_name).toBe('Never Gonna Give You Up')
         })
 
         it('should handle empty input array', () => {

--- a/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.ts
@@ -48,11 +48,17 @@ export class AppleMusicStreamProvider extends StreamProvider<AppleMusicRawRecord
                 return {
                     track_uri: `apple-music:${String(r['Song Name'] ?? '')}`,
                     track_name: String(r['Song Name'] ?? ''),
-                    artist_name: '',
-                    album_name: String(r['Album Name'] ?? ''),
+                    artist_name: 'Unknown Artist',
+                    album_name:
+                        r['Album Name'] != null
+                            ? String(r['Album Name'])
+                            : 'Unknown Album',
                     ts,
                     ms_played: Math.max(0, msDuration),
-                    platform: String(r['Device Type'] ?? ''),
+                    platform:
+                        r['Device Type'] != null
+                            ? String(r['Device Type'])
+                            : 'Unknown Device',
                 }
             })
     }

--- a/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.ts
@@ -31,7 +31,11 @@ export class AppleMusicStreamProvider extends StreamProvider<AppleMusicRawRecord
 
     transform(rawData: AppleMusicRawRecord[]): StreamRecord[] {
         return rawData
-            .filter((r) => r['Media Type'] === 'AUDIO')
+            .filter(
+                (r) =>
+                    r['Media Type'] === 'AUDIO' &&
+                    r['Container Origin Type'] !== 'STREAM_RADIO_STATION'
+            )
             .map((r) => {
                 const tsRaw = r['Event Start Timestamp']
                 const ts =

--- a/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.ts
@@ -11,6 +11,7 @@ export class AppleMusicStreamProvider extends StreamProvider<AppleMusicRawRecord
     readonly acceptedFormats = 'ZIP/CSV'
     readonly filePattern = /^Apple Music Play Activity\.csv$/i
     readonly fileContentType = 'text/csv'
+    readonly experimental = true
 
     async readFile(file: File): Promise<AppleMusicRawRecord[]> {
         const buffer = await file.arrayBuffer()

--- a/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.ts
@@ -1,0 +1,55 @@
+import { getDB } from '../../db/getDB'
+import { StreamProvider } from '../StreamProvider'
+import type { StreamRecord } from '../types'
+import type { AppleMusicRawRecord } from './types'
+
+const TMP_FILE_NAME = '_apple_music_tmp.csv'
+
+export class AppleMusicStreamProvider extends StreamProvider<AppleMusicRawRecord> {
+    readonly name = 'apple-music'
+    readonly displayName = 'Apple Music'
+    readonly acceptedFormats = 'ZIP/CSV'
+    readonly filePattern = /^Apple Music Play Activity\.csv$/i
+    readonly fileContentType = 'text/csv'
+
+    async readFile(file: File): Promise<AppleMusicRawRecord[]> {
+        const buffer = await file.arrayBuffer()
+        const { db, conn } = await getDB()
+
+        await db.registerFileBuffer(TMP_FILE_NAME, new Uint8Array(buffer))
+        try {
+            const result = await conn.query(
+                `SELECT * FROM read_csv('${TMP_FILE_NAME}', header=true)`
+            )
+            return result
+                .toArray()
+                .map((row) => row.toJSON() as AppleMusicRawRecord)
+        } finally {
+            await db.dropFile(TMP_FILE_NAME)
+        }
+    }
+
+    transform(rawData: AppleMusicRawRecord[]): StreamRecord[] {
+        return rawData
+            .filter((r) => r['Media Type'] === 'AUDIO')
+            .map((r) => {
+                const tsRaw = r['Event Start Timestamp']
+                const ts =
+                    tsRaw instanceof Date
+                        ? tsRaw.toISOString()
+                        : typeof tsRaw === 'number' || typeof tsRaw === 'bigint'
+                          ? new Date(Number(tsRaw)).toISOString()
+                          : String(tsRaw ?? '')
+                const msDuration = Number(r['Play Duration Milliseconds']) || 0
+                return {
+                    track_uri: `apple-music:${String(r['Song Name'] ?? '')}`,
+                    track_name: String(r['Song Name'] ?? ''),
+                    artist_name: '',
+                    album_name: String(r['Album Name'] ?? ''),
+                    ts,
+                    ms_played: Math.max(0, msDuration),
+                    platform: String(r['Client Platform'] ?? ''),
+                }
+            })
+    }
+}

--- a/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.ts
@@ -52,7 +52,7 @@ export class AppleMusicStreamProvider extends StreamProvider<AppleMusicRawRecord
                     album_name: String(r['Album Name'] ?? ''),
                     ts,
                     ms_played: Math.max(0, msDuration),
-                    platform: String(r['Client Platform'] ?? ''),
+                    platform: String(r['Device Type'] ?? ''),
                 }
             })
     }

--- a/app/src/streamProvider/AppleMusicStreamProvider/index.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/index.ts
@@ -1,0 +1,1 @@
+export { AppleMusicStreamProvider } from './AppleMusicStreamProvider'

--- a/app/src/streamProvider/AppleMusicStreamProvider/types.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/types.ts
@@ -5,7 +5,7 @@ export interface AppleMusicRawRecord {
     'Media Type': unknown // "AUDIO" | "VIDEO" | ...
     'Event Start Timestamp': unknown // TIMESTAMP WITH TIME ZONE — Arrow returns Date or BigInt
     'Play Duration Milliseconds': unknown // can be negative
-    'Client Platform': unknown
+    'Device Type': unknown
     'Container Origin Type': unknown
     [key: string]: unknown
 }

--- a/app/src/streamProvider/AppleMusicStreamProvider/types.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/types.ts
@@ -1,0 +1,11 @@
+export interface AppleMusicRawRecord {
+    'Song Name': unknown
+    'Album Name': unknown
+    'Container Artist Name': unknown // always null
+    'Media Type': unknown // "AUDIO" | "VIDEO" | ...
+    'Event Start Timestamp': unknown // TIMESTAMP WITH TIME ZONE — Arrow returns Date or BigInt
+    'Play Duration Milliseconds': unknown // can be negative
+    'Client Platform': unknown
+    'Container Origin Type': unknown
+    [key: string]: unknown
+}

--- a/app/src/streamProvider/StreamProvider.ts
+++ b/app/src/streamProvider/StreamProvider.ts
@@ -22,6 +22,8 @@ export abstract class StreamProvider<TRawData = unknown> {
 
     abstract readonly fileContentType: string
 
+    readonly experimental: boolean = false
+
     /**
      * Validate if a file belongs to this provider
      *

--- a/app/src/streamProvider/index.test.ts
+++ b/app/src/streamProvider/index.test.ts
@@ -24,6 +24,14 @@ describe('StreamProvider Factory', () => {
             expect(streamProvider?.name).toBe('deezer')
         })
 
+        it('should detect Apple Music files', () => {
+            const file = new File([], 'Apple Music Play Activity.csv')
+            const streamProvider = detectProvider(file)
+
+            expect(streamProvider).not.toBeUndefined()
+            expect(streamProvider?.name).toBe('apple-music')
+        })
+
         it('should return undefined for unknown file formats', () => {
             const file = new File([], 'unknown_format.json')
             const streamProvider = detectProvider(file)
@@ -43,9 +51,10 @@ describe('StreamProvider Factory', () => {
 
         it('returns one entry per registered provider with format hint', () => {
             const names = getSupportedProviderNames()
-            expect(names.length).toBe(2)
+            expect(names.length).toBe(3)
             expect(names).toContain('Spotify (ZIP/JSON)')
             expect(names).toContain('Deezer (XLSX)')
+            expect(names).toContain('Apple Music (ZIP/CSV)')
         })
     })
 
@@ -65,6 +74,7 @@ describe('StreamProvider Factory', () => {
         it.each([
             'application/json',
             'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'text/csv',
         ])(
             'should return true if the file content type %s is allowed',
             (contentType) => {

--- a/app/src/streamProvider/index.test.ts
+++ b/app/src/streamProvider/index.test.ts
@@ -51,10 +51,10 @@ describe('StreamProvider Factory', () => {
 
         it('returns one entry per registered provider with format hint', () => {
             const names = getSupportedProviderNames()
-            expect(names.length).toBe(3)
+            expect(names.length).toBe(2)
             expect(names).toContain('Spotify (ZIP/JSON)')
             expect(names).toContain('Deezer (XLSX)')
-            expect(names).toContain('Apple Music (ZIP/CSV)')
+            expect(names).not.toContain('Apple Music (ZIP/CSV)')
         })
     })
 

--- a/app/src/streamProvider/index.ts
+++ b/app/src/streamProvider/index.ts
@@ -34,7 +34,7 @@ export const isAllowedFileContentType = (file: File) => {
 }
 
 export function getSupportedProviderNames(): string[] {
-    return STREAM_PROVIDERS.map(
+    return STREAM_PROVIDERS.filter((p) => !p.experimental).map(
         (p) => `${p.displayName} (${p.acceptedFormats})`
     )
 }

--- a/app/src/streamProvider/index.ts
+++ b/app/src/streamProvider/index.ts
@@ -1,3 +1,4 @@
+import { AppleMusicStreamProvider } from './AppleMusicStreamProvider/AppleMusicStreamProvider'
 import { DeezerStreamProvider } from './DeezerStreamProvider/DeezerStreamProvider'
 import type { StreamProvider } from './StreamProvider'
 import { SpotifyStreamProvider } from './SpotifyStreamProvider/SpotifyStreamProvider'
@@ -6,6 +7,7 @@ import { SpotifyStreamProvider } from './SpotifyStreamProvider/SpotifyStreamProv
 const STREAM_PROVIDERS: StreamProvider[] = [
     new SpotifyStreamProvider(),
     new DeezerStreamProvider(),
+    new AppleMusicStreamProvider(),
 ]
 
 export const STREAM_PROVIDERS_CONTENT_TYPES = STREAM_PROVIDERS.map(

--- a/app/src/utils/extractFilesRecursively.test.ts
+++ b/app/src/utils/extractFilesRecursively.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { extractFilesRecursively } from './extractFilesRecursively'
+import * as openArchiveModule from './openArchive'
+
+function makeFile(name: string, content = 'data'): File {
+    return new File([content], name)
+}
+
+function makeZipFile(name: string): File {
+    return new File(['zip-bytes'], name, { type: 'application/zip' })
+}
+
+function mockArchive(files: Record<string, File | Record<string, File>>) {
+    return {
+        extractFiles: vi.fn().mockResolvedValue(files),
+    }
+}
+
+describe('extractFilesRecursively', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('should extract flat files from a ZIP', async () => {
+        const csv = makeFile('Apple Music Play Activity.csv')
+        vi.spyOn(openArchiveModule, 'openArchive').mockResolvedValue(
+            mockArchive({ 'Apple Music Play Activity.csv': csv }) as never
+        )
+
+        const result = await extractFilesRecursively(makeZipFile('export.zip'))
+
+        expect(result).toHaveLength(1)
+        expect(result[0].name).toBe('Apple Music Play Activity.csv')
+    })
+
+    it('should flatten nested directories', async () => {
+        const csv = makeFile('playback.csv')
+        vi.spyOn(openArchiveModule, 'openArchive').mockResolvedValue(
+            mockArchive({ folder: { 'playback.csv': csv } }) as never
+        )
+
+        const result = await extractFilesRecursively(makeZipFile('export.zip'))
+
+        expect(result).toHaveLength(1)
+        expect(result[0].name).toBe('playback.csv')
+    })
+
+    it('should filter __MACOSX entries at the top level', async () => {
+        const csv = makeFile('data.csv')
+        vi.spyOn(openArchiveModule, 'openArchive').mockResolvedValue(
+            mockArchive({
+                '__MACOSX/._data.csv': makeFile('._data.csv'),
+                'data.csv': csv,
+            }) as never
+        )
+
+        const result = await extractFilesRecursively(makeZipFile('export.zip'))
+
+        expect(result).toHaveLength(1)
+        expect(result[0].name).toBe('data.csv')
+    })
+
+    it('should recurse into nested ZIP files', async () => {
+        const innerCsv = makeFile('Apple Music Play Activity.csv')
+        const innerZip = makeZipFile('Apple_Media_Services.zip')
+
+        const innerArchive = mockArchive({
+            'Apple Music Play Activity.csv': innerCsv,
+        })
+        const outerArchive = mockArchive({
+            'Apple_Media_Services.zip': innerZip,
+        })
+
+        vi.spyOn(openArchiveModule, 'openArchive')
+            .mockResolvedValueOnce(outerArchive as never)
+            .mockResolvedValueOnce(innerArchive as never)
+
+        const result = await extractFilesRecursively(makeZipFile('export.zip'))
+
+        expect(result).toHaveLength(1)
+        expect(result[0].name).toBe('Apple Music Play Activity.csv')
+    })
+
+    it('should handle empty archive', async () => {
+        vi.spyOn(openArchiveModule, 'openArchive').mockResolvedValue(
+            mockArchive({}) as never
+        )
+
+        const result = await extractFilesRecursively(makeZipFile('empty.zip'))
+
+        expect(result).toHaveLength(0)
+    })
+})

--- a/app/src/utils/extractFilesRecursively.ts
+++ b/app/src/utils/extractFilesRecursively.ts
@@ -1,0 +1,42 @@
+import { openArchive } from './openArchive'
+
+const HIDDEN_FILE_PREFIXES = ['__MACOSX']
+
+function isHidden(name: string): boolean {
+    return HIDDEN_FILE_PREFIXES.some((prefix) => name.startsWith(prefix))
+}
+
+function hasZipExtension(file: File): boolean {
+    return file.name.toLowerCase().endsWith('.zip')
+}
+
+/**
+ * Recursively extracts all non-hidden files from a ZIP archive.
+ * If any extracted file is itself a ZIP, it is extracted recursively.
+ * Terminates when no extracted file has a .zip extension.
+ */
+export async function extractFilesRecursively(zipFile: File): Promise<File[]> {
+    const archive = await openArchive(zipFile)
+    const extracted: Record<string, File | Record<string, File>> =
+        await archive.extractFiles()
+
+    const topLevel: File[] = Object.entries(extracted)
+        .filter(([key]) => !isHidden(key))
+        .flatMap(([, value]) =>
+            value instanceof File ? [value] : Object.values(value)
+        )
+        .filter((file) => !isHidden(file.name))
+
+    const result: File[] = []
+
+    for (const file of topLevel) {
+        if (hasZipExtension(file)) {
+            const nested = await extractFilesRecursively(file)
+            result.push(...nested)
+        } else {
+            result.push(file)
+        }
+    }
+
+    return result
+}

--- a/synthetic-datasets/synthetic_datasets/app.py
+++ b/synthetic-datasets/synthetic_datasets/app.py
@@ -4,10 +4,20 @@ from datetime import datetime
 from pathlib import Path
 
 from synthetic_datasets.config import GenerationConfig
+from synthetic_datasets.factories.apple_music import AppleMusicFactory
 from synthetic_datasets.factories.deezer import DeezerFactory
 from synthetic_datasets.factories.spotify import SpotifyFactory
+from synthetic_datasets.writers.apple_music import AppleMusicWriter
 from synthetic_datasets.writers.deezer import DeezerWriter
 from synthetic_datasets.writers.spotify import SpotifyWriter
+
+
+def apple_music(num_records: int, output_dir: Path, config: GenerationConfig):
+    factory = AppleMusicFactory(num_records, config=config)
+    all_streamings = factory.create_streaming_history()
+
+    writer = AppleMusicWriter(output_dir=output_dir, reference_date=config.reference_date)
+    writer.write(all_streamings)
 
 
 def spotify(num_records: int, output_dir: Path, config: GenerationConfig):
@@ -62,7 +72,7 @@ Examples:
     )
     parser.add_argument(
         "--provider",
-        choices=["spotify", "deezer"],
+        choices=["spotify", "deezer", "apple-music"],
         default="spotify",
         help="Streaming provider to generate data for (default: spotify)",
     )
@@ -75,6 +85,8 @@ Examples:
 
     if args.provider == "deezer":
         deezer(args.num_records, args.output_dir, config)
+    elif args.provider == "apple-music":
+        apple_music(args.num_records, args.output_dir, config)
     else:
         spotify(args.num_records, args.output_dir, config)
     print("--- %s seconds ---" % (time.time() - start_data_generation))

--- a/synthetic-datasets/synthetic_datasets/factories/apple_music.py
+++ b/synthetic-datasets/synthetic_datasets/factories/apple_music.py
@@ -1,0 +1,158 @@
+import calendar
+import random
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import numpy as np
+from faker import Faker
+from tqdm import tqdm
+
+from ..config import GenerationConfig
+from ..models.apple_music import AppleMusicRecord
+
+
+@dataclass
+class AppleMusicTrack:
+    song_name: str
+    duration_ms: int
+
+
+CLIENT_PLATFORMS = ["FUSE", "TILT"]
+
+
+class AppleMusicFactory:
+    month_weights = [0.08, 0.07, 0.07, 0.06, 0.07, 0.08, 0.08, 0.08, 0.1, 0.10, 0.11, 0.1]
+    hour_weights = [
+        0.01, 0.01, 0.01, 0.01, 0.02, 0.04, 0.07, 0.09, 0.08, 0.06, 0.04, 0.04,
+        0.05, 0.03, 0.04, 0.05, 0.05, 0.06, 0.07, 0.06, 0.05, 0.03, 0.02, 0.01,
+    ]  # fmt: skip
+
+    def __init__(self, num_records: int, config: GenerationConfig):
+        self.config = config
+
+        random.seed(self.config.seed)
+        np.random.seed(self.config.seed)
+        Faker.seed(self.config.seed)
+
+        self.faker = Faker()
+        self.now = self.config.reference_date
+        self.start_year = 2020
+        self.skip_chance_trend = np.linspace(0.15, 0.30, self.now.year - self.start_year + 1)
+
+        num_tracks = max(int(num_records * 0.5), 1)
+
+        print("🎵 Generating music catalog...")
+        print(f" - records: {num_records}")
+        print(f" - tracks : {num_tracks}")
+        self.tracks = self._generate_catalog(num_tracks)
+
+        print("📈 Generating evolving listening tastes...")
+        self.weighted_tracks = self._generate_weighted_tracks_by_year()
+        for year, weighted_records in self.weighted_tracks.items():
+            print(f" - {year}: {len(weighted_records)} records")
+
+        print("📅 Generating distribution over year...")
+        self.records_per_year = self._generate_distribution_over_year(num_records)
+        for year, num_records_for_year in self.records_per_year.items():
+            print(f" - {year}: {num_records_for_year} records")
+
+    def _generate_catalog(self, num_tracks: int) -> list[AppleMusicTrack]:
+        return [
+            AppleMusicTrack(
+                song_name=" ".join(self.faker.words(4)).title(),
+                duration_ms=random.randint(120_000, 360_000),
+            )
+            for _ in range(num_tracks)
+        ]
+
+    def _generate_weighted_tracks_by_year(self) -> dict[int, list[AppleMusicTrack]]:
+        weighted_tracks_by_year = {}
+        for year in range(self.start_year, self.now.year + 1):
+            popularity = np.random.zipf(a=1.8, size=len(self.tracks))
+            np.random.shuffle(popularity)
+
+            weighted = []
+            for track, weight in zip(self.tracks, popularity):
+                repeats = min(int(weight / 10), 100)
+                if repeats > 0:
+                    weighted.extend([track] * repeats)
+                else:
+                    weighted.extend([track])
+
+            weighted_tracks_by_year[year] = weighted
+
+        return weighted_tracks_by_year
+
+    def _get_random_datetime_for_year(self, year: int) -> datetime:
+        if year < self.now.year:
+            months = np.arange(1, 13)
+            month_weights = np.array(self.month_weights)
+        else:
+            months = np.arange(1, self.now.month + 1)
+            month_weights = np.array(self.month_weights[: self.now.month])
+
+        month_weights = month_weights / month_weights.sum()
+        month = np.random.choice(months, p=month_weights)
+
+        max_day = calendar.monthrange(year, month)[1]
+        day = random.randint(1, max_day)
+
+        hour_weights = np.array(self.hour_weights)
+        hour_weights = hour_weights / hour_weights.sum()
+        hour = np.random.choice(range(24), p=hour_weights)
+
+        minute = random.randint(0, 59)
+        second = random.randint(0, 59)
+
+        candidate = datetime(year, month, day, hour, minute, second)
+
+        if candidate > self.now:
+            start = datetime(year, 1, 1)
+            delta_seconds = int((self.now - start).total_seconds())
+            return start + timedelta(seconds=random.randint(0, delta_seconds))
+
+        return candidate
+
+    def _create_one_record(self, ts: datetime) -> AppleMusicRecord:
+        year_index = ts.year - self.start_year
+        is_skipped = random.random() < self.skip_chance_trend[year_index]
+
+        track = random.choice(self.weighted_tracks[ts.year])
+        play_duration_ms = random.randint(1_000, 29_000) if is_skipped else random.randint(30_000, track.duration_ms)
+
+        client_platform = random.choice(CLIENT_PLATFORMS)
+
+        return AppleMusicRecord(
+            event_start_timestamp=ts,
+            song_name=track.song_name,
+            media_type="AUDIO",
+            play_duration_ms=play_duration_ms,
+            client_platform=client_platform,
+        )
+
+    def _generate_distribution_over_year(self, n_records: int) -> dict[int, int]:
+        years = range(self.start_year, self.now.year + 1)
+
+        year_weights = [random.uniform(0.5, 1.5) for _ in years]
+        base_records_per_year = n_records / sum(year_weights)
+        records_per_year = {
+            year: int(base_records_per_year * year_weight) for year, year_weight in zip(years, year_weights)
+        }
+        records_per_year[self.now.year] += n_records - sum(records_per_year.values())
+        return records_per_year
+
+    def create_streaming_history(self) -> list[AppleMusicRecord]:
+        all_records = []
+
+        for year, num_records_for_year in self.records_per_year.items():
+            year_records = [
+                self._create_one_record(self._get_random_datetime_for_year(year))
+                for _ in tqdm(
+                    range(num_records_for_year),
+                    desc=f"💿 Generating streamings for {year}",
+                    leave=True,
+                )
+            ]
+            all_records.extend(year_records)
+
+        return all_records

--- a/synthetic-datasets/synthetic_datasets/models/apple_music.py
+++ b/synthetic-datasets/synthetic_datasets/models/apple_music.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+from pydantic import BaseModel, PastDatetime, field_serializer
+
+
+class AppleMusicRecord(BaseModel):
+    event_start_timestamp: PastDatetime
+    song_name: str
+    media_type: str = "AUDIO"
+    play_duration_ms: int  # milliseconds; always >= 0
+    client_platform: str  # e.g. "FUSE", "TILT"
+
+    @field_serializer("event_start_timestamp")
+    def serialize_event_start_timestamp(self, ts: datetime) -> str:
+        return ts.strftime("%Y-%m-%dT%H:%M:%S.000Z")

--- a/synthetic-datasets/synthetic_datasets/writers/apple_music.py
+++ b/synthetic-datasets/synthetic_datasets/writers/apple_music.py
@@ -1,0 +1,49 @@
+import csv
+from datetime import datetime
+from pathlib import Path
+
+from tqdm import tqdm
+
+from ..models.apple_music import AppleMusicRecord
+
+COLUMNS = [
+    "Event Start Timestamp",
+    "Song Name",
+    "Container Artist Name",
+    "Media Type",
+    "Play Duration Milliseconds",
+    "Feature Name",
+]
+
+
+class AppleMusicWriter:
+    def __init__(self, output_dir: Path, reference_date: datetime) -> None:
+        self.output_path = output_dir / "apple_music" / "Apple Music Play Activity.csv"
+        self.reference_date = reference_date
+
+    def write(self, records: list[AppleMusicRecord]) -> None:
+        print(
+            f"Write `csv` file: status: `starting`, path: `{self.output_path.absolute()}`, count_records: `{len(records)}`"
+        )
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.output_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=COLUMNS)
+            writer.writeheader()
+            for record in tqdm(
+                records,
+                desc=f"📦 Writing {self.output_path.name}",
+                unit=" records",
+            ):
+                writer.writerow(
+                    {
+                        "Event Start Timestamp": record.serialize_event_start_timestamp(record.event_start_timestamp),
+                        "Song Name": record.song_name,
+                        "Container Artist Name": "",
+                        "Media Type": record.media_type,
+                        "Play Duration Milliseconds": str(record.play_duration_ms),
+                        "Feature Name": record.client_platform,
+                    }
+                )
+        print(
+            f"Write `csv` file: status: `success`, path: `{self.output_path.absolute()}`, count_records: `{len(records)}`"
+        )

--- a/synthetic-datasets/tests/conftest.py
+++ b/synthetic-datasets/tests/conftest.py
@@ -4,6 +4,7 @@ from ipaddress import IPv4Address
 import pytest
 
 from synthetic_datasets.config import GenerationConfig
+from synthetic_datasets.models.apple_music import AppleMusicRecord
 from synthetic_datasets.models.deezer import DeezerStreaming
 from synthetic_datasets.models.spotify import ReasonEndEnum, ReasonStartEnum, Streaming
 
@@ -41,6 +42,17 @@ def deezer_streaming_record():
         platform_name="web",
         platform_model="",
         date=datetime.fromisoformat("2020-08-07T11:48:23"),
+    )
+
+
+@pytest.fixture
+def apple_music_record():
+    return AppleMusicRecord(
+        event_start_timestamp=datetime.fromisoformat("2020-08-07T11:48:23"),
+        song_name="Never Gonna Give You Up",
+        media_type="AUDIO",
+        play_duration_ms=213_000,
+        client_platform="FUSE",
     )
 
 

--- a/synthetic-datasets/tests/factories/test_apple_music.py
+++ b/synthetic-datasets/tests/factories/test_apple_music.py
@@ -1,0 +1,87 @@
+from dataclasses import replace
+
+import pytest
+
+from synthetic_datasets.factories.apple_music import AppleMusicFactory
+from synthetic_datasets.models.apple_music import AppleMusicRecord
+
+
+@pytest.mark.parametrize("num_records", range(0, 100, 3))
+def test_create_streaming_history(num_records, default_generation_config):
+    # given
+    factory = AppleMusicFactory(num_records=num_records, config=default_generation_config)
+    # when
+    records = factory.create_streaming_history()
+    # then
+    assert len(records) == num_records
+    for record in records:
+        assert isinstance(record, AppleMusicRecord)
+
+
+def test_same_seed_produces_identical_results(default_generation_config):
+    # given
+    num_records = 100
+    # when
+    factory1 = AppleMusicFactory(num_records, default_generation_config)
+    records1 = factory1.create_streaming_history()
+
+    factory2 = AppleMusicFactory(num_records, default_generation_config)
+    records2 = factory2.create_streaming_history()
+    # then
+    assert len(records1) == len(records2)
+    assert records1 == records2
+
+
+def test_different_seeds_produce_different_results(default_generation_config):
+    # given
+    num_records = 50
+    config1 = replace(default_generation_config, seed=123)
+    config2 = replace(default_generation_config, seed=456)
+    # when
+    factory1 = AppleMusicFactory(num_records, config1)
+    records1 = factory1.create_streaming_history()
+
+    factory2 = AppleMusicFactory(num_records, config2)
+    records2 = factory2.create_streaming_history()
+    # then
+    assert records1 != records2
+
+
+@pytest.mark.parametrize("seed", [0, 1, 42, 999, 12345])
+def test_various_seeds_work(seed, default_generation_config):
+    # given
+    config = replace(default_generation_config, seed=seed)
+    # when
+    factory = AppleMusicFactory(100, config)
+    records = factory.create_streaming_history()
+    # then
+    assert len(records) == 100
+
+
+def test_all_records_are_audio(default_generation_config):
+    factory = AppleMusicFactory(num_records=200, config=default_generation_config)
+    records = factory.create_streaming_history()
+    for record in records:
+        assert record.media_type == "AUDIO"
+
+
+def test_records_have_valid_client_platforms(default_generation_config):
+    valid_platforms = {"FUSE", "TILT"}
+    factory = AppleMusicFactory(num_records=200, config=default_generation_config)
+    records = factory.create_streaming_history()
+    for record in records:
+        assert record.client_platform in valid_platforms
+
+
+def test_play_duration_is_non_negative(default_generation_config):
+    factory = AppleMusicFactory(num_records=200, config=default_generation_config)
+    records = factory.create_streaming_history()
+    for record in records:
+        assert record.play_duration_ms >= 0
+
+
+def test_song_names_are_non_empty(default_generation_config):
+    factory = AppleMusicFactory(num_records=50, config=default_generation_config)
+    records = factory.create_streaming_history()
+    for record in records:
+        assert record.song_name.strip() != ""

--- a/synthetic-datasets/tests/writers/test_apple_music.py
+++ b/synthetic-datasets/tests/writers/test_apple_music.py
@@ -1,0 +1,86 @@
+import csv
+from datetime import datetime
+
+from synthetic_datasets.writers.apple_music import COLUMNS, AppleMusicWriter
+
+
+def test_write_creates_file(tmp_path, apple_music_record):
+    # given
+    reference_date = datetime(2026, 2, 8)
+    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=reference_date)
+    # when
+    writer.write([apple_music_record])
+    # then
+    assert writer.output_path.exists()
+
+
+def test_write_csv_headers(tmp_path, apple_music_record):
+    # given
+    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    # when
+    writer.write([apple_music_record])
+    # then
+    with open(writer.output_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        assert reader.fieldnames == COLUMNS
+
+
+def test_write_csv_row_count(tmp_path, apple_music_record):
+    # given
+    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    num_records = 5
+    records = [apple_music_record] * num_records
+    # when
+    writer.write(records)
+    # then
+    with open(writer.output_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    assert len(rows) == num_records
+
+
+def test_write_csv_timestamp_format(tmp_path, apple_music_record):
+    # given
+    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    # when
+    writer.write([apple_music_record])
+    # then
+    with open(writer.output_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        row = next(reader)
+    ts_str = row["Event Start Timestamp"]
+    parsed = datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%S.000Z")
+    assert parsed is not None
+
+
+def test_write_creates_output_directory(tmp_path, apple_music_record):
+    # given
+    nested_dir = tmp_path / "nested" / "output"
+    writer = AppleMusicWriter(output_dir=nested_dir, reference_date=datetime(2026, 2, 8))
+    # when
+    writer.write([apple_music_record])
+    # then
+    assert writer.output_path.exists()
+
+
+def test_write_csv_output_path(tmp_path, apple_music_record):
+    # given
+    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    # then
+    assert writer.output_path.name == "Apple Music Play Activity.csv"
+    assert writer.output_path.parent.name == "apple_music"
+
+
+def test_write_csv_record_values(tmp_path, apple_music_record):
+    # given
+    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    # when
+    writer.write([apple_music_record])
+    # then
+    with open(writer.output_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        row = next(reader)
+    assert row["Song Name"] == apple_music_record.song_name
+    assert row["Media Type"] == apple_music_record.media_type
+    assert row["Play Duration Milliseconds"] == str(apple_music_record.play_duration_ms)
+    assert row["Container Artist Name"] == ""


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Users who stream on Apple Music have no way to visualize their listening history in Tracksy.

## 🎹 Proposal

Tracksy now accepts Apple Music privacy exports. Users can drop their ZIP directly — the app extracts it automatically, detects the activity file, and loads their listening history.

Because Apple's export does not include artist name, and the data quality has known limitations, Apple Music is marked as experimental: it works but does not appear in the list of supported providers in the UI.

Recursive ZIP extraction (introduced here) is shared logic that will benefit future providers shipped inside nested archives.

## 🎶 Comments

Apple Music exports do not contain artist name. Artist-based charts will show "Unknown Artist" for all Apple Music streams. Radio station plays are excluded from the import.

The synthetic dataset generator does not yet produce a ZIP archive: it outputs a flat CSV only. The exact nested ZIP structure of current Apple exports still needs to be confirmed. Follow-up: #421.

## 🎤 Test

1. Request your data at privacy.apple.com (Apple Media Services information).
2. Drop the downloaded ZIP onto Tracksy.
3. Verify that your listening history loads and that track names, album names, and play durations are correct.
4. Alternatively, drop an `Apple Music Play Activity.csv` file directly.