### PR TITLE
feat(charts): add StreamVariety chart to LabView

### DIFF
--- a/app/.sqruff
+++ b/app/.sqruff
@@ -45,9 +45,10 @@ order_condition = streaks desc
 # so this substitution is a no-op for linting but documents the expected type.
 year = 2024
 year_for_new = 2024
-# StreamTimeline granularity placeholders
+# StreamTimeline / StreamVariety granularity placeholders
 spineTimeTrunc = ts::date
 streamTimeTrunc = ts::date
 spineStart = '2024-01-01'::date
 spineEnd = '2024-12-31'::date
 step = interval 1 month
+entity_column = track_uri

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.sql
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.sql
@@ -1,0 +1,24 @@
+with spine as (
+    select ${spineTimeTrunc} as ts
+    from generate_series(${spineStart}, ${spineEnd}, ${step}) as t (dt)
+),
+
+stream_agg as (
+    select
+        ${streamTimeTrunc} as ts,
+        count(distinct ${entity_column}) as distinct_count,
+        count(*) - count(distinct ${entity_column}) as repeat_count,
+        count(*) as total_count
+    from ${table}
+    where ${year_condition}
+    group by ${streamTimeTrunc}
+)
+
+select
+    spine.ts::varchar as ts,
+    coalesce(stream_agg.distinct_count, 0)::int as distinct_count,
+    coalesce(stream_agg.repeat_count, 0)::int as repeat_count,
+    coalesce(stream_agg.total_count, 0)::int as total_count
+from spine
+left join stream_agg on spine.ts = stream_agg.ts
+order by spine.ts

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { StreamVariety } from './StreamVariety'
+import type {
+    StreamVarietyQueryResult,
+    StreamVarietyStatsQueryResult,
+} from './query'
+
+const twoMonths: StreamVarietyQueryResult[] = [
+    { ts: '2006-01-01', distinct_count: 2, repeat_count: 1, total_count: 3 },
+    { ts: '2006-04-01', distinct_count: 1, repeat_count: 0, total_count: 1 },
+]
+
+const defaultStats: StreamVarietyStatsQueryResult = {
+    total_distinct: 3,
+    total_repeat: 1,
+    total_streams: 4,
+}
+
+const defaultProps = {
+    year: 2006 as number | undefined,
+    granularity: 'month' as const,
+    availableGranularities: ['month', 'week', 'day'] as const,
+    onGranularityChange: () => {},
+    entity: 'tracks' as const,
+    onEntityChange: () => {},
+    stats: defaultStats,
+    isLoading: false,
+}
+
+describe('StreamVariety', () => {
+    it('renders empty state when data is empty', () => {
+        render(<StreamVariety {...defaultProps} data={[]} />)
+        screen.getByText('No data for this year')
+    })
+
+    it('renders empty state when all totals are zero', () => {
+        render(
+            <StreamVariety
+                {...defaultProps}
+                data={[
+                    {
+                        ts: '2006-01-01',
+                        distinct_count: 0,
+                        repeat_count: 0,
+                        total_count: 0,
+                    },
+                ]}
+                stats={{ total_distinct: 0, total_repeat: 0, total_streams: 0 }}
+            />
+        )
+        screen.getByText('No data for this year')
+    })
+
+    it('renders chart heading and summary stats', () => {
+        render(<StreamVariety {...defaultProps} data={twoMonths} />)
+        screen.getByRole('heading', { name: /Stream Variety/ })
+        screen.getByText('Unique tracks listened')
+        screen.getByText('Variety rate')
+        screen.getByText('3')
+        screen.getByText('75%')
+    })
+
+    it('renders stacked bars with distinct and re-listen segments', () => {
+        render(<StreamVariety {...defaultProps} data={twoMonths} />)
+        const yellowSegments = document.querySelectorAll('.bg-yellow-400')
+        const orangeSegments = document.querySelectorAll('.bg-orange-400')
+        expect(yellowSegments.length).toBeGreaterThan(0)
+        expect(orangeSegments.length).toBeGreaterThan(0)
+    })
+
+    it('renders legend for Distinct and Re-listens', () => {
+        render(<StreamVariety {...defaultProps} data={twoMonths} />)
+        screen.getByText('Distinct')
+        screen.getByText('Re-listens')
+    })
+
+    it('renders all three entity buttons', () => {
+        render(<StreamVariety {...defaultProps} data={twoMonths} />)
+        screen.getByRole('button', { name: 'Tracks' })
+        screen.getByRole('button', { name: 'Artists' })
+        screen.getByRole('button', { name: 'Albums' })
+    })
+
+    it('active entity button is highlighted', () => {
+        render(<StreamVariety {...defaultProps} data={twoMonths} />)
+        const tracksBtn = screen.getByRole('button', { name: 'Tracks' })
+        expect(tracksBtn.className).toContain('bg-blue-500')
+    })
+
+    it('calls onEntityChange when entity tab is clicked', () => {
+        const onEntityChange = vi.fn()
+        render(
+            <StreamVariety
+                {...defaultProps}
+                onEntityChange={onEntityChange}
+                data={twoMonths}
+            />
+        )
+        fireEvent.click(screen.getByRole('button', { name: 'Artists' }))
+        expect(onEntityChange).toHaveBeenCalledWith('artists')
+    })
+
+    it('renders all four granularity buttons', () => {
+        render(<StreamVariety {...defaultProps} data={twoMonths} />)
+        screen.getByRole('button', { name: 'Year' })
+        screen.getByRole('button', { name: 'Month' })
+        screen.getByRole('button', { name: 'Week' })
+        screen.getByRole('button', { name: 'Day' })
+    })
+
+    it('active granularity button is highlighted, unavailable buttons are disabled', () => {
+        render(<StreamVariety {...defaultProps} data={twoMonths} />)
+        const monthBtn = screen.getByRole('button', { name: 'Month' })
+        const yearBtn = screen.getByRole('button', { name: 'Year' })
+        expect(monthBtn.className).toContain('bg-blue-500')
+        expect((yearBtn as HTMLButtonElement).disabled).toBe(true)
+    })
+
+    it('calls onGranularityChange when granularity tab is clicked', () => {
+        const onGranularityChange = vi.fn()
+        render(
+            <StreamVariety
+                {...defaultProps}
+                onGranularityChange={onGranularityChange}
+                data={twoMonths}
+            />
+        )
+        fireEvent.click(screen.getByRole('button', { name: 'Week' }))
+        expect(onGranularityChange).toHaveBeenCalledWith('week')
+    })
+
+    it('shows tooltip on bar hover and hides on mouse leave', () => {
+        render(<StreamVariety {...defaultProps} data={twoMonths} />)
+        const bars = document.querySelectorAll('.flex-1.rounded-t')
+        fireEvent.mouseEnter(bars[0])
+        expect(screen.getByText('2 distinct')).toBeDefined()
+        expect(screen.getByText('1 re-listens')).toBeDefined()
+
+        fireEvent.mouseLeave(bars[0].closest('.flex.items-end')!)
+        expect(screen.queryByText('2 distinct')).toBeNull()
+    })
+
+    it('does not show tooltip on zero-count bar hover', () => {
+        const dataWithZero: StreamVarietyQueryResult[] = [
+            {
+                ts: '2006-02-01',
+                distinct_count: 0,
+                repeat_count: 0,
+                total_count: 0,
+            },
+            {
+                ts: '2006-03-01',
+                distinct_count: 1,
+                repeat_count: 0,
+                total_count: 1,
+            },
+        ]
+        render(<StreamVariety {...defaultProps} data={dataWithZero} />)
+        const bars = document.querySelectorAll('.flex-1.rounded-t')
+        fireEvent.mouseEnter(bars[0])
+        expect(document.querySelector('.fixed.z-50')).toBeNull()
+    })
+})

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -1,0 +1,327 @@
+import type { FC } from 'react'
+import { useState } from 'react'
+import type {
+    Entity,
+    Granularity,
+    StreamVarietyQueryResult,
+    StreamVarietyStatsQueryResult,
+} from './query'
+import {
+    ChartCard,
+    ChartCardEmpty,
+    ChartTooltip,
+} from '../../SimpleCharts/shared'
+
+type TooltipState = {
+    x: number
+    y: number
+    ts: string
+    distinct_count: number
+    repeat_count: number
+    total_count: number
+}
+
+type Props = {
+    data: StreamVarietyQueryResult[] | undefined
+    stats: StreamVarietyStatsQueryResult | undefined
+    year: number | undefined
+    granularity: Granularity
+    availableGranularities: Granularity[]
+    onGranularityChange: (g: Granularity) => void
+    entity: Entity
+    onEntityChange: (e: Entity) => void
+    isLoading?: boolean
+}
+
+const GRAN_LABELS: Record<Granularity, string> = {
+    year: 'Year',
+    month: 'Month',
+    week: 'Week',
+    day: 'Day',
+}
+
+const ENTITY_LABELS: Record<Entity, string> = {
+    tracks: 'Tracks',
+    artists: 'Artists',
+    albums: 'Albums',
+}
+
+const ENTITY_SINGULAR: Record<Entity, string> = {
+    tracks: 'track',
+    artists: 'artist',
+    albums: 'album',
+}
+
+function formatTooltipDate(date: Date, granularity: Granularity): string {
+    if (granularity === 'year')
+        return date.toLocaleDateString(undefined, { year: 'numeric' })
+    if (granularity === 'month')
+        return date.toLocaleDateString(undefined, {
+            month: 'long',
+            year: 'numeric',
+        })
+    return date.toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+    })
+}
+
+function getBarLabel(
+    d: StreamVarietyQueryResult,
+    index: number,
+    data: StreamVarietyQueryResult[],
+    year: number | undefined,
+    granularity: Granularity
+): string {
+    const date = new Date(d.ts)
+
+    if (granularity === 'year') return String(date.getUTCFullYear())
+
+    if (granularity === 'month') {
+        if (year !== undefined)
+            return date.toLocaleDateString(undefined, { month: 'short' })
+        return date.getUTCMonth() === 0 ? String(date.getUTCFullYear()) : ''
+    }
+
+    if (granularity === 'week') {
+        if (index === 0)
+            return date.toLocaleDateString(undefined, { month: 'short' })
+        const prev = new Date(data[index - 1].ts)
+        return date.getUTCMonth() !== prev.getUTCMonth()
+            ? date.toLocaleDateString(undefined, { month: 'short' })
+            : ''
+    }
+
+    // day
+    return date.getUTCDate() === 1
+        ? date.toLocaleDateString(undefined, { month: 'short' })
+        : ''
+}
+
+export const StreamVariety: FC<Props> = ({
+    data,
+    stats,
+    year,
+    granularity,
+    availableGranularities,
+    onGranularityChange,
+    entity,
+    onEntityChange,
+    isLoading,
+}) => {
+    const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+
+    const totalDistinct = stats?.total_distinct ?? 0
+    const varietyRate =
+        (stats?.total_streams ?? 0) > 0
+            ? Math.round(
+                  ((stats?.total_distinct ?? 0) / (stats?.total_streams ?? 0)) *
+                      100
+              )
+            : 0
+    const maxTotal = data?.length
+        ? Math.max(...data.map((d) => d.total_count))
+        : 0
+    const sparseLabelLayout = granularity !== 'month' || year === undefined
+
+    const entityTabs = (
+        <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30">
+            {(['tracks', 'artists', 'albums'] as const).map((e) => (
+                <button
+                    key={e}
+                    onClick={() => onEntityChange(e)}
+                    className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
+                        entity === e
+                            ? 'bg-blue-500 text-white shadow-sm'
+                            : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
+                    }`}
+                >
+                    {ENTITY_LABELS[e]}
+                </button>
+            ))}
+        </div>
+    )
+
+    return (
+        <ChartCard
+            title="Stream Variety"
+            emoji="🔀"
+            isLoading={isLoading}
+            question="How varied was my listening?"
+            headerActions={entityTabs}
+        >
+            <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30 self-start mb-3">
+                {(['year', 'month', 'week', 'day'] as const).map((g) => {
+                    const available = availableGranularities.includes(g)
+                    const active = granularity === g
+                    return (
+                        <button
+                            key={g}
+                            onClick={() => available && onGranularityChange(g)}
+                            disabled={!available}
+                            className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
+                                active
+                                    ? 'bg-blue-500 text-white shadow-sm'
+                                    : available
+                                      ? 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
+                                      : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
+                            }`}
+                        >
+                            {GRAN_LABELS[g]}
+                        </button>
+                    )
+                })}
+            </div>
+
+            {!data?.length || (stats?.total_streams ?? 0) === 0 ? (
+                <ChartCardEmpty
+                    message={
+                        year !== undefined ? 'No data for this year' : 'No data'
+                    }
+                />
+            ) : (
+                <>
+                    <div className="overflow-x-auto mt-4">
+                        <div
+                            className="flex items-end gap-0.5 h-24 mb-1"
+                            style={{ minWidth: `${data.length * 4}px` }}
+                            onMouseLeave={() => setTooltip(null)}
+                        >
+                            {data.map((d) => {
+                                const height =
+                                    maxTotal > 0
+                                        ? (d.total_count / maxTotal) * 100
+                                        : 0
+                                return (
+                                    <div
+                                        key={d.ts}
+                                        className="flex-1 min-w-[3px] flex flex-col rounded-t overflow-hidden"
+                                        style={{ height: `${height}%` }}
+                                        onMouseEnter={(e) => {
+                                            if (d.total_count === 0) return
+                                            const rect =
+                                                e.currentTarget.getBoundingClientRect()
+                                            setTooltip({
+                                                x: rect.left + rect.width / 2,
+                                                y: rect.top,
+                                                ts: d.ts,
+                                                distinct_count:
+                                                    d.distinct_count,
+                                                repeat_count: d.repeat_count,
+                                                total_count: d.total_count,
+                                            })
+                                        }}
+                                    >
+                                        <div
+                                            className="bg-yellow-400"
+                                            style={{ flex: d.repeat_count }}
+                                        />
+                                        <div
+                                            className="bg-orange-400"
+                                            style={{
+                                                flex:
+                                                    d.distinct_count ||
+                                                    (d.total_count > 0 ? 1 : 0),
+                                            }}
+                                        />
+                                    </div>
+                                )
+                            })}
+                        </div>
+
+                        <div
+                            className="flex gap-0.5 mb-4"
+                            style={{ minWidth: `${data.length * 4}px` }}
+                        >
+                            {data.map((d, i) => {
+                                const label = getBarLabel(
+                                    d,
+                                    i,
+                                    data,
+                                    year,
+                                    granularity
+                                )
+                                return (
+                                    <div
+                                        key={d.ts}
+                                        className={`flex-1 min-w-[3px] text-[9px] text-gray-400 dark:text-gray-500 ${
+                                            sparseLabelLayout
+                                                ? 'overflow-visible whitespace-nowrap'
+                                                : 'text-center truncate'
+                                        }`}
+                                    >
+                                        {label}
+                                    </div>
+                                )
+                            })}
+                        </div>
+                    </div>
+
+                    <div className="mt-1 mb-3 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+                        <span className="flex items-center gap-1">
+                            <span className="inline-block w-2 h-2 rounded-sm bg-orange-400" />
+                            Distinct
+                        </span>
+                        <span className="flex items-center gap-1">
+                            <span className="inline-block w-2 h-2 rounded-sm bg-yellow-400" />
+                            Re-listens
+                        </span>
+                    </div>
+
+                    <ul
+                        className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700"
+                        role="list"
+                    >
+                        <li
+                            className="flex justify-between items-center"
+                            role="listitem"
+                        >
+                            <span className="text-sm text-gray-600 dark:text-gray-400">
+                                Unique {ENTITY_SINGULAR[entity]}s listened
+                            </span>
+                            <span className="font-bold">
+                                {totalDistinct.toLocaleString()}
+                            </span>
+                        </li>
+                        <li
+                            className="flex justify-between items-center mt-1"
+                            role="listitem"
+                        >
+                            <span className="text-sm text-gray-600 dark:text-gray-400">
+                                Variety rate
+                                <span className="ml-1 text-xs font-normal text-gray-400 dark:text-gray-500">
+                                    (unique / total streams)
+                                </span>
+                            </span>
+                            <span className="font-bold">{varietyRate}%</span>
+                        </li>
+                    </ul>
+                </>
+            )}
+            {tooltip && (
+                <ChartTooltip x={tooltip.x} y={tooltip.y}>
+                    <div className="font-semibold">
+                        {formatTooltipDate(new Date(tooltip.ts), granularity)}
+                    </div>
+                    <div className="text-gray-300 dark:text-gray-400">
+                        {tooltip.distinct_count.toLocaleString()} distinct
+                    </div>
+                    <div className="text-gray-300 dark:text-gray-400">
+                        {tooltip.repeat_count.toLocaleString()} re-listens
+                    </div>
+                    <div className="text-gray-300 dark:text-gray-400">
+                        {tooltip.total_count > 0
+                            ? Math.round(
+                                  (tooltip.distinct_count /
+                                      tooltip.total_count) *
+                                      100
+                              )
+                            : 0}
+                        % variety
+                    </div>
+                </ChartTooltip>
+            )}
+        </ChartCard>
+    )
+}

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVarietyStats.sql
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVarietyStats.sql
@@ -1,0 +1,6 @@
+select
+    count(distinct ${entity_column})::int as total_distinct,
+    (count(*) - count(distinct ${entity_column}))::int as total_repeat,
+    count(*)::int as total_streams
+from ${table}
+where ${year_condition}

