### PR TITLE
fix(app): fix upload-error edge cases and footer

### DIFF
--- a/app/src/components/App.tsx
+++ b/app/src/components/App.tsx
@@ -33,7 +33,7 @@ export function App() {
                         rel="noopener noreferrer"
                         className="hover:text-gray-600 dark:hover:text-slate-300 transition-colors"
                     >
-                        Music stats made with ❤️ & 🔐
+                        Music stats made with ❤️ & 🔐 · View on GitHub
                     </a>
                 </footer>
             </div>

--- a/app/src/components/App.tsx
+++ b/app/src/components/App.tsx
@@ -5,14 +5,14 @@ import { ThemeToggle } from './ThemeToggle/ThemeToggle'
 export function App() {
     return (
         <ThemeProvider>
-            <div className="min-h-screen bg-gray-50 dark:bg-slate-950 relative transition-colors duration-300">
+            <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-slate-950 relative transition-colors duration-300">
                 {/* Theme toggle button */}
                 <div className="absolute top-6 right-6 z-50">
                     <ThemeToggle />
                 </div>
 
                 {/* Main content area */}
-                <div className="flex items-center justify-center min-h-screen px-4 relative z-10">
+                <div className="flex flex-1 items-center justify-center px-4 relative z-10">
                     <div className="max-w-4xl w-full mx-auto py-12">
                         <h1 className="text-4xl md:text-5xl font-bold text-center mb-8 animate-fade-in">
                             <a

--- a/app/src/components/UploadError.test.tsx
+++ b/app/src/components/UploadError.test.tsx
@@ -73,6 +73,30 @@ describe('UploadError', () => {
         expect(onDismiss).not.toHaveBeenCalled()
     })
 
+    it('resets timer to full delay when message changes while hovered', () => {
+        const onDismiss = vi.fn()
+        const { rerender } = render(
+            <UploadError message="Error 1" onDismiss={onDismiss} />
+        )
+        act(() => {
+            vi.advanceTimersByTime(7000)
+        })
+        fireEvent.mouseEnter(screen.getByRole('alert'))
+        act(() => {
+            vi.advanceTimersByTime(2000)
+        })
+        rerender(<UploadError message="Error 2" onDismiss={onDismiss} />)
+        fireEvent.mouseLeave(screen.getByRole('alert'))
+        act(() => {
+            vi.advanceTimersByTime(7999)
+        })
+        expect(onDismiss).not.toHaveBeenCalled()
+        act(() => {
+            vi.advanceTimersByTime(1)
+        })
+        expect(onDismiss).toHaveBeenCalledOnce()
+    })
+
     it('resumes timer with remaining time after hover ends', () => {
         const onDismiss = vi.fn()
         render(<UploadError message="Error" onDismiss={onDismiss} />)

--- a/app/src/components/UploadError.tsx
+++ b/app/src/components/UploadError.tsx
@@ -14,11 +14,15 @@ export function UploadError({ message, onDismiss }: UploadErrorProps) {
 
     useEffect(() => {
         remainingRef.current = DISMISS_DELAY_MS
+        startRef.current = Date.now()
     }, [message])
 
     useEffect(() => {
         if (hovered) {
-            remainingRef.current -= Date.now() - startRef.current
+            remainingRef.current = Math.max(
+                0,
+                remainingRef.current - (Date.now() - startRef.current)
+            )
             return
         }
         startRef.current = Date.now()


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

When the upload error message changes while the user is hovering over the toast, the timer restarts from the previous hover state instead of from zero. This causes the toast to dismiss earlier than expected, or to not dismiss at all.

Needed by #422 and #424.

## 🎹 Proposal

Cherry-pick of the fix from the `fix/upload-error-timer-edge-cases` branch. Resets the timer cleanly when the message changes, regardless of hover state.

## 🎶 Comments

Isolated here so it can be merged independently before the two dependent PRs.

## 🎤 Test

Upload a file that triggers an error, then trigger a second error while hovering over the first toast. The timer resets and the toast dismisses after the full delay.