### PR TITLE
feat(charts): add StreamDiscovery chart to LabView

### DIFF
--- a/app/.sqruff
+++ b/app/.sqruff
@@ -47,8 +47,10 @@ year = 2024
 year_for_new = 2024
 # StreamTimeline / StreamVariety granularity placeholders
 spineTimeTrunc = ts::date
-streamTimeTrunc = ts::date
+streamTimeTrunc = stream_date
 spineStart = '2024-01-01'::date
 spineEnd = '2024-12-31'::date
 step = interval 1 month
 entity_column = track_uri
+firstDateTrunc = first_date
+new_condition = true

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.sql
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.sql
@@ -1,0 +1,53 @@
+with first_listen as (
+    select
+        ${entity_column},
+        min(ts::date) as first_date
+    from ${table}
+    group by ${entity_column}
+),
+
+spine as (
+    select ${spineTimeTrunc} as ts
+    from generate_series(${spineStart}, ${spineEnd}, ${step}) as t (dt)
+),
+
+joined as (
+    select
+        s.${entity_column} as entity,
+        s.ts::date as stream_date,
+        f.first_date
+    from ${table} as s
+    inner join first_listen as f on s.${entity_column} = f.${entity_column}
+    where ${year_condition}
+),
+
+tagged as (
+    select
+        ${streamTimeTrunc} as period,
+        case
+            when ${firstDateTrunc} = ${streamTimeTrunc}
+                then entity
+        end as new_entity,
+        entity
+    from joined
+),
+
+stream_agg as (
+    select
+        period as ts,
+        count(distinct new_entity) as new_count,
+        count(distinct entity)
+        - count(distinct new_entity) as known_count,
+        count(distinct entity) as total_count
+    from tagged
+    group by period
+)
+
+select
+    spine.ts::varchar as ts,
+    coalesce(stream_agg.new_count, 0)::int as new_count,
+    coalesce(stream_agg.known_count, 0)::int as known_count,
+    coalesce(stream_agg.total_count, 0)::int as total_count
+from spine
+left join stream_agg on spine.ts = stream_agg.ts
+order by spine.ts

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.test.tsx
@@ -61,10 +61,10 @@ describe('StreamDiscovery', () => {
         screen.getByText('67%')
     })
 
