### PR TITLE
feat(app): add GitHub link footer

### DIFF
--- a/app/src/components/App.tsx
+++ b/app/src/components/App.tsx
@@ -25,6 +25,17 @@ export function App() {
                         <TracksyWrapper />
                     </div>
                 </div>
+
+                <footer className="relative z-10 pb-6 text-center text-sm text-gray-400 dark:text-slate-500">
+                    <a
+                        href="https://github.com/Gudsfile/tracksy"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:text-gray-600 dark:hover:text-slate-300 transition-colors"
+                    >
+                        Music stats made with ❤️ & 🔐
+                    </a>
+                </footer>
             </div>
         </ThemeProvider>
     )


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

No link to the GitHub repository was visible in the app.

## 🎹 Proposal

Adds a footer at the bottom of the page with a link to the GitHub repository. The link text doubles as a tagline: "Music stats made with ❤️ & 🔐".

## 🎶 Comments

Styled to be unobtrusive: muted gray, adapts to light/dark theme.

## 🎤 Test

Open the app: a footer link appears at the bottom of the page. Clicking it opens the GitHub repo in a new tab.