--- a/app/src/components/Charts/LabCharts/StreamVariety/fixtures/seed.json
+++ b/app/src/components/Charts/LabCharts/StreamVariety/fixtures/seed.json
@@ -1,0 +1,37 @@
+[
+    {
+        "ts": "2006-01-17T04:00:00Z",
+        "ms_played": 1.0,
+        "track_uri": "track_A",
+        "artist_name": "artist_X",
+        "album_name": "album_1"
+    },
+    {
+        "ts": "2006-01-20T10:00:00Z",
+        "ms_played": 1.0,
+        "track_uri": "track_B",
+        "artist_name": "artist_X",
+        "album_name": "album_1"
+    },
+    {
+        "ts": "2006-01-25T12:00:00Z",
+        "ms_played": 1.0,
+        "track_uri": "track_A",
+        "artist_name": "artist_X",
+        "album_name": "album_1"
+    },
+    {
+        "ts": "2006-04-20T10:00:00Z",
+        "ms_played": 1.0,
+        "track_uri": "track_C",
+        "artist_name": "artist_Y",
+        "album_name": "album_2"
+    },
+    {
+        "ts": "2006-06-01T04:00:00Z",
+        "ms_played": 1.0,
+        "track_uri": "track_A",
+        "artist_name": "artist_X",
+        "album_name": "album_1"
+    }
+]