-    it('renders stacked bars with new (rose-500) and known (rose-800) segments', () => {
+    it('renders stacked bars with new and known segments', () => {
         render(<StreamDiscovery {...defaultProps} data={twoMonths} />)
-        const newSegments = document.querySelectorAll('.bg-rose-500')
-        const knownSegments = document.querySelectorAll('.bg-rose-800')
+        const newSegments = document.querySelectorAll('.bg-rose-800')
+        const knownSegments = document.querySelectorAll('.bg-rose-500')
         expect(newSegments.length).toBeGreaterThan(0)
         expect(knownSegments.length).toBeGreaterThan(0)
     })
@@ -83,7 +83,7 @@ describe('StreamDiscovery', () => {
                 ]}
             />
         )
-        const newSegment = document.querySelector('.bg-rose-500') as HTMLElement
+        const newSegment = document.querySelector('.bg-rose-800') as HTMLElement
         expect(newSegment.style.flexGrow).toBe('0')
     })
 

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { StreamDiscovery } from './StreamDiscovery'
+import type {
+    StreamDiscoveryQueryResult,
+    StreamDiscoveryStatsQueryResult,
+} from './query'
+
+const twoMonths: StreamDiscoveryQueryResult[] = [
+    { ts: '2006-01-01', new_count: 1, known_count: 1, total_count: 2 },
+    { ts: '2006-04-01', new_count: 1, known_count: 0, total_count: 1 },
+]
+
+const defaultStats: StreamDiscoveryStatsQueryResult = {
+    total_new: 2,
+    total_known: 1,
+    total_distinct: 3,
+}
+
+const defaultProps = {
+    year: 2006 as number | undefined,
+    granularity: 'month' as const,
+    availableGranularities: ['month', 'week', 'day'] as const,
+    onGranularityChange: () => {},
+    entity: 'tracks' as const,
+    onEntityChange: () => {},
+    stats: defaultStats,
+    isLoading: false,
+}
+
+describe('StreamDiscovery', () => {
+    it('renders empty state when data is empty', () => {
+        render(<StreamDiscovery {...defaultProps} data={[]} />)
+        screen.getByText('No data for this year')
+    })
+
+    it('renders empty state when all totals are zero', () => {
+        render(
+            <StreamDiscovery
+                {...defaultProps}
+                data={[
+                    {
+                        ts: '2006-01-01',
+                        new_count: 0,
+                        known_count: 0,
+                        total_count: 0,
+                    },
+                ]}
+                stats={{ total_new: 0, total_known: 0, total_distinct: 0 }}
+            />
+        )
+        screen.getByText('No data for this year')
+    })
+
+    it('renders chart heading and summary stats', () => {
+        render(<StreamDiscovery {...defaultProps} data={twoMonths} />)
+        screen.getByRole('heading', { name: /Stream Discovery/ })
+        screen.getByText('New tracks discovered')
+        screen.getByText('Discovery rate')
+        screen.getByText('2')
+        screen.getByText('67%')
+    })
+
+    it('renders stacked bars with new (rose-500) and known (rose-800) segments', () => {
+        render(<StreamDiscovery {...defaultProps} data={twoMonths} />)
+        const newSegments = document.querySelectorAll('.bg-rose-500')
+        const knownSegments = document.querySelectorAll('.bg-rose-800')
+        expect(newSegments.length).toBeGreaterThan(0)
+        expect(knownSegments.length).toBeGreaterThan(0)
+    })
+
+    it('new segment has flex 0 when new_count is 0', () => {
+        render(
+            <StreamDiscovery
+                {...defaultProps}
+                data={[
+                    {
+                        ts: '2006-01-01',
+                        new_count: 0,
+                        known_count: 3,
+                        total_count: 3,
+                    },
+                ]}
+            />
+        )
+        const newSegment = document.querySelector('.bg-rose-500') as HTMLElement
+        expect(newSegment.style.flexGrow).toBe('0')
+    })
+
+    it('renders legend for New and Known', () => {
+        render(<StreamDiscovery {...defaultProps} data={twoMonths} />)
+        screen.getByText('New')
+        screen.getByText('Known')
+    })
+
+    it('renders all three entity buttons', () => {
+        render(<StreamDiscovery {...defaultProps} data={twoMonths} />)
+        screen.getByRole('button', { name: 'Tracks' })
+        screen.getByRole('button', { name: 'Artists' })
+        screen.getByRole('button', { name: 'Albums' })
+    })
+
+    it('active entity button is highlighted', () => {
+        render(<StreamDiscovery {...defaultProps} data={twoMonths} />)
+        expect(
+            screen.getByRole('button', { name: 'Tracks' }).className
+        ).toContain('bg-blue-500')
+    })
+
+    it('calls onEntityChange when entity tab is clicked', () => {
+        const onEntityChange = vi.fn()
+        render(
+            <StreamDiscovery
+                {...defaultProps}
+                onEntityChange={onEntityChange}
+                data={twoMonths}
+            />
+        )
+        fireEvent.click(screen.getByRole('button', { name: 'Artists' }))
+        expect(onEntityChange).toHaveBeenCalledWith('artists')
+    })
+
+    it('renders all four granularity buttons', () => {
+        render(<StreamDiscovery {...defaultProps} data={twoMonths} />)
+        screen.getByRole('button', { name: 'Year' })
+        screen.getByRole('button', { name: 'Month' })
+        screen.getByRole('button', { name: 'Week' })
+        screen.getByRole('button', { name: 'Day' })
+    })
+
+    it('active granularity button is highlighted, unavailable buttons are disabled', () => {
+        render(<StreamDiscovery {...defaultProps} data={twoMonths} />)
+        const monthBtn = screen.getByRole('button', { name: 'Month' })
+        const yearBtn = screen.getByRole('button', { name: 'Year' })
+        expect(monthBtn.className).toContain('bg-blue-500')
+        expect((yearBtn as HTMLButtonElement).disabled).toBe(true)
+    })
+
+    it('calls onGranularityChange when granularity tab is clicked', () => {
+        const onGranularityChange = vi.fn()
+        render(
+            <StreamDiscovery
+                {...defaultProps}
+                onGranularityChange={onGranularityChange}
+                data={twoMonths}
+            />
+        )
+        fireEvent.click(screen.getByRole('button', { name: 'Week' }))
+        expect(onGranularityChange).toHaveBeenCalledWith('week')
+    })
+
+    it('shows tooltip on bar hover and hides on mouse leave', () => {
+        render(<StreamDiscovery {...defaultProps} data={twoMonths} />)
+        const bars = document.querySelectorAll('.flex-1.rounded-t')
+        fireEvent.mouseEnter(bars[0])
+        expect(screen.getByText('1 new')).toBeDefined()
+        expect(screen.getByText('1 known')).toBeDefined()
+
+        fireEvent.mouseLeave(bars[0].closest('.flex.items-end')!)
+        expect(screen.queryByText('1 new')).toBeNull()
+    })
+
+    it('does not show tooltip on zero-count bar hover', () => {
+        const dataWithZero: StreamDiscoveryQueryResult[] = [
+            { ts: '2006-02-01', new_count: 0, known_count: 0, total_count: 0 },
+            { ts: '2006-03-01', new_count: 1, known_count: 0, total_count: 1 },
+        ]
+        render(<StreamDiscovery {...defaultProps} data={dataWithZero} />)
+        const bars = document.querySelectorAll('.flex-1.rounded-t')
+        fireEvent.mouseEnter(bars[0])
+        expect(document.querySelector('.fixed.z-50')).toBeNull()
+    })
+})

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -212,11 +212,11 @@ export const StreamDiscovery: FC<Props> = ({
                                         }}
                                     >
                                         <div
-                                            className="bg-rose-800"
+                                            className="bg-rose-500"
                                             style={{ flex: d.known_count }}
                                         />
                                         <div
-                                            className="bg-rose-500"
+                                            className="bg-rose-800"
                                             style={{ flex: d.new_count }}
                                         />
                                     </div>
