### PR TITLE
feat(chat): add contextual quick-question shortcut chips (#391)

### DIFF
--- a/app/src/components/Charts/ChatView.tsx
+++ b/app/src/components/Charts/ChatView.tsx
@@ -11,6 +11,7 @@ import type { DBRow } from '../../llm/inferChartType'
 import { ModelLoader } from '../Chat/ModelLoader'
 import { ChatInput } from '../Chat/ChatInput'
 import { ChatMessageList } from '../Chat/ChatMessageList'
+import { ChatShortcuts } from '../Chat/ChatShortcuts'
 
 function generateId(): string {
     return `${Date.now()}-${Math.random().toString(36).slice(2)}`
@@ -25,6 +26,7 @@ export function ChatView() {
         SummarizeDataQueryResult | undefined
     >()
     const [isAsking, setIsAsking] = useState(false)
+    const [pendingQuestion, setPendingQuestion] = useState<string | null>(null)
     const bottomRef = useRef<HTMLDivElement>(null)
 
     const { state, ensureLoaded, ask } = useChatEngine()
@@ -59,6 +61,15 @@ export function ChatView() {
         bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
     }, [messages])
 
+    // Once the engine finishes loading, auto-send any question queued via a chip
+    useEffect(() => {
+        if (state.kind === 'ready' && pendingQuestion) {
+            const q = pendingQuestion
+            setPendingQuestion(null)
+            handleSubmit(q)
+        }
+    }, [state.kind, pendingQuestion])
+
     const handleEnable = useCallback(() => {
         ensureLoaded()
     }, [ensureLoaded])
@@ -66,6 +77,7 @@ export function ChatView() {
     const handleSubmit = useCallback(
         async (text: string) => {
             if (state.kind !== 'ready') {
+                setPendingQuestion(text)
                 await ensureLoaded()
                 return
             }
@@ -133,6 +145,12 @@ export function ChatView() {
                         />
                         <div ref={bottomRef} />
                     </div>
+                    {messages.length === 0 && (
+                        <ChatShortcuts
+                            onSelect={handleSubmit}
+                            disabled={isLoading}
+                        />
+                    )}
                     <ChatInput
                         disabled={isLoading}
                         placeholder={

--- a/app/src/components/Chat/ChatShortcuts.test.tsx
+++ b/app/src/components/Chat/ChatShortcuts.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ChatShortcuts } from './ChatShortcuts'
+
+describe('ChatShortcuts', () => {
+    it('renders all 6 shortcut chips', () => {
+        render(<ChatShortcuts onSelect={vi.fn()} />)
+        expect(screen.getByText('Top artists')).toBeTruthy()
+        expect(screen.getByText('Late night')).toBeTruthy()
+        expect(screen.getByText('Season trends')).toBeTruthy()
+        expect(screen.getByText('Most replayed')).toBeTruthy()
+        expect(screen.getByText('Peak day')).toBeTruthy()
+        expect(screen.getByText('Discovery')).toBeTruthy()
+    })
+
+    it('calls onSelect with the correct question when a chip is clicked', () => {
+        const onSelect = vi.fn()
+        render(<ChatShortcuts onSelect={onSelect} />)
+
+        fireEvent.click(screen.getByText('Top artists'))
+        expect(onSelect).toHaveBeenCalledWith(
+            'Who are my top 5 most listened to artists?'
+        )
+
+        fireEvent.click(screen.getByText('Season trends'))
+        expect(onSelect).toHaveBeenCalledWith(
+            'How does my listening change by season?'
+        )
+    })
+
+    it('disables all chips when disabled=true', () => {
+        const onSelect = vi.fn()
+        render(<ChatShortcuts onSelect={onSelect} disabled />)
+
+        const buttons = screen.getAllByRole('button')
+        for (const btn of buttons) {
+            expect((btn as HTMLButtonElement).disabled).toBe(true)
+        }
+
+        fireEvent.click(screen.getByText('Top artists'))
+        expect(onSelect).not.toHaveBeenCalled()
+    })
+})

--- a/app/src/components/Chat/ChatShortcuts.tsx
+++ b/app/src/components/Chat/ChatShortcuts.tsx
@@ -1,0 +1,58 @@
+type Shortcut = { emoji: string; label: string; question: string }
+
+const SHORTCUTS: Shortcut[] = [
+    {
+        emoji: '🎵',
+        label: 'Top artists',
+        question: 'Who are my top 5 most listened to artists?',
+    },
+    {
+        emoji: '🌙',
+        label: 'Late night',
+        question: 'What do I listen to after midnight?',
+    },
+    {
+        emoji: '☀️',
+        label: 'Season trends',
+        question: 'How does my listening change by season?',
+    },
+    {
+        emoji: '🔁',
+        label: 'Most replayed',
+        question: 'What is my most replayed track?',
+    },
+    {
+        emoji: '📅',
+        label: 'Peak day',
+        question: 'Which day of the week do I listen most?',
+    },
+    {
+        emoji: '🆕',
+        label: 'Discovery',
+        question: 'Which artists did I discover this year?',
+    },
+]
+
+type ChatShortcutsProps = {
+    onSelect: (question: string) => void
+    disabled?: boolean
+}
+
+export function ChatShortcuts({ onSelect, disabled }: ChatShortcutsProps) {
+    return (
+        <div className="flex gap-2 overflow-x-auto pb-1 md:flex-wrap scrollbar-none">
+            {SHORTCUTS.map((s) => (
+                <button
+                    key={s.label}
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => onSelect(s.question)}
+                    className="flex-none flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/60 dark:bg-slate-800/50 backdrop-blur-md border border-gray-300/60 dark:border-slate-700/50 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:border-gray-400/60 dark:hover:border-slate-600/50 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap shadow-sm"
+                >
+                    <span aria-hidden="true">{s.emoji}</span>
+                    <span>{s.label}</span>
+                </button>
+            ))}
+        </div>
+    )
+}


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Once a user uploads their data, the "what do I ask?" barrier is real — especially on mobile where typing is slow. There's no guidance on what questions are possible, which makes the Chat tab feel blank and uninviting on first open.

## 🎹 Proposal

A row of 6 shortcut chips appears above the chat input whenever the conversation is empty. Tapping a chip auto-submits its predefined question through the existing LLM pipeline — no new chart components, no new query layer. Every chip maps to an already-supported intent in `ChatChartRouter`.

**New component — `ChatShortcuts`** (`src/components/Chat/ChatShortcuts.tsx`):
- Stateless chip row; receives `onSelect(question)` and `disabled` props
- Layout: horizontal scroll on mobile, wraps on desktop (`flex overflow-x-auto md:flex-wrap`)
- Styled with the app's glassmorphic pill design (matches `DemoButton`/`HowToButton`)

**Chips and their resolved intents:**
| Chip | Question | Intent |
|------|----------|--------|
| 🎵 Top artists | Who are my top 5 most listened to artists? | `top_artists` |
| 🌙 Late night | What do I listen to after midnight? | `listening_rhythm` |
| ☀️ Season trends | How does my listening change by season? | `seasonal_patterns` |
| 🔁 Most replayed | What is my most replayed track? | `repeat_behavior` |
| 📅 Peak day | Which day of the week do I listen most? | `streams_per_day_of_week` |
| 🆕 Discovery | Which artists did I discover this year? | `artist_discovery` |

**`ChatView` changes** (`src/components/Charts/ChatView.tsx`):
- Renders `<ChatShortcuts>` above the input when `messages.length === 0`; chips disappear after the first message
- Adds a `pendingQuestion` state: if a chip is tapped before the WebLLM engine has loaded, the question is stored and auto-sent once the model is ready — no double-tap required

## 🎶 Comments

- Zero new DuckDB queries or chart components — the entire chip feature piggybacks on the existing `askLLM` → `ChatChartRouter` pipeline.
- All data stays client-side, consistent with the privacy-first principle.
- The `pendingQuestion` pattern is forward-compatible with Phase 2 (dynamic chips based on dataset) and Phase 3 (free-text routing).

## 🎤 Test

1. `moon run app:dev` → upload a file → open the **Chat** tab → 6 chips appear above the input.
2. Tap any chip → the question is submitted → LLM loads (first time) → the matching chart renders inline.
3. Tap a chip **before** the model has finished loading → model loads → question sends automatically (no second tap).
4. After the first message, chips are no longer visible.
5. On a narrow viewport, chips scroll horizontally; on desktop they wrap.
6. `pnpm vitest run src/components/Chat/ChatShortcuts.test.tsx` — 3 tests pass (renders all chips, correct question on click, disabled state).