--- a/app/src/components/Charts/LabCharts/StreamVariety/index.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/index.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react'
+import { useDBQueryMany } from '../../../../hooks/useDBQuery'
+import {
+    queryStreamVariety,
+    queryStreamVarietyStats,
+    type Entity,
+    type Granularity,
+    type StreamVarietyQueryResult,
+    type StreamVarietyStatsQueryResult,
+} from './query'
+import { StreamVariety as StreamVarietyView } from './StreamVariety'
+
+const ALL_TIME_GRANULARITIES: Granularity[] = ['year', 'month']
+const PER_YEAR_GRANULARITIES: Granularity[] = ['month', 'week', 'day']
+
+interface StreamVarietyProps {
+    year: number | undefined
+}
+
+export function StreamVariety({ year }: StreamVarietyProps) {
+    const [granularity, setGranularity] = useState<Granularity>('month')
+    const [entity, setEntity] = useState<Entity>('tracks')
+
+    const availableGranularities =
+        year !== undefined ? PER_YEAR_GRANULARITIES : ALL_TIME_GRANULARITIES
+
+    // Avoids double-fetch: derived fallback instead of useEffect resetting granularity.
+    const effectiveGranularity = availableGranularities.includes(granularity)
+        ? granularity
+        : availableGranularities[0]
+
+    const { data, isLoading } = useDBQueryMany<StreamVarietyQueryResult>({
+        query: queryStreamVariety(year, effectiveGranularity, entity),
+        year,
+    })
+
+    const { data: statsData } = useDBQueryMany<StreamVarietyStatsQueryResult>({
+        query: queryStreamVarietyStats(year, entity),
+        year,
+    })
+
+    const stats = statsData?.[0]
+
+    return (
+        <StreamVarietyView
+            data={data}
+            stats={stats}
+            year={year}
+            granularity={effectiveGranularity}
+            availableGranularities={availableGranularities}
+            onGranularityChange={setGranularity}
+            entity={entity}
+            onEntityChange={setEntity}
+            isLoading={isLoading}
+        />
+    )
+}