@@ -254,11 +254,11 @@ export const StreamDiscovery: FC<Props> = ({
 
                     <div className="mt-1 mb-3 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
                         <span className="flex items-center gap-1">
-                            <span className="inline-block w-2 h-2 rounded-sm bg-rose-500" />
+                            <span className="inline-block w-2 h-2 rounded-sm bg-rose-800" />
                             New
                         </span>
                         <span className="flex items-center gap-1">
-                            <span className="inline-block w-2 h-2 rounded-sm bg-rose-800" />
+                            <span className="inline-block w-2 h-2 rounded-sm bg-rose-500" />
                             Known
                         </span>
                     </div>

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -1,0 +1,320 @@
+import type { FC } from 'react'
+import { useState } from 'react'
+import type {
+    Entity,
+    Granularity,
+    StreamDiscoveryQueryResult,
+    StreamDiscoveryStatsQueryResult,
+} from './query'
+import {
+    ChartCard,
+    ChartCardEmpty,
+    ChartTooltip,
+} from '../../SimpleCharts/shared'
+
+type TooltipState = {
+    x: number
+    y: number
+    ts: string
+    new_count: number
+    known_count: number
+    total_count: number
+}
+
+type Props = {
+    data: StreamDiscoveryQueryResult[] | undefined
+    stats: StreamDiscoveryStatsQueryResult | undefined
+    year: number | undefined
+    granularity: Granularity
+    availableGranularities: Granularity[]
+    onGranularityChange: (g: Granularity) => void
+    entity: Entity
+    onEntityChange: (e: Entity) => void
+    isLoading?: boolean
+}
+
+const GRAN_LABELS: Record<Granularity, string> = {
+    year: 'Year',
+    month: 'Month',
+    week: 'Week',
+    day: 'Day',
+}
+
+const ENTITY_LABELS: Record<Entity, string> = {
+    tracks: 'Tracks',
+    artists: 'Artists',
+    albums: 'Albums',
+}
+
+const ENTITY_SINGULAR: Record<Entity, string> = {
+    tracks: 'track',
+    artists: 'artist',
+    albums: 'album',
+}
+
+function formatTooltipDate(date: Date, granularity: Granularity): string {
+    if (granularity === 'year')
+        return date.toLocaleDateString(undefined, { year: 'numeric' })
+    if (granularity === 'month')
+        return date.toLocaleDateString(undefined, {
+            month: 'long',
+            year: 'numeric',
+        })
+    return date.toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+    })
+}
+
+function getBarLabel(
+    d: StreamDiscoveryQueryResult,
+    index: number,
+    data: StreamDiscoveryQueryResult[],
+    year: number | undefined,
+    granularity: Granularity
+): string {
+    const date = new Date(d.ts)
+
+    if (granularity === 'year') return String(date.getUTCFullYear())
+
+    if (granularity === 'month') {
+        if (year !== undefined)
+            return date.toLocaleDateString(undefined, { month: 'short' })
+        return date.getUTCMonth() === 0 ? String(date.getUTCFullYear()) : ''
+    }
+
+    if (granularity === 'week') {
+        if (index === 0)
+            return date.toLocaleDateString(undefined, { month: 'short' })
+        const prev = new Date(data[index - 1].ts)
+        return date.getUTCMonth() !== prev.getUTCMonth()
+            ? date.toLocaleDateString(undefined, { month: 'short' })
+            : ''
+    }
+
+    // day
+    return date.getUTCDate() === 1
+        ? date.toLocaleDateString(undefined, { month: 'short' })
+        : ''
+}
+
+export const StreamDiscovery: FC<Props> = ({
+    data,
+    stats,
+    year,
+    granularity,
+    availableGranularities,
+    onGranularityChange,
+    entity,
+    onEntityChange,
+    isLoading,
+}) => {
+    const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+
+    const totalNew = stats?.total_new ?? 0
+    const discoveryRate =
+        (stats?.total_distinct ?? 0) > 0
+            ? Math.round(
+                  ((stats?.total_new ?? 0) / (stats?.total_distinct ?? 0)) * 100
+              )
+            : 0
+    const maxTotal = data?.length
+        ? Math.max(...data.map((d) => d.total_count))
+        : 0
+    const sparseLabelLayout = granularity !== 'month' || year === undefined
+
+    const entityTabs = (
+        <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30">
+            {(['tracks', 'artists', 'albums'] as const).map((e) => (
+                <button
+                    key={e}
+                    onClick={() => onEntityChange(e)}
+                    className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
+                        entity === e
+                            ? 'bg-blue-500 text-white shadow-sm'
+                            : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
+                    }`}
+                >
+                    {ENTITY_LABELS[e]}
+                </button>
+            ))}
+        </div>
+    )
+
+    return (
+        <ChartCard
+            title="Stream Discovery"
+            emoji="🔭"
+            isLoading={isLoading}
+            question="How many new artists, tracks, or albums did I discover?"
+            headerActions={entityTabs}
+        >
+            <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30 self-start mb-3">
+                {(['year', 'month', 'week', 'day'] as const).map((g) => {
+                    const available = availableGranularities.includes(g)
+                    const active = granularity === g
+                    return (
+                        <button
+                            key={g}
+                            onClick={() => available && onGranularityChange(g)}
+                            disabled={!available}
+                            className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
+                                active
+                                    ? 'bg-blue-500 text-white shadow-sm'
+                                    : available
+                                      ? 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
+                                      : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
+                            }`}
+                        >
+                            {GRAN_LABELS[g]}
+                        </button>
+                    )
+                })}
+            </div>
+
+            {!data?.length || (stats?.total_distinct ?? 0) === 0 ? (
+                <ChartCardEmpty
+                    message={
+                        year !== undefined ? 'No data for this year' : 'No data'
+                    }
+                />
+            ) : (
+                <>
+                    <div className="overflow-x-auto mt-4">
+                        <div
+                            className="flex items-end gap-0.5 h-24 mb-1"
+                            style={{ minWidth: `${data.length * 4}px` }}
+                            onMouseLeave={() => setTooltip(null)}
+                        >
+                            {data.map((d) => {
+                                const height =
+                                    maxTotal > 0
+                                        ? (d.total_count / maxTotal) * 100
+                                        : 0
+                                return (
+                                    <div
+                                        key={d.ts}
+                                        className="flex-1 min-w-[3px] flex flex-col rounded-t overflow-hidden"
+                                        style={{ height: `${height}%` }}
+                                        onMouseEnter={(e) => {
+                                            if (d.total_count === 0) return
+                                            const rect =
+                                                e.currentTarget.getBoundingClientRect()
+                                            setTooltip({
+                                                x: rect.left + rect.width / 2,
+                                                y: rect.top,
+                                                ts: d.ts,
+                                                new_count: d.new_count,
+                                                known_count: d.known_count,
+                                                total_count: d.total_count,
+                                            })
+                                        }}
+                                    >
+                                        <div
+                                            className="bg-rose-800"
+                                            style={{ flex: d.known_count }}
+                                        />
+                                        <div
+                                            className="bg-rose-500"
+                                            style={{ flex: d.new_count }}
+                                        />
+                                    </div>
+                                )
+                            })}
+                        </div>
+
+                        <div
+                            className="flex gap-0.5 mb-4"
+                            style={{ minWidth: `${data.length * 4}px` }}
+                        >
+                            {data.map((d, i) => {
+                                const label = getBarLabel(
+                                    d,
+                                    i,
+                                    data,
+                                    year,
+                                    granularity
+                                )
+                                return (
+                                    <div
+                                        key={d.ts}
+                                        className={`flex-1 min-w-[3px] text-[9px] text-gray-400 dark:text-gray-500 ${
+                                            sparseLabelLayout
+                                                ? 'overflow-visible whitespace-nowrap'
+                                                : 'text-center truncate'
+                                        }`}
+                                    >
+                                        {label}
+                                    </div>
+                                )
+                            })}
+                        </div>
+                    </div>
+
+                    <div className="mt-1 mb-3 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+                        <span className="flex items-center gap-1">
+                            <span className="inline-block w-2 h-2 rounded-sm bg-rose-500" />
+                            New
+                        </span>
+                        <span className="flex items-center gap-1">
+                            <span className="inline-block w-2 h-2 rounded-sm bg-rose-800" />
+                            Known
+                        </span>
+                    </div>
+
+                    <ul
+                        className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700"
+                        role="list"
+                    >
+                        <li
+                            className="flex justify-between items-center"
+                            role="listitem"
+                        >
+                            <span className="text-sm text-gray-600 dark:text-gray-400">
+                                New {ENTITY_SINGULAR[entity]}s discovered
+                            </span>
+                            <span className="font-bold">
+                                {totalNew.toLocaleString()}
+                            </span>
+                        </li>
+                        <li
+                            className="flex justify-between items-center mt-1"
+                            role="listitem"
+                        >
+                            <span className="text-sm text-gray-600 dark:text-gray-400">
+                                Discovery rate
+                                <span className="ml-1 text-xs font-normal text-gray-400 dark:text-gray-500">
+                                    (new / total distinct)
+                                </span>
+                            </span>
+                            <span className="font-bold">{discoveryRate}%</span>
+                        </li>
+                    </ul>
+                </>
+            )}
+            {tooltip && (
+                <ChartTooltip x={tooltip.x} y={tooltip.y}>
+                    <div className="font-semibold">
+                        {formatTooltipDate(new Date(tooltip.ts), granularity)}
+                    </div>
+                    <div className="text-gray-300 dark:text-gray-400">
+                        {tooltip.new_count.toLocaleString()} new
+                    </div>
+                    <div className="text-gray-300 dark:text-gray-400">
+                        {tooltip.known_count.toLocaleString()} known
+                    </div>
+                    <div className="text-gray-300 dark:text-gray-400">
+                        {tooltip.total_count > 0
+                            ? Math.round(
+                                  (tooltip.new_count / tooltip.total_count) *
+                                      100
+                              )
+                            : 0}
+                        % discovery
+                    </div>
+                </ChartTooltip>
+            )}
+        </ChartCard>
+    )
+}

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscoveryStats.sql
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscoveryStats.sql
@@ -1,0 +1,22 @@
+with first_listen as (
+    select
+        ${entity_column},
+        min(ts::date) as first_date
+    from ${table}
+    group by ${entity_column}
+)
+
+select
+    count(
+        distinct case when ${new_condition} then s.${entity_column} end
+    )::int as total_new,
+    (
+        count(distinct s.${entity_column})
+        - count(
+            distinct case when ${new_condition} then s.${entity_column} end
+        )
+    )::int as total_known,
+    count(distinct s.${entity_column})::int as total_distinct
+from ${table} as s
+inner join first_listen as f on s.${entity_column} = f.${entity_column}
+where ${year_condition}

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/fixtures/seed.json
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/fixtures/seed.json
@@ -1,0 +1,37 @@
+[
+    {
+        "ts": "2005-03-10T10:00:00Z",
+        "ms_played": 1.0,
+        "track_uri": "track_A",
+        "artist_name": "artist_X",
+        "album_name": "album_1"
+    },
+    {
+        "ts": "2006-01-15T10:00:00Z",
+        "ms_played": 1.0,
+        "track_uri": "track_A",
+        "artist_name": "artist_X",
+        "album_name": "album_1"
+    },
+    {
+        "ts": "2006-01-20T10:00:00Z",
+        "ms_played": 1.0,
+        "track_uri": "track_B",
+        "artist_name": "artist_Y",
+        "album_name": "album_2"
+    },
+    {
+        "ts": "2006-04-05T10:00:00Z",
+        "ms_played": 1.0,
+        "track_uri": "track_C",
+        "artist_name": "artist_Z",
+        "album_name": "album_3"
+    },
+    {
+        "ts": "2006-06-01T10:00:00Z",
+        "ms_played": 1.0,
+        "track_uri": "track_B",
+        "artist_name": "artist_Y",
+        "album_name": "album_2"
+    }
+]

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/index.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/index.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react'
+import { useDBQueryMany } from '../../../../hooks/useDBQuery'
+import {
+    queryStreamDiscovery,
+    queryStreamDiscoveryStats,
+    type Entity,
+    type Granularity,
+    type StreamDiscoveryQueryResult,
+    type StreamDiscoveryStatsQueryResult,
+} from './query'
+import { StreamDiscovery as StreamDiscoveryView } from './StreamDiscovery'
+
+const ALL_TIME_GRANULARITIES: Granularity[] = ['year', 'month']
+const PER_YEAR_GRANULARITIES: Granularity[] = ['month', 'week', 'day']
+
+interface StreamDiscoveryProps {
+    year: number | undefined
+}
+
+export function StreamDiscovery({ year }: StreamDiscoveryProps) {
+    const [granularity, setGranularity] = useState<Granularity>('month')
+    const [entity, setEntity] = useState<Entity>('tracks')
+
+    const availableGranularities =
+        year !== undefined ? PER_YEAR_GRANULARITIES : ALL_TIME_GRANULARITIES
+
+    // Avoids double-fetch: derived fallback instead of useEffect resetting granularity.
+    const effectiveGranularity = availableGranularities.includes(granularity)
+        ? granularity
+        : availableGranularities[0]
+
+    const { data, isLoading } = useDBQueryMany<StreamDiscoveryQueryResult>({
+        query: queryStreamDiscovery(year, effectiveGranularity, entity),
+        year,
+    })
+
+    const { data: statsData } = useDBQueryMany<StreamDiscoveryStatsQueryResult>(
+        {
+            query: queryStreamDiscoveryStats(year, entity),
+            year,
+        }
+    )
+
+    const stats = statsData?.[0]
+
+    return (
+        <StreamDiscoveryView
+            data={data}
+            stats={stats}
+            year={year}
+            granularity={effectiveGranularity}
+            availableGranularities={availableGranularities}
+            onGranularityChange={setGranularity}
+            entity={entity}
+            onEntityChange={setEntity}
+            isLoading={isLoading}
+        />
+    )
+}

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/query.test.ts
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/query.test.ts
@@ -1,0 +1,245 @@
+import {
+    afterAll,
+    beforeAll,
+    beforeEach,
+    describe,
+    it,
+    expect,
+    vi,
+} from 'vitest'
+import { DuckDBConnection } from '@duckdb/node-api'
+import { queryStreamDiscovery, queryStreamDiscoveryStats } from './query'
+import { TABLE } from '../../../../db/queries/constants'
+
+const seedPath =
+    'src/components/Charts/LabCharts/StreamDiscovery/fixtures/seed.json'
+let conn: DuckDBConnection
+
+beforeAll(async () => {
+    conn = await DuckDBConnection.create()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-15'))
+})
+
+afterAll(() => {
+    conn.closeSync()
+    vi.useRealTimers()
+})
+
+beforeEach(async () => {
+    await conn.run(`CREATE OR REPLACE TABLE ${TABLE} AS (FROM '${seedPath}')`)
+})
+
+// Seed:
+// 2005-03-10: track_A / artist_X / album_1  (pre-2006, so "known" in 2006)
+// 2006-01-15: track_A / artist_X / album_1  (known — first heard 2005)
+// 2006-01-20: track_B / artist_Y / album_2  (new — first heard Jan 2006)
+// 2006-04-05: track_C / artist_Z / album_3  (new — first heard Apr 2006)
+// 2006-06-01: track_B / artist_Y / album_2  (known — first heard Jan 2006)
+
+describe('StreamDiscovery query — month granularity, tracks entity', () => {
+    it('distinguishes new tracks from known tracks per month', async () => {
+        const rows = (
+            await conn.runAndReadAll(
+                queryStreamDiscovery(2006, 'month', 'tracks')
+            )
+        ).getRowObjectsJson()
+
+        expect(rows).toHaveLength(12)
+
+        // Jan: track_A (known, first=2005) + track_B (new, first=Jan 2006)
+        const jan = rows.find((r) => r.ts === '2006-01-01')
+        expect(jan?.new_count).toBe(1)
+        expect(jan?.known_count).toBe(1)
+        expect(jan?.total_count).toBe(2)
+
+        // Apr: track_C (new)
+        const apr = rows.find((r) => r.ts === '2006-04-01')
+        expect(apr?.new_count).toBe(1)
+        expect(apr?.known_count).toBe(0)
+        expect(apr?.total_count).toBe(1)
+
+        // Jun: track_B (known — first heard Jan 2006, not Jun)
+        const jun = rows.find((r) => r.ts === '2006-06-01')
+        expect(jun?.new_count).toBe(0)
+        expect(jun?.known_count).toBe(1)
+        expect(jun?.total_count).toBe(1)
+
+        // Feb: gap-filled
+        const feb = rows.find((r) => r.ts === '2006-02-01')
+        expect(feb?.new_count).toBe(0)
+        expect(feb?.known_count).toBe(0)
+        expect(feb?.total_count).toBe(0)
+    })
+
+    it('includes pre-period data in all-time view', async () => {
+        const rows = (
+            await conn.runAndReadAll(
+                queryStreamDiscovery(undefined, 'month', 'tracks')
+            )
+        ).getRowObjectsJson()
+
+        // Mar 2005: track_A heard for first time → new
+        const mar2005 = rows.find((r) => r.ts === '2005-03-01')
+        expect(mar2005?.new_count).toBe(1)
+        expect(mar2005?.known_count).toBe(0)
+
+        // Jan 2006: track_A known (first=2005), track_B new
+        const jan2006 = rows.find((r) => r.ts === '2006-01-01')
+        expect(jan2006?.new_count).toBe(1)
+        expect(jan2006?.known_count).toBe(1)
+    })
+})
+
+describe('StreamDiscovery query — artists entity', () => {
+    it('counts distinct new/known artists per month', async () => {
+        const rows = (
+            await conn.runAndReadAll(
+                queryStreamDiscovery(2006, 'month', 'artists')
+            )
+        ).getRowObjectsJson()
+
+        // Jan: artist_X (known, first=2005) + artist_Y (new, first=Jan 2006)
+        const jan = rows.find((r) => r.ts === '2006-01-01')
+        expect(jan?.new_count).toBe(1)
+        expect(jan?.known_count).toBe(1)
+
+        // Apr: artist_Z (new)
+        const apr = rows.find((r) => r.ts === '2006-04-01')
+        expect(apr?.new_count).toBe(1)
+        expect(apr?.known_count).toBe(0)
+    })
+})
+
+describe('StreamDiscovery query — albums entity', () => {
+    it('counts distinct new/known albums per month', async () => {
+        const rows = (
+            await conn.runAndReadAll(
+                queryStreamDiscovery(2006, 'month', 'albums')
+            )
+        ).getRowObjectsJson()
+
+        // Jan: album_1 (known, first=2005) + album_2 (new, first=Jan 2006)
+        const jan = rows.find((r) => r.ts === '2006-01-01')
+        expect(jan?.new_count).toBe(1)
+        expect(jan?.known_count).toBe(1)
+    })
+})
+
+describe('StreamDiscovery query — week granularity', () => {
+    it('returns ISO Monday-first weeks covering full year', async () => {
+        const rows = (
+            await conn.runAndReadAll(
+                queryStreamDiscovery(2006, 'week', 'tracks')
+            )
+        ).getRowObjectsJson()
+
+        for (const row of rows) {
+            const date = new Date(`${row.ts}T00:00:00Z`)
+            expect(date.getUTCDay()).toBe(1)
+        }
+
+        expect(rows[0].ts).toBe('2005-12-26')
+        expect(rows[rows.length - 1].ts).toBe('2006-12-25')
+
+        // Jan 15 (Sun) → week of Jan 9: track_A (known, first=2005)
+        const weekJan9 = rows.find((r) => r.ts === '2006-01-09')
+        expect(weekJan9?.new_count).toBe(0)
+        expect(weekJan9?.known_count).toBe(1)
+
+        // Jan 20 (Fri) → week of Jan 16: track_B (new, first=2006-01-20)
+        const weekJan16 = rows.find((r) => r.ts === '2006-01-16')
+        expect(weekJan16?.new_count).toBe(1)
+        expect(weekJan16?.known_count).toBe(0)
+    })
+})
+
+describe('StreamDiscovery query — day granularity', () => {
+    it('returns 365 gap-filled days for 2006', async () => {
+        const rows = (
+            await conn.runAndReadAll(
+                queryStreamDiscovery(2006, 'day', 'tracks')
+            )
+        ).getRowObjectsJson()
+
+        expect(rows).toHaveLength(365)
+
+        // Jan 15: track_A (known, first=2005-03-10)
+        const jan15 = rows.find((r) => r.ts === '2006-01-15')
+        expect(jan15?.new_count).toBe(0)
+        expect(jan15?.known_count).toBe(1)
+
+        // Jan 20: track_B (new, first=2006-01-20)
+        const jan20 = rows.find((r) => r.ts === '2006-01-20')
+        expect(jan20?.new_count).toBe(1)
+        expect(jan20?.known_count).toBe(0)
+
+        // Jan 18: gap-filled
+        const jan18 = rows.find((r) => r.ts === '2006-01-18')
+        expect(jan18?.new_count).toBe(0)
+        expect(jan18?.total_count).toBe(0)
+    })
+})
+
+describe('StreamDiscovery query — year granularity', () => {
+    it('returns one row per year all-time', async () => {
+        const rows = (
+            await conn.runAndReadAll(
+                queryStreamDiscovery(undefined, 'year', 'tracks')
+            )
+        ).getRowObjectsJson()
+
+        expect(rows).toHaveLength(2)
+
+        // 2005: track_A first heard → new=1, known=0
+        const row2005 = rows.find((r) => r.ts === '2005-01-01')
+        expect(row2005?.new_count).toBe(1)
+        expect(row2005?.known_count).toBe(0)
+
+        // 2006: track_A (known from 2005), track_B and track_C new in 2006
+        const row2006 = rows.find((r) => r.ts === '2006-01-01')
+        expect(row2006?.new_count).toBe(2)
+        expect(row2006?.known_count).toBe(1)
+        expect(row2006?.total_count).toBe(3)
+    })
+})
+
+describe('StreamDiscoveryStats query', () => {
+    it('returns global new/known/distinct counts for a year', async () => {
+        const rows = (
+            await conn.runAndReadAll(queryStreamDiscoveryStats(2006, 'tracks'))
+        ).getRowObjectsJson()
+
+        expect(rows).toHaveLength(1)
+        // Distinct in 2006: A, B, C = 3
+        // New in 2006 (first_date in 2006): B, C = 2
+        // Known: A = 1
+        expect(rows[0].total_distinct).toBe(3)
+        expect(rows[0].total_new).toBe(2)
+        expect(rows[0].total_known).toBe(1)
+    })
+
+    it('returns all entities as new for all-time query', async () => {
+        const rows = (
+            await conn.runAndReadAll(
+                queryStreamDiscoveryStats(undefined, 'tracks')
+            )
+        ).getRowObjectsJson()
+
+        // All-time: new_condition=true → all distinct entities are "new"
+        expect(rows[0].total_distinct).toBe(3)
+        expect(rows[0].total_new).toBe(3)
+        expect(rows[0].total_known).toBe(0)
+    })
+
+    it('counts distinct artists', async () => {
+        const rows = (
+            await conn.runAndReadAll(queryStreamDiscoveryStats(2006, 'artists'))
+        ).getRowObjectsJson()
+
+        // In 2006: artist_X (known, first=2005), artist_Y (new, first=Jan 2006), artist_Z (new, first=Apr 2006)
+        expect(rows[0].total_distinct).toBe(3)
+        expect(rows[0].total_new).toBe(2)
+        expect(rows[0].total_known).toBe(1)
+    })
+})

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/query.ts
@@ -1,0 +1,110 @@
+import { TABLE } from '../../../../db/queries/constants'
+import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
+import sqlQueryStreamDiscovery from './StreamDiscovery.sql?raw'
+import sqlQueryStreamDiscoveryStats from './StreamDiscoveryStats.sql?raw'
+
+export type Granularity = 'year' | 'month' | 'week' | 'day'
+
+export type Entity = 'tracks' | 'artists' | 'albums'
+
+export type StreamDiscoveryQueryResult = {
+    ts: string
+    new_count: number
+    known_count: number
+    total_count: number
+}
+
+export type StreamDiscoveryStatsQueryResult = {
+    total_new: number
+    total_known: number
+    total_distinct: number
+}
+
+const ENTITY_COLUMN: Record<Entity, string> = {
+    tracks: 'track_uri',
+    artists: 'artist_name',
+    albums: 'album_name',
+}
+
+type GranConfig = {
+    periodTrunc: (col: string) => string
+    spineStart: (minCol: string, perYear: boolean) => string
+    spineEnd: (maxCol: string, perYear: boolean) => string
+    step: string
+}
+
+const GRAN_CONFIG: Record<Granularity, GranConfig> = {
+    year: {
+        periodTrunc: (col) => `make_date(year(${col}), 1, 1)`,
+        spineStart: (col) => `make_date(year(${col}), 1, 1)`,
+        spineEnd: (col) => `make_date(year(${col}), 1, 1)`,
+        step: `interval 1 year`,
+    },
+    month: {
+        periodTrunc: (col) => `make_date(year(${col}), month(${col}), 1)`,
+        spineStart: (col, perYear) =>
+            perYear
+                ? `make_date(year(${col}), 1, 1)`
+                : `make_date(year(${col}), month(${col}), 1)`,
+        spineEnd: (col, perYear) =>
+            perYear
+                ? `make_date(year(${col}), 12, 1)`
+                : `make_date(year(${col}), month(${col}), 1)`,
+        step: `interval 1 month`,
+    },
+    week: {
+        periodTrunc: (col) => `date_trunc('week', ${col})`,
+        spineStart: (col, perYear) =>
+            perYear
+                ? `date_trunc('week', make_date(year(${col}), 1, 1))`
+                : `date_trunc('week', ${col})`,
+        spineEnd: (col, perYear) =>
+            perYear
+                ? `date_trunc('week', make_date(year(${col}), 12, 31))`
+                : `date_trunc('week', ${col})`,
+        step: `interval 7 days`,
+    },
+    day: {
+        periodTrunc: (col) => `${col}::date`,
+        spineStart: (col) => `make_date(year(${col}), 1, 1)`,
+        spineEnd: (col) => `make_date(year(${col}), 12, 31)`,
+        step: `interval 1 day`,
+    },
+}
+
+export function queryStreamDiscoveryStats(
+    year: number | undefined,
+    entity: Entity
+): string {
+    const yearCondition = buildYearCondition(year)
+    const newCondition =
+        year !== undefined ? `year(f.first_date) = ${year}` : 'true'
+    return sqlQueryStreamDiscoveryStats
+        .replaceAll('${entity_column}', ENTITY_COLUMN[entity])
+        .replaceAll('${table}', TABLE)
+        .replaceAll('${year_condition}', yearCondition)
+        .replaceAll('${new_condition}', newCondition)
+}
+
+export function queryStreamDiscovery(
+    year: number | undefined,
+    granularity: Granularity,
+    entity: Entity
+): string {
+    const yearCondition = buildYearCondition(year)
+    const perYear = year !== undefined
+    const { periodTrunc, spineStart, spineEnd, step } = GRAN_CONFIG[granularity]
+    const minExpr = `(select min(ts::date) from ${TABLE} where ${yearCondition})`
+    const maxExpr = `(select max(ts::date) from ${TABLE} where ${yearCondition})`
+
+    return sqlQueryStreamDiscovery
+        .replaceAll('${spineTimeTrunc}', periodTrunc('t.dt'))
+        .replaceAll('${firstDateTrunc}', periodTrunc('first_date'))
+        .replaceAll('${streamTimeTrunc}', periodTrunc('stream_date'))
+        .replaceAll('${entity_column}', ENTITY_COLUMN[entity])
+        .replaceAll('${spineStart}', spineStart(minExpr, perYear))
+        .replaceAll('${spineEnd}', spineEnd(maxExpr, perYear))
+        .replaceAll('${step}', step)
+        .replaceAll('${table}', TABLE)
+        .replaceAll('${year_condition}', yearCondition)
+}

