### PR TITLE
fix(results): fix spacing regression across all views

### DIFF
--- a/app/src/components/Results/Results.tsx
+++ b/app/src/components/Results/Results.tsx
@@ -52,25 +52,19 @@ export function Results() {
                             aria-selected={activeTab === tab.id}
                             title={tab.tooltip}
                             onClick={() => setActiveTab(tab.id)}
-                            className={`group relative z-10 flex-1 px-4 py-3 text-sm font-semibold rounded-xl transition-all duration-300 ${
+                            className={`relative z-10 flex-1 px-4 py-3 text-sm font-semibold rounded-xl transition-all duration-300 ${
                                 activeTab === tab.id
                                     ? 'text-white'
                                     : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
                             }`}
                         >
                             {tab.label}
-                            <span
-                                aria-hidden="true"
-                                className="pointer-events-none absolute left-1/2 top-full mt-2 -translate-x-1/2 whitespace-nowrap rounded-lg bg-gray-900 px-2 py-1 text-xs font-normal text-white opacity-0 transition-opacity duration-200 group-hover:opacity-100 dark:bg-slate-700"
-                            >
-                                {tab.tooltip}
-                            </span>
                         </button>
                     ))}
                 </div>
             </div>
 
-            <div className="min-h-screen">
+            <div>
                 {activeTab === 'simple' ? (
                     <SimpleView />
                 ) : activeTab === 'lab' ? (


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Spacing regression visible across all views (Simple, Lab, Chat, Query), two root causes:
1. Tooltip `<span>` elements use `whitespace-nowrap` with long text (~210px wide), overflowing the `max-w-xl` container. Invisible (`opacity-0`) but still counted in scroll width by the browser -> phantom horizontal scrollbar appears on all views.
2. `min-h-screen` on the content div forces 100vh height, compounded by `flex items-center` in the parent layout, creating excessive vertical space around the nav bar.

Closes #410.

## 🎹 Proposal

- Remove custom tooltip `<span>` elements from the tab bar: the native `title` attribute on each button already provides tooltip functionality. Eliminates horizontal overflow at the source. Also removes the now-unused `group` Tailwind class from the buttons.
- Remove `min-h-screen` from the content div: page scrolls naturally, this constraint served no purpose.

## 🎶 Comments

Two changes in a single file (`app/src/components/Results/Results.tsx`).

## 🎤 Test

1. Load the app and upload or use demo data.
2. Check all 4 tabs (Simple, Lab, Chat, Query).
3. Verify no horizontal scrollbar appears.
4. Verify the nav bar spacing is correct.