--- a/app/src/components/Charts/LabCharts/StreamVariety/query.test.ts
+++ b/app/src/components/Charts/LabCharts/StreamVariety/query.test.ts
@@ -1,0 +1,187 @@
+import {
+    afterAll,
+    beforeAll,
+    beforeEach,
+    describe,
+    it,
+    expect,
+    vi,
+} from 'vitest'
+import { DuckDBConnection } from '@duckdb/node-api'
+import { queryStreamVariety, queryStreamVarietyStats } from './query'
+import { TABLE } from '../../../../db/queries/constants'
+
+const seedPath =
+    'src/components/Charts/LabCharts/StreamVariety/fixtures/seed.json'
+let conn: DuckDBConnection
+
+beforeAll(async () => {
+    conn = await DuckDBConnection.create()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-15'))
+})
+
+afterAll(() => {
+    conn.closeSync()
+    vi.useRealTimers()
+})
+
+beforeEach(async () => {
+    await conn.run(`CREATE OR REPLACE TABLE ${TABLE} AS (FROM '${seedPath}')`)
+})
+
+describe('StreamVariety query — month granularity, tracks entity', () => {
+    it('returns distinct/repeat counts per month for a specific year', async () => {
+        const rows = (
+            await conn.runAndReadAll(
+                queryStreamVariety(2006, 'month', 'tracks')
+            )
+        ).getRowObjectsJson()
+
+        expect(rows).toHaveLength(12)
+
+        // Jan: track_A x2, track_B x1 → distinct=2, repeat=1, total=3
+        const jan = rows.find((r) => r.ts === '2006-01-01')
+        expect(jan?.distinct_count).toBe(2)
+        expect(jan?.repeat_count).toBe(1)
+        expect(jan?.total_count).toBe(3)
+
+        // Apr: track_C x1 → distinct=1, repeat=0, total=1
+        const apr = rows.find((r) => r.ts === '2006-04-01')
+        expect(apr?.distinct_count).toBe(1)
+        expect(apr?.repeat_count).toBe(0)
+        expect(apr?.total_count).toBe(1)
+
+        // Feb: gap-filled
+        const feb = rows.find((r) => r.ts === '2006-02-01')
+        expect(feb?.distinct_count).toBe(0)
+        expect(feb?.repeat_count).toBe(0)
+        expect(feb?.total_count).toBe(0)
+    })
+
+    it('returns all-time data across years without year filter', async () => {
+        const rows = (
+            await conn.runAndReadAll(
+                queryStreamVariety(undefined, 'month', 'tracks')
+            )
+        ).getRowObjectsJson()
+
+        const jan = rows.find((r) => r.ts === '2006-01-01')
+        expect(jan?.distinct_count).toBe(2)
+        expect(jan?.total_count).toBe(3)
+    })
+})
+
+describe('StreamVariety query — artists entity', () => {
+    it('counts distinct artists, not tracks', async () => {
+        const rows = (
+            await conn.runAndReadAll(
+                queryStreamVariety(2006, 'month', 'artists')
+            )
+        ).getRowObjectsJson()
+
+        // Jan: all 3 streams are artist_X → distinct=1, repeat=2, total=3
+        const jan = rows.find((r) => r.ts === '2006-01-01')
+        expect(jan?.distinct_count).toBe(1)
+        expect(jan?.repeat_count).toBe(2)
+        expect(jan?.total_count).toBe(3)
+    })
+})
+
+describe('StreamVariety query — albums entity', () => {
+    it('counts distinct albums', async () => {
+        const rows = (
+            await conn.runAndReadAll(
+                queryStreamVariety(2006, 'month', 'albums')
+            )
+        ).getRowObjectsJson()
+
+        // Jan: all 3 streams are album_1 → distinct=1, repeat=2, total=3
+        const jan = rows.find((r) => r.ts === '2006-01-01')
+        expect(jan?.distinct_count).toBe(1)
+        expect(jan?.repeat_count).toBe(2)
+        expect(jan?.total_count).toBe(3)
+    })
+})
+
+describe('StreamVariety query — week granularity', () => {
+    it('returns ISO Monday-first weeks covering full year', async () => {
+        const rows = (
+            await conn.runAndReadAll(queryStreamVariety(2006, 'week', 'tracks'))
+        ).getRowObjectsJson()
+
+        for (const row of rows) {
+            const date = new Date(`${row.ts}T00:00:00Z`)
+            expect(date.getUTCDay()).toBe(1)
+        }
+
+        expect(rows[0].ts).toBe('2005-12-26')
+        expect(rows[rows.length - 1].ts).toBe('2006-12-25')
+    })
+})
+
+describe('StreamVariety query — day granularity', () => {
+    it('returns 365 gap-filled days for 2006', async () => {
+        const rows = (
+            await conn.runAndReadAll(queryStreamVariety(2006, 'day', 'tracks'))
+        ).getRowObjectsJson()
+
+        expect(rows).toHaveLength(365)
+
+        const jan17 = rows.find((r) => r.ts === '2006-01-17')
+        expect(jan17?.distinct_count).toBe(1)
+        expect(jan17?.total_count).toBe(1)
+
+        const jan18 = rows.find((r) => r.ts === '2006-01-18')
+        expect(jan18?.distinct_count).toBe(0)
+        expect(jan18?.total_count).toBe(0)
+    })
+})
+
+describe('StreamVarietyStats query', () => {
+    it('returns global distinct/repeat/total counts independent of granularity', async () => {
+        const rows = (
+            await conn.runAndReadAll(queryStreamVarietyStats(2006, 'tracks'))
+        ).getRowObjectsJson()
+
+        expect(rows).toHaveLength(1)
+        expect(rows[0].total_distinct).toBe(3)
+        expect(rows[0].total_repeat).toBe(2)
+        expect(rows[0].total_streams).toBe(5)
+    })
+
+    it('filters by year', async () => {
+        const rows = (
+            await conn.runAndReadAll(
+                queryStreamVarietyStats(undefined, 'tracks')
+            )
+        ).getRowObjectsJson()
+
+        expect(rows[0].total_streams).toBe(5)
+    })
+
+    it('counts distinct artists', async () => {
+        const rows = (
+            await conn.runAndReadAll(queryStreamVarietyStats(2006, 'artists'))
+        ).getRowObjectsJson()
+
+        expect(rows[0].total_distinct).toBe(2)
+        expect(rows[0].total_repeat).toBe(3)
+    })
+})
+
+describe('StreamVariety query — year granularity', () => {
+    it('returns one row per year all-time', async () => {
+        const rows = (
+            await conn.runAndReadAll(
+                queryStreamVariety(undefined, 'year', 'tracks')
+            )
+        ).getRowObjectsJson()
+
+        expect(rows).toHaveLength(1)
+        const row2006 = rows.find((r) => r.ts === '2006-01-01')
+        expect(row2006?.total_count).toBe(5)
+        expect(row2006?.distinct_count).toBe(3)
+        expect(row2006?.repeat_count).toBe(2)
+    })
+})