--- a/app/src/components/Charts/LabView.test.tsx
+++ b/app/src/components/Charts/LabView.test.tsx
@@ -44,6 +44,12 @@ import {
     type Top10TracksEvolutionQueryResult,
     queryTop10TracksEvolution,
 } from './LabCharts/Top10TracksEvolution/query'
+import {
+    type StreamDiscoveryQueryResult,
+    type StreamDiscoveryStatsQueryResult,
+    queryStreamDiscovery,
+    queryStreamDiscoveryStats,
+} from './LabCharts/StreamDiscovery/query'
 
 const summarizedDataMock: SummarizeDataQueryResult[] = [
     {
@@ -120,6 +126,14 @@ const streamVarietyStatsMock: StreamVarietyStatsQueryResult[] = [
     { total_distinct: 2, total_repeat: 1, total_streams: 3 },
 ]
 
+const streamDiscoveryResultMock: StreamDiscoveryQueryResult[] = [
+    { ts: '2024-01-01', new_count: 1, known_count: 1, total_count: 2 },
+]
+
+const streamDiscoveryStatsMock: StreamDiscoveryStatsQueryResult[] = [
+    { total_new: 1, total_known: 1, total_distinct: 2 },
+]
+
 const top10TracksEvolutionResultMock: Top10TracksEvolutionQueryResult[] = [
     {
         year: 2024,
@@ -164,6 +178,10 @@ it('renders all Charts', async () => {
             return Promise.resolve(streamVarietyResultMock)
         if (query === queryStreamVarietyStats(2024, 'tracks'))
             return Promise.resolve(streamVarietyStatsMock)
+        if (query === queryStreamDiscovery(2024, 'month', 'tracks'))
+            return Promise.resolve(streamDiscoveryResultMock)
+        if (query === queryStreamDiscoveryStats(2024, 'tracks'))
+            return Promise.resolve(streamDiscoveryStatsMock)
         if (query === summarizePerYearQuery(2024))
             return Promise.resolve(summaryPerYearResultMock)
         if (query === queryArtistDiscovery())

--- a/app/src/components/Charts/LabView.tsx
+++ b/app/src/components/Charts/LabView.tsx
@@ -1,5 +1,6 @@
 import { StreamTimeline } from './LabCharts/StreamTimeline'
 import { StreamVariety } from './LabCharts/StreamVariety'
+import { StreamDiscovery } from './LabCharts/StreamDiscovery'
 import { SummaryPerYear } from './LabCharts/SummaryPerYear'
 import { YearSidebar } from '../YearSidebar/YearSidebar'
 import { useState, useEffect, useCallback } from 'react'
@@ -69,6 +70,7 @@ export function LabView() {
                     <div className="flex flex-col gap-4">
                         <StreamTimeline year={debouncedYear} />
                         <StreamVariety year={debouncedYear} />
+                        <StreamDiscovery year={debouncedYear} />
                         <SummaryPerYear year={debouncedYear} />
                         <ArtistDiscovery />
                         <StreamPerDayOfWeek year={debouncedYear} />


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Lab view shows how much a user listened (StreamTimeline), but not what kind of listening it was. StreamDiscovery is the second addition to a family of charts that answer complementary questions about listening behaviour.

## 🎹 Proposal

New `StreamDiscovery` chart. Stacked bar answering "How many items did I discover for the first time ever in each period?":

- Bottom segment (rose-800, darker): new entities — first listen ever, all-time look-back
- Top segment (rose-500, lighter): known entities — heard before this period

Controls: entity tabs (Tracks / Artists / Albums) in the card header, granularity tabs (Year / Month / Week / Day) in the card body. Global stats below the bars: total new entities discovered and discovery rate (new / total distinct).

SQL uses a `joined` CTE to isolate the multi-table JOIN, then a `tagged` CTE for period aggregation.

## 🎶 Comments

**Segment order and color:** "New" is the primary signal of this chart so it anchors the bottom of the bar. The bottom segment has a stable baseline at zero, making its height directly comparable across periods. The top segment floats and is harder to read. Darker shade at the bottom matches the StreamVariety convention (Distinct darker, at bottom). "Known" is lighter and sits on top.

`queryStreamDiscoveryStats` runs independently of granularity — it aggregates over the full selected period rather than summing per-period buckets, so the discovery rate stays consistent regardless of which granularity is active.

## 🎤 Test

```
moon run app:test -- src/components/Charts/LabCharts/StreamDiscovery/
```