### PR TITLE
fix(upload-error): fix accidental dismiss and improve error toast UX

### DIFF
--- a/app/src/components/UploadError.test.tsx
+++ b/app/src/components/UploadError.test.tsx
@@ -17,6 +17,19 @@ describe('UploadError', () => {
         expect(screen.getByRole('alert').textContent).toContain('Upload failed')
     })
 
+    it('has aria-live="assertive" and aria-atomic="true"', () => {
+        render(<UploadError message="Error" onDismiss={vi.fn()} />)
+        const alert = screen.getByRole('alert')
+        expect(alert.getAttribute('aria-live')).toBe('assertive')
+        expect(alert.getAttribute('aria-atomic')).toBe('true')
+    })
+
+    it('close button has type="button"', () => {
+        render(<UploadError message="Error" onDismiss={vi.fn()} />)
+        const btn = screen.getByRole('button', { name: 'Dismiss error' })
+        expect(btn.getAttribute('type')).toBe('button')
+    })
+
     it('calls onDismiss when close button is clicked', () => {
         const onDismiss = vi.fn()
         render(<UploadError message="Error" onDismiss={onDismiss} />)

--- a/app/src/components/UploadError.test.tsx
+++ b/app/src/components/UploadError.test.tsx
@@ -14,28 +14,20 @@ describe('UploadError', () => {
 
     it('renders with role="alert" and displays the message', () => {
         render(<UploadError message="Upload failed" onDismiss={vi.fn()} />)
-        const alert = screen.getByRole('alert')
-        expect(alert.textContent).toBe('Upload failed')
+        expect(screen.getByRole('alert').textContent).toContain('Upload failed')
     })
 
-    it('calls onDismiss when clicked', () => {
+    it('calls onDismiss when close button is clicked', () => {
         const onDismiss = vi.fn()
         render(<UploadError message="Error" onDismiss={onDismiss} />)
-        fireEvent.click(screen.getByRole('alert'))
+        fireEvent.click(screen.getByRole('button', { name: 'Dismiss error' }))
         expect(onDismiss).toHaveBeenCalledOnce()
     })
 
-    it('calls onDismiss when Enter is pressed', () => {
+    it('does not dismiss when clicking the message text', () => {
         const onDismiss = vi.fn()
         render(<UploadError message="Error" onDismiss={onDismiss} />)
-        fireEvent.keyDown(screen.getByRole('alert'), { key: 'Enter' })
-        expect(onDismiss).toHaveBeenCalledOnce()
-    })
-
-    it('does not call onDismiss for non-Enter key presses', () => {
-        const onDismiss = vi.fn()
-        render(<UploadError message="Error" onDismiss={onDismiss} />)
-        fireEvent.keyDown(screen.getByRole('alert'), { key: 'Escape' })
+        fireEvent.click(screen.getByText('Error'))
         expect(onDismiss).not.toHaveBeenCalled()
     })
 

--- a/app/src/components/UploadError.test.tsx
+++ b/app/src/components/UploadError.test.tsx
@@ -49,4 +49,36 @@ describe('UploadError', () => {
         })
         expect(onDismiss).not.toHaveBeenCalled()
     })
+
+    it('pauses auto-dismiss timer while hovered', () => {
+        const onDismiss = vi.fn()
+        render(<UploadError message="Error" onDismiss={onDismiss} />)
+        fireEvent.mouseEnter(screen.getByRole('alert'))
+        act(() => {
+            vi.advanceTimersByTime(8000)
+        })
+        expect(onDismiss).not.toHaveBeenCalled()
+    })
+
+    it('resumes timer with remaining time after hover ends', () => {
+        const onDismiss = vi.fn()
+        render(<UploadError message="Error" onDismiss={onDismiss} />)
+        act(() => {
+            vi.advanceTimersByTime(3000)
+        })
+        fireEvent.mouseEnter(screen.getByRole('alert'))
+        act(() => {
+            vi.advanceTimersByTime(5000)
+        })
+        expect(onDismiss).not.toHaveBeenCalled()
+        fireEvent.mouseLeave(screen.getByRole('alert'))
+        act(() => {
+            vi.advanceTimersByTime(4999)
+        })
+        expect(onDismiss).not.toHaveBeenCalled()
+        act(() => {
+            vi.advanceTimersByTime(1)
+        })
+        expect(onDismiss).toHaveBeenCalledOnce()
+    })
 })

--- a/app/src/components/UploadError.tsx
+++ b/app/src/components/UploadError.tsx
@@ -29,14 +29,17 @@ export function UploadError({ message, onDismiss }: UploadErrorProps) {
     return (
         <div
             role="alert"
+            aria-live="assertive"
+            aria-atomic="true"
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
             className="fixed top-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 rounded-lg bg-rose-700 px-5 py-3 text-white shadow-lg"
         >
             <span className="select-text">{message}</span>
             <button
+                type="button"
                 onClick={onDismiss}
-                className="ml-1 rounded p-0.5 hover:bg-rose-600 transition-colors"
+                className="ml-1 rounded p-0.5 hover:bg-rose-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
                 aria-label="Dismiss error"
             >
                 ✕

--- a/app/src/components/UploadError.tsx
+++ b/app/src/components/UploadError.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 const DISMISS_DELAY_MS = 8000
 
@@ -8,17 +8,32 @@ interface UploadErrorProps {
 }
 
 export function UploadError({ message, onDismiss }: UploadErrorProps) {
+    const [hovered, setHovered] = useState(false)
+    const remainingRef = useRef(DISMISS_DELAY_MS)
+    const startRef = useRef(Date.now())
+
     useEffect(() => {
-        const t = setTimeout(onDismiss, DISMISS_DELAY_MS)
+        remainingRef.current = DISMISS_DELAY_MS
+    }, [message])
+
+    useEffect(() => {
+        if (hovered) {
+            remainingRef.current -= Date.now() - startRef.current
+            return
+        }
+        startRef.current = Date.now()
+        const t = setTimeout(onDismiss, remainingRef.current)
         return () => clearTimeout(t)
-    }, [message, onDismiss])
+    }, [hovered, message, onDismiss])
 
     return (
         <div
             role="alert"
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
             className="fixed top-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 rounded-lg bg-rose-700 px-5 py-3 text-white shadow-lg"
         >
-            <span>{message}</span>
+            <span className="select-text">{message}</span>
             <button
                 onClick={onDismiss}
                 className="ml-1 rounded p-0.5 hover:bg-rose-600 transition-colors"

--- a/app/src/components/UploadError.tsx
+++ b/app/src/components/UploadError.tsx
@@ -16,13 +16,16 @@ export function UploadError({ message, onDismiss }: UploadErrorProps) {
     return (
         <div
             role="alert"
-            aria-label="Dismiss error"
-            tabIndex={0}
-            onClick={onDismiss}
-            onKeyDown={(e) => e.key === 'Enter' && onDismiss()}
-            className="fixed top-6 left-1/2 -translate-x-1/2 z-50 cursor-pointer rounded-lg bg-rose-700 px-5 py-3 text-white shadow-lg hover:bg-red-700 transition-colors"
+            className="fixed top-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 rounded-lg bg-rose-700 px-5 py-3 text-white shadow-lg"
         >
-            {message}
+            <span>{message}</span>
+            <button
+                onClick={onDismiss}
+                className="ml-1 rounded p-0.5 hover:bg-rose-600 transition-colors"
+                aria-label="Dismiss error"
+            >
+                ✕
+            </button>
         </div>
     )
 }


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Clicking anywhere on the upload error toast dismissed it immediately, even when the user was just trying to read the message. There was also no way to select or copy the error text, and the toast kept counting down regardless of whether the user was actively reading it.

## 🎹 Proposal

The toast no longer dismisses on click. A dedicated × button handles dismissal instead. The error message is now selectable, and the auto-dismiss countdown pauses while the user hovers over the toast, resuming from where it left off when they move away.

## 🎶 Comments

Screen reader support is also improved: `aria-live` and `aria-atomic` are now explicit on the alert container, and the close button has a visible focus ring for keyboard navigation.

## 🎤 Test

1. Upload an invalid file to trigger an error toast.
2. Click on the message text: toast should stay visible.
3. Hover over the toast for more than 8 seconds: toast should not dismiss.
4. Move the cursor away: toast should dismiss after the remaining time.
5. Click the × button: toast should dismiss immediately.