### PR TITLE
feat(charts): warn on name collision risk for artists and albums entity

### DIFF
--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.test.tsx
@@ -170,4 +170,39 @@ describe('StreamDiscovery', () => {
         fireEvent.mouseEnter(bars[0])
         expect(document.querySelector('.fixed.z-50')).toBeNull()
     })
+
+    it('hides name collision warning when entity is tracks', () => {
+        render(
+            <StreamDiscovery
+                {...defaultProps}
+                entity="tracks"
+                data={twoMonths}
+            />
+        )
+        expect(
+            screen.queryByText(/Artist and album counts rely on names/)
+        ).toBeNull()
+    })
+
+    it('shows name collision warning when entity is artists', () => {
+        render(
+            <StreamDiscovery
+                {...defaultProps}
+                entity="artists"
+                data={twoMonths}
+            />
+        )
+        screen.getByText(/Artist and album counts rely on names/)
+    })
+
+    it('shows name collision warning when entity is albums', () => {
+        render(
+            <StreamDiscovery
+                {...defaultProps}
+                entity="albums"
+                data={twoMonths}
+            />
+        )
+        screen.getByText(/Artist and album counts rely on names/)
+    })
 })

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -291,6 +291,13 @@ export const StreamDiscovery: FC<Props> = ({
                             <span className="font-bold">{discoveryRate}%</span>
                         </li>
                     </ul>
+                    {entity !== 'tracks' && (
+                        <p className="mt-2 text-xs italic text-gray-400 dark:text-gray-500">
+                            Artist and album counts rely on names, not unique
+                            IDs. Two different artists or albums sharing the
+                            same name are counted as one.
+                        </p>
+                    )}
                 </>
             )}
             {tooltip && (

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.test.tsx
@@ -161,4 +161,31 @@ describe('StreamVariety', () => {
         fireEvent.mouseEnter(bars[0])
         expect(document.querySelector('.fixed.z-50')).toBeNull()
     })
+
+    it('hides name collision warning when entity is tracks', () => {
+        render(
+            <StreamVariety {...defaultProps} entity="tracks" data={twoMonths} />
+        )
+        expect(
+            screen.queryByText(/Artist and album counts rely on names/)
+        ).toBeNull()
+    })
+
+    it('shows name collision warning when entity is artists', () => {
+        render(
+            <StreamVariety
+                {...defaultProps}
+                entity="artists"
+                data={twoMonths}
+            />
+        )
+        screen.getByText(/Artist and album counts rely on names/)
+    })
+
+    it('shows name collision warning when entity is albums', () => {
+        render(
+            <StreamVariety {...defaultProps} entity="albums" data={twoMonths} />
+        )
+        screen.getByText(/Artist and album counts rely on names/)
+    })
 })

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -297,6 +297,13 @@ export const StreamVariety: FC<Props> = ({
                             <span className="font-bold">{varietyRate}%</span>
                         </li>
                     </ul>
+                    {entity !== 'tracks' && (
+                        <p className="mt-2 text-xs italic text-gray-400 dark:text-gray-500">
+                            Artist and album counts rely on names, not unique
+                            IDs. Two different artists or albums sharing the
+                            same name are counted as one.
+                        </p>
+                    )}
                 </>
             )}
             {tooltip && (


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

When switching Stream Variety or Stream Discovery to the Artists or Albums entity, the counts are based on plain string columns (`artist_name`, `album_name`). Two different artists or albums that share the same name are indistinguishable and counted as one. Users have no way of knowing this without reading the source code.

## 🎹 Proposal

A small italic note appears below the stats block whenever the active entity is Artists or Albums. It is hidden for Tracks, which uses a unique URI. The note is informational only and does not block any interaction.

## 🎶 Comments

The warning covers both charts (Stream Variety and Stream Discovery) with the same text, since the limitation is identical in both cases.

## 🎤 Test

1. Open the Lab view with a dataset that has streams.
2. In Stream Variety or Stream Discovery, switch the entity tab to Artists — the note appears below the stats.
3. Switch to Albums — the note remains visible.
4. Switch back to Tracks — the note disappears.