### PR TITLE
fix(upload-error): fix timer edge cases when message changes while hovered

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,29 @@ Or bring your own data:
 
 </details>
 
+<details>
+<summary>Any other source</summary>
+<br>
+
+Tracksy accepts data from **any source** as long as you format it as a CSV with the following columns:
+
+| Column        | Type                | Description                      | Example                      |
+| ------------- | ------------------- | -------------------------------- | ---------------------------- |
+| `ts`          | ISO 8601 UTC string | Start of play                    | `2024-03-15T14:30:00.000Z`   |
+| `track_name`  | string              | Song title                       | `Never Gonna Give You Up`    |
+| `artist_name` | string              | Artist (empty string if unknown) | `Rick Astley`                |
+| `album_name`  | string              | Album (empty string if unknown)  | `Whenever You Need Somebody` |
+| `ms_played`   | integer ≥ 0         | Milliseconds played              | `213000`                     |
+| `track_uri`   | string              | Stable unique ID for the track   | `custom:rick-astley:ngru`    |
+| `platform`    | string              | Source label                     | `tidal`                      |
+
+Save the file as **`tracksy-custom.csv`** (exact name required) and upload it to Tracksy.
+
+> Records with `ms_played < 30000` (less than 30 seconds) are filtered automatically.
+> Use any stable string for `track_uri` — `custom:{artist}:{title}` works fine.
+
+</details>
+
 ### 🚀 Upload your data
 
 Go to [Tracksy](https://gudsfile.github.io/tracksy/) and upload your file, or hit the demo button.

--- a/app/src/components/UploadError.test.tsx
+++ b/app/src/components/UploadError.test.tsx
@@ -73,6 +73,28 @@ describe('UploadError', () => {
         expect(onDismiss).not.toHaveBeenCalled()
     })
 
+    it('resets timer to full delay when message changes while hovered', () => {
+        const onDismiss = vi.fn()
+        const { rerender } = render(<UploadError message="Error 1" onDismiss={onDismiss} />)
+        act(() => {
+            vi.advanceTimersByTime(7000)
+        })
+        fireEvent.mouseEnter(screen.getByRole('alert'))
+        act(() => {
+            vi.advanceTimersByTime(2000)
+        })
+        rerender(<UploadError message="Error 2" onDismiss={onDismiss} />)
+        fireEvent.mouseLeave(screen.getByRole('alert'))
+        act(() => {
+            vi.advanceTimersByTime(7999)
+        })
+        expect(onDismiss).not.toHaveBeenCalled()
+        act(() => {
+            vi.advanceTimersByTime(1)
+        })
+        expect(onDismiss).toHaveBeenCalledOnce()
+    })
+
     it('resumes timer with remaining time after hover ends', () => {
         const onDismiss = vi.fn()
         render(<UploadError message="Error" onDismiss={onDismiss} />)

--- a/app/src/components/UploadError.tsx
+++ b/app/src/components/UploadError.tsx
@@ -14,11 +14,12 @@ export function UploadError({ message, onDismiss }: UploadErrorProps) {
 
     useEffect(() => {
         remainingRef.current = DISMISS_DELAY_MS
+        startRef.current = Date.now()
     }, [message])
 
     useEffect(() => {
         if (hovered) {
-            remainingRef.current -= Date.now() - startRef.current
+            remainingRef.current = Math.max(0, remainingRef.current - (Date.now() - startRef.current))
             return
         }
         startRef.current = Date.now()

--- a/app/src/streamProvider/CustomStreamProvider/CustomStreamProvider.test.ts
+++ b/app/src/streamProvider/CustomStreamProvider/CustomStreamProvider.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CustomStreamProvider } from './CustomStreamProvider'
+import type { CustomRawRecord } from './types'
+import type { StreamRecord } from '../types'
+
+function mockFile(
+    buffer: ArrayBuffer,
+    name: string,
+    options: { type: string }
+) {
+    return {
+        name,
+        arrayBuffer: async () => buffer,
+        type: options.type,
+        size: buffer.byteLength,
+    } as unknown as File
+}
+
+const CSV_TYPE = 'text/csv'
+
+const RAW_RECORD: CustomRawRecord = {
+    ts: '2024-03-15T14:30:00.000Z',
+    track_name: 'Never Gonna Give You Up',
+    artist_name: 'Rick Astley',
+    album_name: 'Whenever You Need Somebody',
+    ms_played: 213000,
+    track_uri: 'custom:rick-astley:ngru',
+    platform: 'tidal',
+}
+
+describe('CustomStreamProvider', () => {
+    const provider = new CustomStreamProvider()
+
+    it('should return correct metadata', () => {
+        expect(provider.name).toBe('custom')
+        expect(provider.fileContentType).toBe(CSV_TYPE)
+        expect(provider.filePattern).toBeInstanceOf(RegExp)
+        expect(provider.acceptedFormats).toBe('CSV')
+    })
+
+    describe('validateFile', () => {
+        it.each(['tracksy-custom.csv', 'TRACKSY-CUSTOM.CSV'])(
+            'should return true for %s',
+            (filename) => {
+                const file = mockFile(new ArrayBuffer(0), filename, {
+                    type: CSV_TYPE,
+                })
+                expect(provider.validateFile(file)).toBe(true)
+            }
+        )
+
+        it.each([
+            'custom.csv',
+            'tracksy.csv',
+            'tracksy-custom.json',
+            'my-data.csv',
+        ])('should return false for %s', (filename) => {
+            const file = mockFile(new ArrayBuffer(0), filename, {
+                type: CSV_TYPE,
+            })
+            expect(provider.validateFile(file)).toBe(false)
+        })
+    })
+
+    describe('transform', () => {
+        it('should map raw record to StreamRecord', () => {
+            const result = provider.transform([RAW_RECORD])
+            const expected: StreamRecord = {
+                track_uri: 'custom:rick-astley:ngru',
+                track_name: 'Never Gonna Give You Up',
+                artist_name: 'Rick Astley',
+                album_name: 'Whenever You Need Somebody',
+                ts: '2024-03-15T14:30:00.000Z',
+                ms_played: 213000,
+                platform: 'tidal',
+            }
+            expect(result).toHaveLength(1)
+            expect(result[0]).toEqual(expected)
+        })
+
+        it('should guard against negative ms_played', () => {
+            const record: CustomRawRecord = { ...RAW_RECORD, ms_played: -1000 }
+            const result = provider.transform([record])
+            expect(result[0].ms_played).toBe(0)
+        })
+
+        it('should guard against null ms_played', () => {
+            const record: CustomRawRecord = { ...RAW_RECORD, ms_played: null }
+            const result = provider.transform([record])
+            expect(result[0].ms_played).toBe(0)
+        })
+
+        it('should fall back to "custom" platform if missing', () => {
+            const record: CustomRawRecord = { ...RAW_RECORD, platform: null }
+            const result = provider.transform([record])
+            expect(result[0].platform).toBe('custom')
+        })
+
+        it('should coerce numeric ms_played string', () => {
+            const record: CustomRawRecord = {
+                ...RAW_RECORD,
+                ms_played: '213000',
+            }
+            const result = provider.transform([record])
+            expect(result[0].ms_played).toBe(213000)
+        })
+
+        it('should handle empty input array', () => {
+            expect(provider.transform([])).toEqual([])
+        })
+    })
+
+    describe('readFile', () => {
+        let mockConn: { query: ReturnType<typeof vi.fn> }
+        let mockDb: {
+            registerFileBuffer: ReturnType<typeof vi.fn>
+            dropFile: ReturnType<typeof vi.fn>
+        }
+
+        beforeEach(() => {
+            mockConn = { query: vi.fn() }
+            mockDb = {
+                registerFileBuffer: vi.fn(),
+                dropFile: vi.fn(),
+            }
+        })
+
+        it('should register, query, and drop the temp file', async () => {
+            const mockRow = { toJSON: () => ({ ...RAW_RECORD }) }
+            mockConn.query.mockResolvedValue({ toArray: () => [mockRow] })
+
+            const getDB = await import('../../db/getDB')
+            vi.spyOn(getDB, 'getDB').mockResolvedValue({
+                db: mockDb as never,
+                conn: mockConn as never,
+            })
+
+            const file = mockFile(new ArrayBuffer(8), 'tracksy-custom.csv', {
+                type: CSV_TYPE,
+            })
+            const result = await provider.readFile(file)
+
+            expect(mockDb.registerFileBuffer).toHaveBeenCalledWith(
+                '_custom_tmp.csv',
+                expect.any(Uint8Array)
+            )
+            expect(mockConn.query).toHaveBeenCalledWith(
+                expect.stringContaining('read_csv')
+            )
+            expect(mockDb.dropFile).toHaveBeenCalledWith('_custom_tmp.csv')
+            expect(result).toHaveLength(1)
+        })
+
+        it('should drop temp file even if query fails', async () => {
+            mockConn.query.mockRejectedValue(new Error('query failed'))
+
+            const getDB = await import('../../db/getDB')
+            vi.spyOn(getDB, 'getDB').mockResolvedValue({
+                db: mockDb as never,
+                conn: mockConn as never,
+            })
+
+            const file = mockFile(new ArrayBuffer(8), 'tracksy-custom.csv', {
+                type: CSV_TYPE,
+            })
+            await expect(provider.readFile(file)).rejects.toThrow(
+                'query failed'
+            )
+            expect(mockDb.dropFile).toHaveBeenCalledWith('_custom_tmp.csv')
+        })
+    })
+})

--- a/app/src/streamProvider/CustomStreamProvider/CustomStreamProvider.ts
+++ b/app/src/streamProvider/CustomStreamProvider/CustomStreamProvider.ts
@@ -1,0 +1,43 @@
+import { getDB } from '../../db/getDB'
+import { StreamProvider } from '../StreamProvider'
+import type { StreamRecord } from '../types'
+import type { CustomRawRecord } from './types'
+
+const TMP_FILE_NAME = '_custom_tmp.csv'
+
+export class CustomStreamProvider extends StreamProvider<CustomRawRecord> {
+    readonly name = 'custom'
+    readonly displayName = 'Custom'
+    readonly acceptedFormats = 'CSV'
+    readonly filePattern = /^tracksy-custom\.csv$/i
+    readonly fileContentType = 'text/csv'
+
+    async readFile(file: File): Promise<CustomRawRecord[]> {
+        const buffer = await file.arrayBuffer()
+        const { db, conn } = await getDB()
+
+        await db.registerFileBuffer(TMP_FILE_NAME, new Uint8Array(buffer))
+        try {
+            const result = await conn.query(
+                `SELECT * FROM read_csv('${TMP_FILE_NAME}', header=true)`
+            )
+            return result
+                .toArray()
+                .map((row) => row.toJSON() as CustomRawRecord)
+        } finally {
+            await db.dropFile(TMP_FILE_NAME)
+        }
+    }
+
+    transform(rawData: CustomRawRecord[]): StreamRecord[] {
+        return rawData.map((r) => ({
+            track_uri: String(r.track_uri ?? ''),
+            track_name: String(r.track_name ?? ''),
+            artist_name: String(r.artist_name ?? ''),
+            album_name: String(r.album_name ?? ''),
+            ts: String(r.ts ?? ''),
+            ms_played: Math.max(0, Number(r.ms_played) || 0),
+            platform: String(r.platform ?? 'custom'),
+        }))
+    }
+}

--- a/app/src/streamProvider/CustomStreamProvider/index.ts
+++ b/app/src/streamProvider/CustomStreamProvider/index.ts
@@ -1,0 +1,1 @@
+export { CustomStreamProvider } from './CustomStreamProvider'

--- a/app/src/streamProvider/CustomStreamProvider/types.ts
+++ b/app/src/streamProvider/CustomStreamProvider/types.ts
@@ -1,0 +1,10 @@
+export interface CustomRawRecord {
+    ts: unknown
+    track_name: unknown
+    artist_name: unknown
+    album_name: unknown
+    ms_played: unknown
+    track_uri: unknown
+    platform: unknown
+    [key: string]: unknown
+}

--- a/app/src/streamProvider/index.test.ts
+++ b/app/src/streamProvider/index.test.ts
@@ -32,6 +32,14 @@ describe('StreamProvider Factory', () => {
             expect(streamProvider?.name).toBe('apple-music')
         })
 
+        it('should detect custom files', () => {
+            const file = new File([], 'tracksy-custom.csv')
+            const streamProvider = detectProvider(file)
+
+            expect(streamProvider).not.toBeUndefined()
+            expect(streamProvider?.name).toBe('custom')
+        })
+
         it('should return undefined for unknown file formats', () => {
             const file = new File([], 'unknown_format.json')
             const streamProvider = detectProvider(file)
@@ -51,9 +59,10 @@ describe('StreamProvider Factory', () => {
 
         it('returns one entry per registered provider with format hint', () => {
             const names = getSupportedProviderNames()
-            expect(names.length).toBe(2)
+            expect(names.length).toBe(3)
             expect(names).toContain('Spotify (ZIP/JSON)')
             expect(names).toContain('Deezer (XLSX)')
+            expect(names).toContain('Custom (CSV)')
             expect(names).not.toContain('Apple Music (ZIP/CSV)')
         })
     })

--- a/app/src/streamProvider/index.ts
+++ b/app/src/streamProvider/index.ts
@@ -1,13 +1,14 @@
 import { AppleMusicStreamProvider } from './AppleMusicStreamProvider/AppleMusicStreamProvider'
+import { CustomStreamProvider } from './CustomStreamProvider/CustomStreamProvider'
 import { DeezerStreamProvider } from './DeezerStreamProvider/DeezerStreamProvider'
 import type { StreamProvider } from './StreamProvider'
 import { SpotifyStreamProvider } from './SpotifyStreamProvider/SpotifyStreamProvider'
 
-// Registry of all available provider adapters
 const STREAM_PROVIDERS: StreamProvider[] = [
     new SpotifyStreamProvider(),
     new DeezerStreamProvider(),
     new AppleMusicStreamProvider(),
+    new CustomStreamProvider(),
 ]
 
 export const STREAM_PROVIDERS_CONTENT_TYPES = STREAM_PROVIDERS.map(

--- a/specs/spec-12-provider-custom.md
+++ b/specs/spec-12-provider-custom.md
@@ -1,0 +1,78 @@
+# Spec: Custom / Generic Provider
+
+## Objective
+
+Let users import listening history from **any source** — even sources Tracksy doesn't
+natively support — by providing a simple CSV template with predefined column names that
+map directly to Tracksy's internal `StreamRecord` format.
+
+No UI column mapper. No server processing. The user reformats their data locally (in
+Excel, Python, etc.) to match the template, then uploads the file.
+
+**Success looks like:** a user exports data from Tidal, Last.fm, Navidrome, or a
+home-grown scrobbler, fills in the template CSV, uploads `tracksy-custom.csv`, and sees
+their listening history in Tracksy exactly like a native provider.
+
+## Template format
+
+**Filename:** `tracksy-custom.csv`
+**Content-type:** `text/csv`
+
+### Required columns
+
+| Column | Type | Description | Example |
+|---|---|---|---|
+| `ts` | ISO 8601 string (UTC) | Start of play | `2024-03-15T14:30:00.000Z` |
+| `track_name` | string | Song title | `Never Gonna Give You Up` |
+| `artist_name` | string | Primary artist (empty string if unknown) | `Rick Astley` |
+| `album_name` | string | Album (empty string if unknown) | `Whenever You Need Somebody` |
+| `ms_played` | integer ≥ 0 | Milliseconds played | `213000` |
+| `track_uri` | string | Unique ID for the track | `custom:rick-astley:ngr` |
+| `platform` | string | Source platform label | `tidal` |
+
+All columns are required. Rows that fail validation (missing required fields, `ms_played`
+< 30 000) are silently dropped — same as all other providers.
+
+### Notes
+
+- `track_uri` only needs to be internally consistent for deduplication; any stable string
+  works. Suggested format: `custom:{artist}:{title}` or a native ID from the source.
+- `artist_name` and `album_name` may be empty strings — providers like JellyFin already
+  do this.
+- Records with `ms_played < 30000` are filtered (global 30 s rule). Skipped plays should
+  be excluded by the user before upload, or set `ms_played` to the actual played
+  duration.
+
+## Implementation
+
+### App
+
+- New `CustomStreamProvider` in `app/src/streamProvider/CustomStreamProvider/`
+- `filePattern = /^tracksy-custom\.csv$/i`
+- `fileContentType = 'text/csv'`
+- `readFile`: DuckDB `read_csv` (same pattern as JellyFin)
+- `transform`: columns already match `StreamRecord` — direct passthrough + type coercion
+- Register in `app/src/streamProvider/index.ts`
+- README section: template download link or inline example, copy-paste instructions
+
+### Synthetic datasets
+
+- Not needed — users provide their own data. No factory/writer to generate.
+
+## Open questions
+
+None — format is entirely under our control.
+
+## Success criteria
+
+- [ ] `tracksy-custom.csv` with valid rows loads and displays charts identically to
+      native providers
+- [ ] Rows with `ms_played < 30000` are filtered
+- [ ] Rows missing required columns are dropped silently
+- [ ] README documents the column format with a worked example
+- [ ] A downloadable CSV template (header-only) is linked or embedded in the UI
+
+## Non-goals
+
+- UI column mapper (drag-drop field assignment) — future work if demand exists
+- Supporting custom XLSX or JSON — CSV only for v1


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

After merging #422, post-merge review identified two edge cases in the hover-pause timer logic:

1. If a new message arrives while the toast is hovered and total elapsed time exceeds `DISMISS_DELAY_MS`, `remainingRef` goes negative. `setTimeout(onDismiss, negative)` clamps to 0 and fires immediately on mouse leave.
2. The message-reset effect only reset `remainingRef` but not `startRef`. When the hover-pause effect ran again due to the message dep change, it subtracted elapsed time from the wrong anchor, giving the new message less than the full dismiss delay.

## 🎹 Proposal

- Clamp remaining time to 0 with `Math.max(0, ...)` in the hover-pause branch.
- Also reset `startRef.current = Date.now()` in the message-reset effect so the hover anchor is always relative to the latest message.

## 🎶 Comments

Both fixes are one-liners. The `Math.max` clamp is defensive; the `startRef` reset is the root fix that prevents the negative case when a message changes while hovered.

## 🎤 Test

1. Upload an invalid file to trigger the error toast.
2. Hover over the toast for the full 8 seconds: toast should not dismiss.
3. Move cursor away: toast should dismiss after a short delay (remaining time), not immediately.
4. Trigger a new error while hovering over an existing toast: the new message should get the full 8 s delay after you stop hovering.

New regression test added: `resets timer to full delay when message changes while hovered`.