### PR TITLE
feat(devtools): add Astro dev toolbar plugin (#390)

### DIFF
--- a/app/astro.config.mjs
+++ b/app/astro.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from 'astro/config'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 import react from '@astrojs/react'
 import tailwindcss from '@tailwindcss/vite'
+import { tracksyDevToolbar } from './src/devToolbar/integration.ts'
 
 // @duckdb/node-api (devDependency used for tests) ships platform-specific native binaries
 // that Rollup/Vite cannot bundle. We mark them as external so they are resolved at runtime
@@ -52,5 +53,7 @@ export default defineConfig({
             external: DUCKDB_EXTERNALS,
         },
     },
-    integrations: [...(process.env.VITEST ? [] : [react()])],
+    integrations: [
+        ...(process.env.VITEST ? [] : [react(), tracksyDevToolbar()]),
+    ],
 })

--- a/app/src/db/queries/queryDB.ts
+++ b/app/src/db/queries/queryDB.ts
@@ -1,10 +1,27 @@
 import { getDB } from '../getDB'
+import { devBus } from '../../devToolbar/devBus'
 
 export async function queryDBAsJSON<
     T extends Record<string, string | number | null | undefined>,
 >(query: string): Promise<T[]> {
     const { conn } = await getDB()
-    const table = await conn.query(query)
-    const jsonResult = table.toArray().map((row) => row.toJSON())
-    return jsonResult as T[]
+    const start = performance.now()
+    try {
+        const table = await conn.query(query)
+        const jsonResult = table.toArray().map((row) => row.toJSON())
+        devBus.emit('duckdb:query', {
+            sql: query,
+            durationMs: performance.now() - start,
+            rowCount: jsonResult.length,
+        })
+        return jsonResult as T[]
+    } catch (e) {
+        devBus.emit('duckdb:query', {
+            sql: query,
+            durationMs: performance.now() - start,
+            rowCount: 0,
+            error: String(e),
+        })
+        throw e
+    }
 }