--- a/app/src/components/Charts/LabCharts/StreamVariety/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamVariety/query.ts
@@ -1,0 +1,106 @@
+import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
+import sqlQueryStreamVariety from './StreamVariety.sql?raw'
+import sqlQueryStreamVarietyStats from './StreamVarietyStats.sql?raw'
+
+export type Granularity = 'year' | 'month' | 'week' | 'day'
+
+export type Entity = 'tracks' | 'artists' | 'albums'
+
+export type StreamVarietyQueryResult = {
+    ts: string
+    distinct_count: number
+    repeat_count: number
+    total_count: number
+}
+
+const ENTITY_COLUMN: Record<Entity, string> = {
+    tracks: 'track_uri',
+    artists: 'artist_name',
+    albums: 'album_name',
+}
+
+type GranConfig = {
+    periodTrunc: (col: string) => string
+    spineStart: (minCol: string, perYear: boolean) => string
+    spineEnd: (maxCol: string, perYear: boolean) => string
+    step: string
+}
+
+const GRAN_CONFIG: Record<Granularity, GranConfig> = {
+    year: {
+        periodTrunc: (col) => `make_date(year(${col}), 1, 1)`,
+        spineStart: (col) => `make_date(year(${col}), 1, 1)`,
+        spineEnd: (col) => `make_date(year(${col}), 1, 1)`,
+        step: `interval 1 year`,
+    },
+    month: {
+        periodTrunc: (col) => `make_date(year(${col}), month(${col}), 1)`,
+        spineStart: (col, perYear) =>
+            perYear
+                ? `make_date(year(${col}), 1, 1)`
+                : `make_date(year(${col}), month(${col}), 1)`,
+        spineEnd: (col, perYear) =>
+            perYear
+                ? `make_date(year(${col}), 12, 1)`
+                : `make_date(year(${col}), month(${col}), 1)`,
+        step: `interval 1 month`,
+    },
+    week: {
+        periodTrunc: (col) => `date_trunc('week', ${col})`,
+        spineStart: (col, perYear) =>
+            perYear
+                ? `date_trunc('week', make_date(year(${col}), 1, 1))`
+                : `date_trunc('week', ${col})`,
+        spineEnd: (col, perYear) =>
+            perYear
+                ? `date_trunc('week', make_date(year(${col}), 12, 31))`
+                : `date_trunc('week', ${col})`,
+        step: `interval 7 days`,
+    },
+    day: {
+        periodTrunc: (col) => `${col}::date`,
+        spineStart: (col) => `make_date(year(${col}), 1, 1)`,
+        spineEnd: (col) => `make_date(year(${col}), 12, 31)`,
+        step: `interval 1 day`,
+    },
+}
+
+export type StreamVarietyStatsQueryResult = {
+    total_distinct: number
+    total_repeat: number
+    total_streams: number
+}
+
+export function queryStreamVarietyStats(
+    year: number | undefined,
+    entity: Entity
+): string {
+    const yearCondition = buildYearCondition(year)
+    return sqlQueryStreamVarietyStats
+        .replaceAll('${entity_column}', ENTITY_COLUMN[entity])
+        .replaceAll('${table}', TABLE)
+        .replaceAll('${year_condition}', yearCondition)
+}
+
+export function queryStreamVariety(
+    year: number | undefined,
+    granularity: Granularity,
+    entity: Entity
+): string {
+    const yearCondition = buildYearCondition(year)
+    const perYear = year !== undefined
+    const { periodTrunc, spineStart, spineEnd, step } = GRAN_CONFIG[granularity]
+    const minExpr = `(select min(ts::date) from ${TABLE} where ${yearCondition})`
+    const maxExpr = `(select max(ts::date) from ${TABLE} where ${yearCondition})`
+
+    return sqlQueryStreamVariety
+        .replaceAll('${spineTimeTrunc}', periodTrunc('t.dt'))
+        .replaceAll('${streamTimeTrunc}', periodTrunc('ts::date'))
+        .replaceAll('${entity_column}', ENTITY_COLUMN[entity])
+        .replaceAll('${spineStart}', spineStart(minExpr, perYear))
+        .replaceAll('${spineEnd}', spineEnd(maxExpr, perYear))
+        .replaceAll('${step}', step)
+        .replaceAll('${table}', TABLE)
+        .replaceAll('${year_condition}', yearCondition)
+}

