### PR TITLE
feat(providers): add custom CSV provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The same old song? Late at night? Only in summer? Tracksy helps you answer these
 
 Tracksy is a **privacy-first** music streaming data visualization tool. All processing happens in your browser. Your data never leaves your device.
 
-- 🎵 Supports **Spotify** and **Deezer** streaming history
+- 🎵 Supports **Spotify**, **Deezer**, and **any source** via custom CSV
 - 🦆 Powered by **DuckDB WASM**: SQL in the browser, zero server
 - 🔒 **No account. No upload. No tracking.**
 
@@ -73,6 +73,74 @@ Or bring your own data:
 3. Download and extract the ZIP you receive by email
 4. Inside the archive, navigate to `Apple Music Activity/` and find `Apple Music Play Activity.csv`.
 5. If the data is in a nested ZIP (e.g. `Apple_Media_Services.zip`), upload the outer ZIP directly, Tracksy extracts it automatically.
+
+</details>
+
+<details>
+<summary>Any other source</summary>
+<br>
+
+Tracksy accepts data from **any source** as long as you format it as a CSV with the following columns:
+
+| Column        | Type                | Description                      | Example                      |
+| ------------- | ------------------- | -------------------------------- | ---------------------------- |
+| `ts`          | ISO 8601 UTC string | Start of play                    | `2024-03-15T14:30:00.000Z`   |
+| `track_name`  | string              | Song title                       | `Le vent se lève`            |
+| `artist_name` | string              | Artist (empty string if unknown) | `Veridis Project`            |
+| `album_name`  | string              | Album (empty string if unknown)  | `Voir le soleil`             |
+| `ms_played`   | integer ≥ 0         | Milliseconds played              | `213000`                     |
+| `track_uri`   | string              | Stable identifier (any unique string) | `custom:veridis-project:le-vent-se-leve` |
+| `platform`    | string              | Source label                     | `tidal`                      |
+
+Save the file as **`tracksy-custom.csv`** (exact name required) and upload it to Tracksy.
+
+> [!NOTE]
+>
+> Records with `ms_played < 30000` (less than 30 seconds) are filtered automatically.
+>
+> Use any stable string for `track_uri` - `custom:{artist}:{title}` works fine.
+
+#### Example
+
+```csv
+ts,track_name,artist_name,album_name,ms_played,track_uri,platform
+2024-03-15T14:30:00.000Z,Le vent se lève,Veridis Project,Voir le soleil,213000,custom:veridis-project:le-vent-se-leve,tidal
+2024-03-15T14:33:53.000Z,Veridis Quo,Daft Punk,Discovery,243000,custom:daft-punk:veridis-quo,tidal
+2024-03-15T14:38:06.000Z,my dey,Zubi,Dear Z,120000,custom:zubi:my-dey,tidal
+```
+
+#### Convert with a spreadsheet editor
+
+Works with Excel, Google Sheets, LibreOffice Calc, or any equivalent.
+
+1. Open your export file in your spreadsheet editor.
+2. Rename each column header to match the required names: `ts`, `track_name`, `artist_name`, `album_name`, `ms_played`, `track_uri`, `platform`.
+3. Make sure `ts` is formatted as ISO 8601 UTC (e.g. `2024-03-15T14:30:00.000Z`). If it is a date/time cell, format it as plain text first.
+4. If your source has no unique track ID, add a `track_uri` column with a formula like `="custom:"&[artist column]&":"&[title column]`.
+5. Delete rows where the play duration is under 30 seconds (30 000 ms).
+6. Export as CSV with UTF-8 encoding.
+7. Rename the saved file to `tracksy-custom.csv`.
+
+#### Convert with DuckDB CLI
+
+If your source data is already in CSV or JSON, [DuckDB CLI](https://duckdb.org/docs/installation/) can reshape it in one query:
+
+```sql
+COPY (
+    SELECT
+        your_timestamp_col                                        AS ts,
+        your_title_col                                            AS track_name,
+        your_artist_col                                           AS artist_name,
+        your_album_col                                            AS album_name,
+        your_duration_ms_col                                      AS ms_played,
+        'custom:' || your_artist_col || ':' || your_title_col     AS track_uri,
+        'my-source'                                               AS platform
+    FROM read_csv('your-export.csv', header = true)
+    WHERE your_duration_ms_col >= 30000
+) TO 'tracksy-custom.csv' (HEADER, DELIMITER ',');
+```
+
+Replace `read_csv` with `read_json`, `read_xlsx` [or other](https://duckdb.org/docs/current/data/data_sources) depending on your source.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Or bring your own data:
 
 
 <details>
-<summary>Apple Music ⚠️ Experimental</summary>
+<summary>Apple Music (experimental)</summary>
 <br>
 
-> **Warning**
+> [!IMPORTANT]
 > Apple Music support is experimental. The export format has significant limitations: artist name is not included in the data, which means artist-based charts will not populate. Some data quality issues may affect visualizations. Use at your own discretion.
 
 1. Sign in at [privacy.apple.com](https://privacy.apple.com) and request a copy of your data.

--- a/app/src/streamProvider/CustomStreamProvider/CustomStreamProvider.test.ts
+++ b/app/src/streamProvider/CustomStreamProvider/CustomStreamProvider.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as getDBModule from '../../db/getDB'
+import { CustomStreamProvider } from './CustomStreamProvider'
+import type { CustomRawRecord } from './types'
+import type { StreamRecord } from '../types'
+
+function mockFile(
+    buffer: ArrayBuffer,
+    name: string,
+    options: { type: string }
+) {
+    return {
+        name,
+        arrayBuffer: async () => buffer,
+        type: options.type,
+        size: buffer.byteLength,
+    } as unknown as File
+}
+
+const CSV_TYPE = 'text/csv'
+
+const RAW_RECORD: CustomRawRecord = {
+    ts: '2024-03-15T14:30:00.000Z',
+    track_name: 'Never Gonna Give You Up',
+    artist_name: 'Rick Astley',
+    album_name: 'Whenever You Need Somebody',
+    ms_played: 213000,
+    track_uri: 'custom:rick-astley:ngru',
+    platform: 'tidal',
+}
+
+describe('CustomStreamProvider', () => {
+    const provider = new CustomStreamProvider()
+
+    it('should return correct metadata', () => {
+        expect(provider.name).toBe('custom')
+        expect(provider.fileContentType).toBe(CSV_TYPE)
+        expect(provider.filePattern).toBeInstanceOf(RegExp)
+        expect(provider.acceptedFormats).toBe('CSV')
+    })
+
+    describe('validateFile', () => {
+        it.each(['tracksy-custom.csv', 'TRACKSY-CUSTOM.CSV'])(
+            'should return true for %s',
+            (filename) => {
+                const file = mockFile(new ArrayBuffer(0), filename, {
+                    type: CSV_TYPE,
+                })
+                expect(provider.validateFile(file)).toBe(true)
+            }
+        )
+
+        it.each([
+            'custom.csv',
+            'tracksy.csv',
+            'tracksy-custom.json',
+            'my-data.csv',
+        ])('should return false for %s', (filename) => {
+            const file = mockFile(new ArrayBuffer(0), filename, {
+                type: CSV_TYPE,
+            })
+            expect(provider.validateFile(file)).toBe(false)
+        })
+    })
+
+    describe('transform', () => {
+        it('should map raw record to StreamRecord', () => {
+            const result = provider.transform([RAW_RECORD])
+            const expected: StreamRecord = {
+                track_uri: 'custom:rick-astley:ngru',
+                track_name: 'Never Gonna Give You Up',
+                artist_name: 'Rick Astley',
+                album_name: 'Whenever You Need Somebody',
+                ts: '2024-03-15T14:30:00.000Z',
+                ms_played: 213000,
+                platform: 'tidal',
+            }
+            expect(result).toHaveLength(1)
+            expect(result[0]).toEqual(expected)
+        })
+
+        it('should guard against negative ms_played', () => {
+            const record: CustomRawRecord = { ...RAW_RECORD, ms_played: -1000 }
+            const result = provider.transform([record])
+            expect(result[0].ms_played).toBe(0)
+        })
+
+        it('should guard against null ms_played', () => {
+            const record: CustomRawRecord = { ...RAW_RECORD, ms_played: null }
+            const result = provider.transform([record])
+            expect(result[0].ms_played).toBe(0)
+        })
+
+        it('should drop records with null ts', () => {
+            const record: CustomRawRecord = { ...RAW_RECORD, ts: null }
+            expect(provider.transform([record])).toHaveLength(0)
+        })
+
+        it('should drop records with null track_uri', () => {
+            const record: CustomRawRecord = { ...RAW_RECORD, track_uri: null }
+            expect(provider.transform([record])).toHaveLength(0)
+        })
+
+        it('should fall back to "Unknown Artist" artist_name if missing', () => {
+            const record: CustomRawRecord = { ...RAW_RECORD, artist_name: null }
+            const result = provider.transform([record])
+            expect(result[0].artist_name).toBe('Unknown Artist')
+        })
+
+        it('should fall back to "Unknown Track" track_name if missing', () => {
+            const record: CustomRawRecord = { ...RAW_RECORD, track_name: null }
+            const result = provider.transform([record])
+            expect(result[0].track_name).toBe('Unknown Track')
+        })
+
+        it('should fall back to "Unknown Album" album_name if missing', () => {
+            const record: CustomRawRecord = { ...RAW_RECORD, album_name: null }
+            const result = provider.transform([record])
+            expect(result[0].album_name).toBe('Unknown Album')
+        })
+
+        it('should fall back to "Unknown Device" platform if missing', () => {
+            const record: CustomRawRecord = { ...RAW_RECORD, platform: null }
+            const result = provider.transform([record])
+            expect(result[0].platform).toBe('Unknown Device')
+        })
+
+        it('should coerce numeric ms_played string', () => {
+            const record: CustomRawRecord = {
+                ...RAW_RECORD,
+                ms_played: '213000',
+            }
+            const result = provider.transform([record])
+            expect(result[0].ms_played).toBe(213000)
+        })
+
+        it('should handle empty input array', () => {
+            expect(provider.transform([])).toEqual([])
+        })
+    })
+
+    describe('readFile', () => {
+        let mockConn: { query: ReturnType<typeof vi.fn> }
+        let mockDb: {
+            registerFileBuffer: ReturnType<typeof vi.fn>
+            dropFile: ReturnType<typeof vi.fn>
+        }
+
+        beforeEach(() => {
+            mockConn = { query: vi.fn() }
+            mockDb = {
+                registerFileBuffer: vi.fn(),
+                dropFile: vi.fn(),
+            }
+            vi.spyOn(getDBModule, 'getDB').mockResolvedValue({
+                db: mockDb as never,
+                conn: mockConn as never,
+            })
+        })
+
+        it('should register, query, and drop the temp file', async () => {
+            const mockRow = { toJSON: () => ({ ...RAW_RECORD }) }
+            mockConn.query.mockResolvedValue({ toArray: () => [mockRow] })
+
+            const file = mockFile(new ArrayBuffer(8), 'tracksy-custom.csv', {
+                type: CSV_TYPE,
+            })
+            const result = await provider.readFile(file)
+
+            expect(mockDb.registerFileBuffer).toHaveBeenCalledWith(
+                '_custom_tmp.csv',
+                expect.any(Uint8Array)
+            )
+            expect(mockConn.query).toHaveBeenCalledWith(
+                expect.stringContaining('read_csv')
+            )
+            expect(mockDb.dropFile).toHaveBeenCalledWith('_custom_tmp.csv')
+            expect(result).toHaveLength(1)
+        })
+
+        it('should read all columns as varchar to prevent DuckDB auto-detecting ts as TIMESTAMP', async () => {
+            const mockRow = { toJSON: () => ({ ...RAW_RECORD }) }
+            mockConn.query.mockResolvedValue({ toArray: () => [mockRow] })
+
+            const file = mockFile(new ArrayBuffer(8), 'tracksy-custom.csv', {
+                type: CSV_TYPE,
+            })
+            await provider.readFile(file)
+
+            expect(mockConn.query).toHaveBeenCalledWith(
+                expect.stringContaining('all_varchar=true')
+            )
+        })
+
+        it('should drop temp file and wrap error when query fails', async () => {
+            mockConn.query.mockRejectedValue(new Error('query failed'))
+
+            const file = mockFile(new ArrayBuffer(8), 'tracksy-custom.csv', {
+                type: CSV_TYPE,
+            })
+            await expect(provider.readFile(file)).rejects.toThrow(
+                'Failed to parse custom CSV'
+            )
+            expect(mockDb.dropFile).toHaveBeenCalledWith('_custom_tmp.csv')
+        })
+    })
+})

--- a/app/src/streamProvider/CustomStreamProvider/CustomStreamProvider.ts
+++ b/app/src/streamProvider/CustomStreamProvider/CustomStreamProvider.ts
@@ -1,0 +1,56 @@
+import { getDB } from '../../db/getDB'
+import { StreamProvider } from '../StreamProvider'
+import type { StreamRecord } from '../types'
+import type { CustomRawRecord } from './types'
+
+const TMP_FILE_NAME = '_custom_tmp.csv'
+
+export class CustomStreamProvider extends StreamProvider<CustomRawRecord> {
+    readonly name = 'custom'
+    readonly displayName = 'Custom'
+    readonly acceptedFormats = 'CSV'
+    readonly filePattern = /^tracksy-custom\.csv$/i
+    readonly fileContentType = 'text/csv'
+
+    async readFile(file: File): Promise<CustomRawRecord[]> {
+        const buffer = await file.arrayBuffer()
+        const { db, conn } = await getDB()
+
+        await db.registerFileBuffer(TMP_FILE_NAME, new Uint8Array(buffer))
+        try {
+            const result = await conn.query(
+                `SELECT * FROM read_csv('${TMP_FILE_NAME}', header=true, all_varchar=true)`
+            )
+            return result
+                .toArray()
+                .map((row) => row.toJSON() as CustomRawRecord)
+        } catch (error) {
+            throw new Error(
+                'Failed to parse custom CSV. Check that the file has all required columns: ts, track_name, artist_name, album_name, ms_played, track_uri, platform.',
+                { cause: error }
+            )
+        } finally {
+            await db.dropFile(TMP_FILE_NAME)
+        }
+    }
+
+    transform(rawData: CustomRawRecord[]): StreamRecord[] {
+        return rawData.flatMap((r) => {
+            const ts = r.ts != null ? String(r.ts) : undefined
+            const track_uri =
+                r.track_uri != null ? String(r.track_uri) : undefined
+            if (ts === undefined || track_uri === undefined) return []
+            return [
+                {
+                    ts,
+                    track_uri,
+                    track_name: String(r.track_name ?? 'Unknown Track'),
+                    artist_name: String(r.artist_name ?? 'Unknown Artist'),
+                    album_name: String(r.album_name ?? 'Unknown Album'),
+                    ms_played: Math.max(0, Number(r.ms_played) || 0),
+                    platform: String(r.platform ?? 'Unknown Device'),
+                },
+            ]
+        })
+    }
+}

--- a/app/src/streamProvider/CustomStreamProvider/index.ts
+++ b/app/src/streamProvider/CustomStreamProvider/index.ts
@@ -1,0 +1,1 @@
+export { CustomStreamProvider } from './CustomStreamProvider'

--- a/app/src/streamProvider/CustomStreamProvider/types.ts
+++ b/app/src/streamProvider/CustomStreamProvider/types.ts
@@ -1,0 +1,12 @@
+// all_varchar=true in read_csv means every column arrives as string | null;
+// field types are narrowed in transform()
+export interface CustomRawRecord {
+    ts: unknown
+    track_name: unknown
+    artist_name: unknown
+    album_name: unknown
+    ms_played: unknown
+    track_uri: unknown
+    platform: unknown
+    [key: string]: unknown
+}

--- a/app/src/streamProvider/index.test.ts
+++ b/app/src/streamProvider/index.test.ts
@@ -32,6 +32,14 @@ describe('StreamProvider Factory', () => {
             expect(streamProvider?.name).toBe('apple-music')
         })
 
+        it('should detect custom files', () => {
+            const file = new File([], 'tracksy-custom.csv')
+            const streamProvider = detectProvider(file)
+
+            expect(streamProvider).not.toBeUndefined()
+            expect(streamProvider?.name).toBe('custom')
+        })
+
         it('should return undefined for unknown file formats', () => {
             const file = new File([], 'unknown_format.json')
             const streamProvider = detectProvider(file)
@@ -51,9 +59,10 @@ describe('StreamProvider Factory', () => {
 
         it('returns one entry per registered provider with format hint', () => {
             const names = getSupportedProviderNames()
-            expect(names.length).toBe(2)
+            expect(names.length).toBe(3)
             expect(names).toContain('Spotify (ZIP/JSON)')
             expect(names).toContain('Deezer (XLSX)')
+            expect(names).toContain('Custom (CSV)')
             expect(names).not.toContain('Apple Music (ZIP/CSV)')
         })
     })

--- a/app/src/streamProvider/index.ts
+++ b/app/src/streamProvider/index.ts
@@ -1,13 +1,14 @@
 import { AppleMusicStreamProvider } from './AppleMusicStreamProvider/AppleMusicStreamProvider'
+import { CustomStreamProvider } from './CustomStreamProvider/CustomStreamProvider'
 import { DeezerStreamProvider } from './DeezerStreamProvider/DeezerStreamProvider'
 import type { StreamProvider } from './StreamProvider'
 import { SpotifyStreamProvider } from './SpotifyStreamProvider/SpotifyStreamProvider'
 
-// Registry of all available provider adapters
 const STREAM_PROVIDERS: StreamProvider[] = [
     new SpotifyStreamProvider(),
     new DeezerStreamProvider(),
     new AppleMusicStreamProvider(),
+    new CustomStreamProvider(),
 ]
 
 export const STREAM_PROVIDERS_CONTENT_TYPES = STREAM_PROVIDERS.map(


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Users with listening data from unsupported sources (Funkwhale, Tidal, Last.fm, Jellyfin…) have no way to import it into Tracksy.

## 🎹 Proposal

Adds a `CustomStreamProvider` that accepts a CSV file named `tracksy-custom.csv` whose columns map directly to the internal `StreamRecord` format. No UI column mapper: users reformat their data locally to match the template, then upload the file like any other provider.

The README documents the column format with a worked example and a DuckDB SQL snippet for converting an existing CSV or JSON export in one query.

Validation follows the same rules as all other providers: rows with `ms_played < 30000` or missing required fields are silently dropped.

## 🎶 Comments

The provider is registered as non-experimental and appears in the supported provider list in the Dropzone.

## 🎤 Test

Upload a `tracksy-custom.csv` file with valid rows and verify charts populate. Upload a file with rows below 30 seconds and verify they are filtered. Upload a file with missing columns and verify the import completes without error.