--- a/app/src/devToolbar/devBus.test.ts
+++ b/app/src/devToolbar/devBus.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { devBus } from './devBus'
+
+// import.meta.env.DEV is checked inside function bodies at call time,
+// so vi.stubEnv works without re-importing the module.
+
+const PREFIX = 'tracksy:dev:'
+
+describe('devBus', () => {
+    beforeEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    it('is a no-op in production (DEV=false)', () => {
+        vi.stubEnv('DEV', false)
+
+        const spy = vi.fn()
+        window.addEventListener(PREFIX + 'duckdb:query', spy)
+        devBus.emit('duckdb:query', {
+            sql: 'SELECT 1',
+            durationMs: 5,
+            rowCount: 1,
+        })
+        window.removeEventListener(PREFIX + 'duckdb:query', spy)
+
+        expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('dispatches a CustomEvent on window when DEV=true', () => {
+        vi.stubEnv('DEV', true)
+
+        const received: unknown[] = []
+        const off = devBus.on('duckdb:query', (d) => received.push(d))
+
+        devBus.emit('duckdb:query', {
+            sql: 'SELECT 42',
+            durationMs: 12,
+            rowCount: 3,
+        })
+        off()
+
+        expect(received).toHaveLength(1)
+        expect(received[0]).toEqual({
+            sql: 'SELECT 42',
+            durationMs: 12,
+            rowCount: 3,
+        })
+    })
+
+    it('on() cleanup stops receiving events', () => {
+        vi.stubEnv('DEV', true)
+
+        const calls: unknown[] = []
+        const off = devBus.on('stream:parsed', (d) => calls.push(d))
+
+        devBus.emit('stream:parsed', {
+            provider: 'spotify',
+            recordCount: 100,
+            durationMs: 50,
+        })
+        off()
+        devBus.emit('stream:parsed', {
+            provider: 'spotify',
+            recordCount: 200,
+            durationMs: 60,
+        })
+
+        expect(calls).toHaveLength(1)
+    })
+
+    it('passes error field through for duckdb:query', () => {
+        vi.stubEnv('DEV', true)
+
+        const received: unknown[] = []
+        const off = devBus.on('duckdb:query', (d) => received.push(d))
+        devBus.emit('duckdb:query', {
+            sql: 'BAD SQL',
+            durationMs: 2,
+            rowCount: 0,
+            error: 'syntax error',
+        })
+        off()
+
+        expect(received[0]).toMatchObject({
+            error: 'syntax error',
+            rowCount: 0,
+        })
+    })
+})

--- a/app/src/devToolbar/devBus.ts
+++ b/app/src/devToolbar/devBus.ts
@@ -1,0 +1,42 @@
+type DevBusEventMap = {
+    'duckdb:query': {
+        sql: string
+        durationMs: number
+        rowCount: number
+        error?: string
+    }
+    'webllm:load': { model: string; progress: number; text: string }
+    'webllm:inference': {
+        model: string
+        durationMs: number
+        tokensPerSec: number
+    }
+    'stream:parsed': {
+        provider: string
+        recordCount: number
+        durationMs: number
+    }
+}
+
+const PREFIX = 'tracksy:dev:'
+
+export const devBus = {
+    emit<K extends keyof DevBusEventMap>(
+        type: K,
+        detail: DevBusEventMap[K]
+    ): void {
+        if (!import.meta.env.DEV || typeof window === 'undefined') return
+        window.dispatchEvent(new CustomEvent(PREFIX + type, { detail }))
+    },
+    on<K extends keyof DevBusEventMap>(
+        type: K,
+        cb: (d: DevBusEventMap[K]) => void
+    ): () => void {
+        const handler = (e: Event) =>
+            cb((e as CustomEvent<DevBusEventMap[K]>).detail)
+        window.addEventListener(PREFIX + type, handler)
+        return () => window.removeEventListener(PREFIX + type, handler)
+    },
+}
+
+export type { DevBusEventMap }

--- a/app/src/devToolbar/integration.ts
+++ b/app/src/devToolbar/integration.ts
@@ -1,0 +1,26 @@
+import { fileURLToPath } from 'node:url'
+import type { AstroIntegration } from 'astro'
+
+const ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <rect x="2" y="14" width="4" height="8" rx="1"/>
+  <rect x="9" y="9" width="4" height="13" rx="1"/>
+  <rect x="16" y="4" width="4" height="18" rx="1"/>
+</svg>`
+
+export function tracksyDevToolbar(): AstroIntegration {
+    return {
+        name: 'tracksy-dev-toolbar',
+        hooks: {
+            'astro:config:setup': ({ addDevToolbarApp }) => {
+                addDevToolbarApp({
+                    id: 'tracksy',
+                    name: 'Tracksy DevTools',
+                    icon: ICON,
+                    entrypoint: fileURLToPath(
+                        new URL('./tracksyToolbar.ts', import.meta.url)
+                    ),
+                })
+            },
+        },
+    }
+}

--- a/app/src/devToolbar/tracksyToolbar.ts
+++ b/app/src/devToolbar/tracksyToolbar.ts
@@ -9,7 +9,7 @@ type InferenceEntry = DevBusEventMap['webllm:inference'] & { ts: number }
 const MAX_QUERIES = 20
 
 const STYLES = `
-  :host { font-family: ui-monospace, monospace; font-size: 12px; color: #e2e8f0; }
+  :host { font-family: ui-monospace, monospace; font-size: 12px; color: #e2e8f0; z-index: 2147483647; position: relative; }
   .panel { display: flex; flex-direction: column; gap: 12px; padding: 12px; width: 420px; max-height: 480px; overflow-y: auto; background: #0f172a; border-radius: 8px; }
   .section { border: 1px solid #1e293b; border-radius: 6px; overflow: hidden; }
   .section-header { background: #1e293b; padding: 6px 10px; font-weight: 600; font-size: 11px; letter-spacing: .05em; text-transform: uppercase; color: #94a3b8; }
@@ -57,7 +57,7 @@ export default defineToolbarApp({
                 return `<div class="empty">No queries yet.</div>`
             }
             return queries
-                .slice(-20)
+                .slice()
                 .reverse()
                 .map(
                     (q) => `

--- a/app/src/devToolbar/tracksyToolbar.ts
+++ b/app/src/devToolbar/tracksyToolbar.ts
@@ -1,0 +1,148 @@
+import { defineToolbarApp } from 'astro/toolbar'
+import type { DevBusEventMap } from './devBus'
+
+const PREFIX = 'tracksy:dev:'
+
+type DuckDBEntry = DevBusEventMap['duckdb:query'] & { ts: number }
+type InferenceEntry = DevBusEventMap['webllm:inference'] & { ts: number }
+
+const MAX_QUERIES = 20
+
+const STYLES = `
+  :host { font-family: ui-monospace, monospace; font-size: 12px; color: #e2e8f0; }
+  .panel { display: flex; flex-direction: column; gap: 12px; padding: 12px; width: 420px; max-height: 480px; overflow-y: auto; background: #0f172a; border-radius: 8px; }
+  .section { border: 1px solid #1e293b; border-radius: 6px; overflow: hidden; }
+  .section-header { background: #1e293b; padding: 6px 10px; font-weight: 600; font-size: 11px; letter-spacing: .05em; text-transform: uppercase; color: #94a3b8; }
+  .section-body { padding: 8px; display: flex; flex-direction: column; gap: 4px; }
+  .empty { color: #475569; font-style: italic; }
+  .row { display: flex; align-items: center; gap: 6px; padding: 4px 6px; border-radius: 4px; background: #1e293b; }
+  .sql { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: #a5f3fc; }
+  .badge { padding: 1px 5px; border-radius: 3px; font-size: 10px; white-space: nowrap; }
+  .badge-time { background: #1d4ed8; color: #bfdbfe; }
+  .badge-rows { background: #166534; color: #bbf7d0; }
+  .badge-error { background: #991b1b; color: #fecaca; }
+  .kv { display: flex; gap: 8px; align-items: center; }
+  .kv-label { color: #94a3b8; }
+  .kv-value { color: #f8fafc; font-weight: 600; }
+  .progress-bar { height: 6px; background: #1e293b; border-radius: 3px; overflow: hidden; margin-top: 4px; }
+  .progress-fill { height: 100%; background: #3b82f6; border-radius: 3px; transition: width .2s; }
+`
+
+// eslint-disable-next-line import/no-default-export -- Astro toolbar entrypoint requires default export
+export default defineToolbarApp({
+    init(canvas) {
+        const style = document.createElement('style')
+        style.textContent = STYLES
+        canvas.appendChild(style)
+
+        const panel = document.createElement('div')
+        panel.className = 'panel'
+        canvas.appendChild(panel)
+
+        // --- State ---
+        const queries: DuckDBEntry[] = []
+        let loadState: DevBusEventMap['webllm:load'] | null = null
+        let lastInference: InferenceEntry | null = null
+        let lastStream:
+            | (DevBusEventMap['stream:parsed'] & { ts: number })
+            | null = null
+
+        // --- Render helpers ---
+        function fmt(ms: number): string {
+            return ms < 1 ? '<1ms' : `${Math.round(ms)}ms`
+        }
+
+        function renderDuckDB(): string {
+            if (queries.length === 0) {
+                return `<div class="empty">No queries yet.</div>`
+            }
+            return queries
+                .slice(-20)
+                .reverse()
+                .map(
+                    (q) => `
+              <div class="row">
+                <span class="sql" title="${q.sql.replace(/"/g, '&quot;')}">${q.sql}</span>
+                <span class="badge badge-time">${fmt(q.durationMs)}</span>
+                <span class="badge badge-rows">${q.rowCount} rows</span>
+                ${q.error ? `<span class="badge badge-error">ERR</span>` : ''}
+              </div>`
+                )
+                .join('')
+        }
+
+        function renderWebLLM(): string {
+            const model = loadState?.model ?? lastInference?.model ?? '—'
+            const pct = loadState ? Math.round(loadState.progress * 100) : 100
+            const loadText = loadState?.text ?? 'Ready'
+            const latency = lastInference ? fmt(lastInference.durationMs) : '—'
+            const tps = lastInference
+                ? `${lastInference.tokensPerSec.toFixed(1)} tok/s`
+                : '—'
+            return `
+          <div class="kv"><span class="kv-label">Model</span><span class="kv-value">${model}</span></div>
+          <div class="kv"><span class="kv-label">Load</span><span class="kv-value">${pct}% — ${loadText}</span></div>
+          <div class="progress-bar"><div class="progress-fill" style="width:${pct}%"></div></div>
+          <div class="kv"><span class="kv-label">Latency</span><span class="kv-value">${latency}</span></div>
+          <div class="kv"><span class="kv-label">Tokens/s</span><span class="kv-value">${tps}</span></div>`
+        }
+
+        function renderStream(): string {
+            if (!lastStream)
+                return `<div class="empty">No file parsed yet.</div>`
+            return `
+          <div class="kv"><span class="kv-label">Provider</span><span class="kv-value">${lastStream.provider}</span></div>
+          <div class="kv"><span class="kv-label">Records</span><span class="kv-value">${lastStream.recordCount}</span></div>
+          <div class="kv"><span class="kv-label">Parse time</span><span class="kv-value">${fmt(lastStream.durationMs)}</span></div>`
+        }
+
+        function render(): void {
+            panel.innerHTML = `
+          <div class="section">
+            <div class="section-header">DuckDB — ${queries.length} queries</div>
+            <div class="section-body">${renderDuckDB()}</div>
+          </div>
+          <div class="section">
+            <div class="section-header">WebLLM</div>
+            <div class="section-body">${renderWebLLM()}</div>
+          </div>
+          <div class="section">
+            <div class="section-header">StreamProvider</div>
+            <div class="section-body">${renderStream()}</div>
+          </div>`
+        }
+
+        render()
+
+        // --- devBus listeners ---
+        function listen<K extends keyof DevBusEventMap>(
+            type: K,
+            cb: (d: DevBusEventMap[K]) => void
+        ): void {
+            window.addEventListener(PREFIX + type, (e) =>
+                cb((e as CustomEvent<DevBusEventMap[K]>).detail)
+            )
+        }
+
+        listen('duckdb:query', (d) => {
+            queries.push({ ...d, ts: Date.now() })
+            if (queries.length > MAX_QUERIES) queries.shift()
+            render()
+        })
+
+        listen('webllm:load', (d) => {
+            loadState = d
+            render()
+        })
+
+        listen('webllm:inference', (d) => {
+            lastInference = { ...d, ts: Date.now() }
+            render()
+        })
+
+        listen('stream:parsed', (d) => {
+            lastStream = { ...d, ts: Date.now() }
+            render()
+        })
+    },
+})

--- a/app/src/llm/askLLM.ts
+++ b/app/src/llm/askLLM.ts
@@ -6,6 +6,8 @@ import { isIntentName } from './intents'
 import { SYSTEM_PROMPT, FEW_SHOTS, CURRENT_DATE } from './prompt'
 import { resolveYear } from './resolveYear'
 import { LLMError, type ChatAnswer, type ChatMessage } from './types'
+import { devBus } from '../devToolbar/devBus'
+import { selectModelId } from './engine'
 
 function buildMessages(
     userText: string,
@@ -131,11 +133,19 @@ export async function askLLM(
 ): Promise<ChatAnswer> {
     const messages = buildMessages(userText, history)
     let response
+    const start = performance.now()
     try {
         response = await engine.chat.completions.create({
             messages,
             temperature: 0.1,
             max_tokens: 512,
+        })
+        const durationMs = performance.now() - start
+        const tokens = response.usage?.completion_tokens ?? 0
+        devBus.emit('webllm:inference', {
+            model: selectModelId(),
+            durationMs,
+            tokensPerSec: durationMs > 0 ? tokens / (durationMs / 1000) : 0,
         })
     } catch (e) {
         const reason = e instanceof Error ? e.message : String(e)

--- a/app/src/llm/engine.ts
+++ b/app/src/llm/engine.ts
@@ -4,6 +4,7 @@ import {
     type MLCEngineInterface,
 } from '@mlc-ai/web-llm'
 import { isMobileBrowser } from './deviceDetection'
+import { devBus } from '../devToolbar/devBus'
 
 export { isSafariIOS, isMobileBrowser } from './deviceDetection'
 
@@ -37,7 +38,14 @@ export async function getEngine(
     if (enginePromise) return enginePromise
 
     enginePromise = CreateMLCEngine(selectModelId(), {
-        initProgressCallback: (report) => onProgress?.(report),
+        initProgressCallback: (report) => {
+            onProgress?.(report)
+            devBus.emit('webllm:load', {
+                model: selectModelId(),
+                progress: report.progress,
+                text: report.text,
+            })
+        },
     }).catch((e) => {
         // Reset so a future attempt can retry
         enginePromise = null

--- a/app/src/streamProvider/StreamProvider.ts
+++ b/app/src/streamProvider/StreamProvider.ts
@@ -1,5 +1,6 @@
 import type { StreamRecord } from './types'
 import { isValidStreamRecord, isLongEnoughStream } from './validation'
+import { devBus } from '../devToolbar/devBus'
 
 /**
  * Abstract base class for stream provider adapters.
@@ -75,10 +76,16 @@ export abstract class StreamProvider<TRawData = unknown> {
      * @returns Promise resolving to validated and filtered stream records
      */
     async processFile(file: File): Promise<StreamRecord[]> {
+        const start = performance.now()
         const rawData = await this.readFile(file)
         const transformedData = this.transform(rawData)
         const validatedData = this.validate(transformedData)
         const filteredData = this.filter(validatedData)
+        devBus.emit('stream:parsed', {
+            provider: this.name,
+            recordCount: filteredData.length,
+            durationMs: performance.now() - start,
+        })
         return filteredData
     }
 }


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Debugging the DuckDB, WebLLM, and StreamProvider subsystems currently requires scattering `console.log` statements throughout the codebase. There is no consolidated view of query timings, model load progress, or file parse stats during development.

## 🎹 Proposal

Adds an Astro dev toolbar plugin that surfaces live instrumentation inside the browser — visible only during `astro dev`, zero cost in production.

**New files:**
- `src/devToolbar/devBus.ts` — typed `CustomEvent`/`window` event bus. `emit()` is a no-op when `import.meta.env.DEV` is false, so no instrumentation escapes to prod.
- `src/devToolbar/tracksyToolbar.ts` — shadow-DOM panel with three sections rendered imperatively from bus events.
- `src/devToolbar/integration.ts` — Astro integration factory that registers the toolbar app via `addDevToolbarApp`.

**Instrumented call sites:**
- `queryDB.ts` — emits `duckdb:query` with SQL, duration, row count, and optional error after every `conn.query()` call.
- `askLLM.ts` — emits `webllm:inference` with model ID, latency, and tokens/sec after each completion.
- `engine.ts` — emits `webllm:load` with model ID, progress (0–1), and status text inside `initProgressCallback`.
- `StreamProvider.ts` — emits `stream:parsed` with provider name, record count, and total pipeline duration.

**Panel sections:**
- **DuckDB** — scrollable list of the last 20 queries with duration badges, row counts, and red error labels.
- **WebLLM** — model name, load progress bar, last inference latency and tokens/sec.
- **StreamProvider** — provider name, record count, and parse duration for the most recent file.

## 🎶 Comments

- `devBus.emit()` guards on both `import.meta.env.DEV` and `typeof window !== 'undefined'` so it is SSR-safe.
- The toolbar is excluded from the Vitest environment via the existing `process.env.VITEST` guard in `astro.config.mjs`.
- `tokensPerSec` is clamped to 0 when `durationMs === 0` to avoid `Infinity` in the display.

## 🎤 Test

1. `moon run app:dev` — start the dev server and open the app in the browser.
2. Upload a Spotify or Deezer export file — the **StreamProvider** panel should show the provider name, record count, and parse duration.
3. Charts render — the **DuckDB** panel should populate with queries, durations, and row counts.
4. Send a chat message — the **WebLLM** panel should show load progress during model init (first run), then inference latency and tokens/sec.
5. `pnpm vitest run src/devToolbar/` — 4 tests pass (no-op in prod, event dispatch, cleanup, error passthrough).

<img width="1920" height="1088" alt="image" src="https://github.com/user-attachments/assets/1aead040-a71a-4c4d-a1bd-4a4c7ea6c6c6" />