--- a/app/src/components/Charts/LabCharts/Top10BillboardRace/index.tsx
+++ b/app/src/components/Charts/LabCharts/Top10BillboardRace/index.tsx
@@ -55,7 +55,7 @@ export function Top10BillboardRace({ year }: { year: number | undefined }) {
         <ChartCard
             title="Top 10 Billboard Race"
             emoji="🏎️"
-            className="mt-4 md:col-span-2 lg:col-span-3"
+            className="md:col-span-2 lg:col-span-3"
             isLoading={isLoading}
             question="Who stayed in the charts the longest week after week?"
             headerActions={entityTabs}

--- a/app/src/components/Charts/LabCharts/Top10Race/index.tsx
+++ b/app/src/components/Charts/LabCharts/Top10Race/index.tsx
@@ -54,7 +54,7 @@ export function Top10Race({ year }: { year: number | undefined }) {
         <ChartCard
             title="Top 10 Race"
             emoji="🏎️"
-            className="mt-4 md:col-span-2 lg:col-span-3"
+            className="md:col-span-2 lg:col-span-3"
             isLoading={isLoading}
             question="Who dominated my listening, and when did they rise?"
             headerActions={entityTabs}

--- a/app/src/components/Charts/LabView.test.tsx
+++ b/app/src/components/Charts/LabView.test.tsx
@@ -35,6 +35,12 @@ import {
     queryTop10AlbumsEvolution,
 } from './LabCharts/Top10AlbumsEvolution/query'
 import {
+    type StreamVarietyQueryResult,
+    type StreamVarietyStatsQueryResult,
+    queryStreamVariety,
+    queryStreamVarietyStats,
+} from './LabCharts/StreamVariety/query'
+import {
     type Top10TracksEvolutionQueryResult,
     queryTop10TracksEvolution,
 } from './LabCharts/Top10TracksEvolution/query'
@@ -106,6 +112,14 @@ const top10AlbumsEvolutionResultMock: Top10AlbumsEvolutionQueryResult[] = [
     },
 ]
 
+const streamVarietyResultMock: StreamVarietyQueryResult[] = [
+    { ts: '2024-01-01', distinct_count: 2, repeat_count: 1, total_count: 3 },
+]
+
+const streamVarietyStatsMock: StreamVarietyStatsQueryResult[] = [
+    { total_distinct: 2, total_repeat: 1, total_streams: 3 },
+]
+
 const top10TracksEvolutionResultMock: Top10TracksEvolutionQueryResult[] = [
     {
         year: 2024,
@@ -146,6 +160,10 @@ it('renders all Charts', async () => {
         if (query === summarizeQuery) return Promise.resolve(summarizedDataMock)
         if (query === queryStreamTimeline(2024, 'month'))
             return Promise.resolve(streamTimelineResultMock)
+        if (query === queryStreamVariety(2024, 'month', 'tracks'))
+            return Promise.resolve(streamVarietyResultMock)
+        if (query === queryStreamVarietyStats(2024, 'tracks'))
+            return Promise.resolve(streamVarietyStatsMock)
         if (query === summarizePerYearQuery(2024))
             return Promise.resolve(summaryPerYearResultMock)
         if (query === queryArtistDiscovery())

--- a/app/src/components/Charts/LabView.tsx
+++ b/app/src/components/Charts/LabView.tsx
@@ -66,12 +66,14 @@ export function LabView() {
                             Number(summarize.max_datetime)
                         ).getFullYear()}
                     />
-                    <StreamTimeline year={debouncedYear} />
-                    <StreamVariety year={debouncedYear} />
-                    <SummaryPerYear year={debouncedYear} />
-                    <ArtistDiscovery />
-                    <StreamPerDayOfWeek year={debouncedYear} />
-                    <Top10AlbumsEvolution />
+                    <div className="flex flex-col gap-4">
+                        <StreamTimeline year={debouncedYear} />
+                        <StreamVariety year={debouncedYear} />
+                        <SummaryPerYear year={debouncedYear} />
+                        <ArtistDiscovery />
+                        <StreamPerDayOfWeek year={debouncedYear} />
+                        <Top10AlbumsEvolution />
+                    </div>
                 </>
             )}
 
@@ -87,12 +89,14 @@ export function LabView() {
                     development and may contain errors.
                 </p>
 
-                <Streaks />
-                <Top10Evolution />
-                <Top10TracksEvolution />
-                <Top10Race year={debouncedYear} />
-                <Top10BillboardRace year={debouncedYear} />
-                <SessionAnalysisDetailed year={debouncedYear} />
+                <div className="flex flex-col gap-4">
+                    <Streaks />
+                    <Top10Evolution />
+                    <Top10TracksEvolution />
+                    <Top10Race year={debouncedYear} />
+                    <Top10BillboardRace year={debouncedYear} />
+                    <SessionAnalysisDetailed year={debouncedYear} />
+                </div>
             </section>
         </>
     )

--- a/app/src/components/Charts/LabView.tsx
+++ b/app/src/components/Charts/LabView.tsx
@@ -1,4 +1,5 @@
 import { StreamTimeline } from './LabCharts/StreamTimeline'
+import { StreamVariety } from './LabCharts/StreamVariety'
 import { SummaryPerYear } from './LabCharts/SummaryPerYear'
 import { YearSidebar } from '../YearSidebar/YearSidebar'
 import { useState, useEffect, useCallback } from 'react'
@@ -66,6 +67,7 @@ export function LabView() {
                         ).getFullYear()}
                     />
                     <StreamTimeline year={debouncedYear} />
+                    <StreamVariety year={debouncedYear} />
                     <SummaryPerYear year={debouncedYear} />
                     <ArtistDiscovery />
                     <StreamPerDayOfWeek year={debouncedYear} />


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Users have no way to see how varied their listening is, whether they mostly re-listen to the same tracks or constantly discover new ones.

## 🎹 Proposal

New **Stream Variety** chart in the Lab view. Shows distinct vs. re-listen streams as a stacked bar chart, with:

- Entity selector: Tracks / Artists / Albums
- Granularity selector: Year / Month / Week / Day
- Global insights computed over the full selected period (not aggregated from buckets): unique entity count and variety rate
- Tooltip per bar with distinct count, re-listen count, and variety %
- Consistent card spacing in LabView via `flex flex-col gap-4`

## 🎶 Comments

The stats query (`queryStreamVarietyStats`) runs as a separate parallel query against the raw table so the "Unique tracks listened" and "Variety rate" values remain stable regardless of the selected granularity.

## 🎤 Test

1. Load a Spotify history file
2. Navigate to the Lab view
3. Verify the Stream Variety card appears between Stream Timeline and Distribution of streams
4. Switch entity tabs (Tracks / Artists / Albums): bars and stats update
5. Switch granularity tabs: bars update, stats remain stable
6. Hover bars: tooltip shows per-period breakdown
7. Switch between a specific year and All Time: granularity options adjust accordingly