### PR TITLE
feat(charts): unified control bar for Top Race charts

### DIFF
--- a/app/src/components/Charts/LabCharts/Common/RaceControlBar.test.tsx
+++ b/app/src/components/Charts/LabCharts/Common/RaceControlBar.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { RaceControlBar } from './RaceControlBar'
+
+const startTs = 1704067200000 // 2024-01-01
+const endTs = 1735603200000 // 2024-12-31
+
+const defaultProps = {
+    frameCount: 10,
+    startTs,
+    endTs,
+    currentFrameIdx: 0,
+    speedMultiplier: 1,
+    isPlaying: false,
+    onFrameChange: vi.fn(),
+    onSpeedChange: vi.fn(),
+    onPlayPause: vi.fn(),
+}
+
+describe('RaceControlBar', () => {
+    it('renders start and end date labels', () => {
+        render(<RaceControlBar {...defaultProps} />)
+
+        const dates = screen.getAllByText(/2024/)
+        expect(dates.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('renders all speed buttons', () => {
+        render(<RaceControlBar {...defaultProps} />)
+
+        expect(screen.getByRole('button', { name: '0.5x' })).toBeDefined()
+        expect(screen.getByRole('button', { name: '1x' })).toBeDefined()
+        expect(screen.getByRole('button', { name: '2x' })).toBeDefined()
+        expect(screen.getByRole('button', { name: '4x' })).toBeDefined()
+    })
+
+    it('highlights the active speed button', () => {
+        render(<RaceControlBar {...defaultProps} speedMultiplier={2} />)
+
+        expect(screen.getByRole('button', { name: '2x' }).className).toContain(
+            'bg-blue-500'
+        )
+        expect(
+            screen.getByRole('button', { name: '1x' }).className
+        ).not.toContain('bg-blue-500')
+    })
+
+    it('shows Play button when not playing and not at end', () => {
+        render(
+            <RaceControlBar
+                {...defaultProps}
+                isPlaying={false}
+                currentFrameIdx={0}
+            />
+        )
+
+        expect(screen.getByRole('button', { name: 'Play' })).toBeDefined()
+    })
+
+    it('shows Pause button when playing', () => {
+        render(<RaceControlBar {...defaultProps} isPlaying={true} />)
+
+        expect(screen.getByRole('button', { name: 'Pause' })).toBeDefined()
+    })
+
+    it('shows Replay button when at last frame', () => {
+        render(
+            <RaceControlBar
+                {...defaultProps}
+                isPlaying={false}
+                currentFrameIdx={9}
+            />
+        )
+
+        expect(screen.getByRole('button', { name: 'Replay' })).toBeDefined()
+    })
+
+    it('calls onSpeedChange with correct value on speed button click', () => {
+        const onSpeedChange = vi.fn()
+        render(
+            <RaceControlBar {...defaultProps} onSpeedChange={onSpeedChange} />
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: '4x' }))
+        expect(onSpeedChange).toHaveBeenCalledWith(4)
+    })
+
+    it('calls onPlayPause on play button click', () => {
+        const onPlayPause = vi.fn()
+        render(<RaceControlBar {...defaultProps} onPlayPause={onPlayPause} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Play' }))
+        expect(onPlayPause).toHaveBeenCalledOnce()
+    })
+
+    it('calls onFrameChange with slider value', () => {
+        const onFrameChange = vi.fn()
+        render(
+            <RaceControlBar {...defaultProps} onFrameChange={onFrameChange} />
+        )
+
+        const slider = screen.getByRole('slider', {
+            name: 'Animation timeline',
+        })
+        fireEvent.change(slider, { target: { value: '5' } })
+        expect(onFrameChange).toHaveBeenCalledWith(5)
+    })
+})

--- a/app/src/components/Charts/LabCharts/Common/RaceControlBar.tsx
+++ b/app/src/components/Charts/LabCharts/Common/RaceControlBar.tsx
@@ -1,4 +1,4 @@
-type Props = {
+export type RaceControlBarProps = {
     frameCount: number
     startTs: number
     endTs: number
@@ -20,7 +20,7 @@ export function RaceControlBar({
     onFrameChange,
     onSpeedChange,
     onPlayPause,
-}: Props) {
+}: RaceControlBarProps) {
     const atEnd = currentFrameIdx >= frameCount - 1
 
     return (
@@ -53,6 +53,7 @@ export function RaceControlBar({
                 {([0.5, 1, 2, 4] as const).map((speed) => (
                     <button
                         key={speed}
+                        type="button"
                         onClick={() => onSpeedChange(speed)}
                         className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
                             speedMultiplier === speed
@@ -65,6 +66,7 @@ export function RaceControlBar({
                 ))}
                 <div className="w-px h-4 bg-gray-300/50 dark:bg-slate-600/50 mx-1" />
                 <button
+                    type="button"
                     onClick={onPlayPause}
                     aria-label={isPlaying ? 'Pause' : atEnd ? 'Replay' : 'Play'}
                     title={isPlaying ? 'Pause' : atEnd ? 'Replay' : 'Play'}

--- a/app/src/components/Charts/LabCharts/Common/RaceControlBar.tsx
+++ b/app/src/components/Charts/LabCharts/Common/RaceControlBar.tsx
@@ -1,0 +1,103 @@
+type Props = {
+    frameCount: number
+    startTs: number
+    endTs: number
+    currentFrameIdx: number
+    speedMultiplier: number
+    isPlaying: boolean
+    onFrameChange: (idx: number) => void
+    onSpeedChange: (speed: number) => void
+    onPlayPause: () => void
+}
+
+export function RaceControlBar({
+    frameCount,
+    startTs,
+    endTs,
+    currentFrameIdx,
+    speedMultiplier,
+    isPlaying,
+    onFrameChange,
+    onSpeedChange,
+    onPlayPause,
+}: Props) {
+    const atEnd = currentFrameIdx >= frameCount - 1
+
+    return (
+        <div className="flex items-center gap-2 w-full bg-gray-100/50 dark:bg-slate-800/60 p-2 rounded-xl border border-gray-200/30 dark:border-slate-700/40">
+            <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none shrink-0">
+                {new Date(startTs).toLocaleDateString(undefined, {
+                    year: 'numeric',
+                    month: 'short',
+                })}
+            </span>
+            <input
+                type="range"
+                aria-label="Animation timeline"
+                min={0}
+                max={frameCount - 1}
+                value={currentFrameIdx}
+                onChange={(e) => onFrameChange(Number(e.target.value))}
+                className="flex-1 h-1.5 bg-gray-200 dark:bg-slate-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
+            />
+            <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none shrink-0">
+                {new Date(endTs).toLocaleDateString(undefined, {
+                    year: 'numeric',
+                    month: 'short',
+                })}
+            </span>
+            <div className="flex items-center bg-gray-200/80 dark:bg-slate-700/80 rounded-lg p-1 shrink-0">
+                {([0.5, 1, 2, 4] as const).map((speed) => (
+                    <button
+                        key={speed}
+                        onClick={() => onSpeedChange(speed)}
+                        className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
+                            speedMultiplier === speed
+                                ? 'bg-blue-500 text-white shadow-sm'
+                                : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
+                        }`}
+                    >
+                        {speed}x
+                    </button>
+                ))}
+            </div>
+            <button
+                onClick={onPlayPause}
+                aria-label={isPlaying ? 'Pause' : atEnd ? 'Replay' : 'Play'}
+                title={isPlaying ? 'Pause' : atEnd ? 'Replay' : 'Play'}
+                className="p-2 bg-gray-200 dark:bg-slate-700 hover:bg-gray-300 dark:hover:bg-slate-600 rounded-lg transition-colors shrink-0"
+            >
+                {isPlaying ? (
+                    <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        fill="currentColor"
+                    >
+                        <rect x="3" y="2" width="4" height="12" rx="1" />
+                        <rect x="9" y="2" width="4" height="12" rx="1" />
+                    </svg>
+                ) : atEnd ? (
+                    <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        fill="currentColor"
+                    >
+                        <path d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z" />
+                        <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z" />
+                    </svg>
+                ) : (
+                    <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        fill="currentColor"
+                    >
+                        <path d="M11.596 8.697l-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393z" />
+                    </svg>
+                )}
+            </button>
+        </div>
+    )
+}

--- a/app/src/components/Charts/LabCharts/Common/RaceControlBar.tsx
+++ b/app/src/components/Charts/LabCharts/Common/RaceControlBar.tsx
@@ -24,29 +24,32 @@ export function RaceControlBar({
     const atEnd = currentFrameIdx >= frameCount - 1
 
     return (
-        <div className="flex items-center gap-2 w-full bg-gray-100/50 dark:bg-slate-800/60 p-2 rounded-xl border border-gray-200/30 dark:border-slate-700/40">
-            <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none shrink-0">
-                {new Date(startTs).toLocaleDateString(undefined, {
-                    year: 'numeric',
-                    month: 'short',
-                })}
-            </span>
-            <input
-                type="range"
-                aria-label="Animation timeline"
-                min={0}
-                max={frameCount - 1}
-                value={currentFrameIdx}
-                onChange={(e) => onFrameChange(Number(e.target.value))}
-                className="flex-1 h-1.5 bg-gray-200 dark:bg-slate-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
-            />
-            <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none shrink-0">
-                {new Date(endTs).toLocaleDateString(undefined, {
-                    year: 'numeric',
-                    month: 'short',
-                })}
-            </span>
-            <div className="flex items-center bg-gray-200/80 dark:bg-slate-700/80 rounded-lg p-1 shrink-0">
+        <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 w-full bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30">
+            <div className="flex items-center gap-2 flex-1 min-w-0 px-1">
+                <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none shrink-0">
+                    {new Date(startTs).toLocaleDateString(undefined, {
+                        year: 'numeric',
+                        month: 'short',
+                    })}
+                </span>
+                <input
+                    type="range"
+                    aria-label="Animation timeline"
+                    min={0}
+                    max={frameCount - 1}
+                    value={currentFrameIdx}
+                    onChange={(e) => onFrameChange(Number(e.target.value))}
+                    className="flex-1 h-1.5 bg-gray-200 dark:bg-slate-700 rounded-lg appearance-none cursor-pointer accent-blue-500 min-w-0"
+                />
+                <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none shrink-0">
+                    {new Date(endTs).toLocaleDateString(undefined, {
+                        year: 'numeric',
+                        month: 'short',
+                    })}
+                </span>
+            </div>
+
+            <div className="flex items-center shrink-0 self-center sm:self-auto">
                 {([0.5, 1, 2, 4] as const).map((speed) => (
                     <button
                         key={speed}
@@ -60,44 +63,45 @@ export function RaceControlBar({
                         {speed}x
                     </button>
                 ))}
+                <div className="w-px h-4 bg-gray-300/50 dark:bg-slate-600/50 mx-1" />
+                <button
+                    onClick={onPlayPause}
+                    aria-label={isPlaying ? 'Pause' : atEnd ? 'Replay' : 'Play'}
+                    title={isPlaying ? 'Pause' : atEnd ? 'Replay' : 'Play'}
+                    className="p-1.5 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white rounded-md transition-all"
+                >
+                    {isPlaying ? (
+                        <svg
+                            width="16"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            fill="currentColor"
+                        >
+                            <rect x="3" y="2" width="4" height="12" rx="1" />
+                            <rect x="9" y="2" width="4" height="12" rx="1" />
+                        </svg>
+                    ) : atEnd ? (
+                        <svg
+                            width="16"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            fill="currentColor"
+                        >
+                            <path d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z" />
+                            <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z" />
+                        </svg>
+                    ) : (
+                        <svg
+                            width="16"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            fill="currentColor"
+                        >
+                            <path d="M11.596 8.697l-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393z" />
+                        </svg>
+                    )}
+                </button>
             </div>
-            <button
-                onClick={onPlayPause}
-                aria-label={isPlaying ? 'Pause' : atEnd ? 'Replay' : 'Play'}
-                title={isPlaying ? 'Pause' : atEnd ? 'Replay' : 'Play'}
-                className="p-2 bg-gray-200 dark:bg-slate-700 hover:bg-gray-300 dark:hover:bg-slate-600 rounded-lg transition-colors shrink-0"
-            >
-                {isPlaying ? (
-                    <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 16 16"
-                        fill="currentColor"
-                    >
-                        <rect x="3" y="2" width="4" height="12" rx="1" />
-                        <rect x="9" y="2" width="4" height="12" rx="1" />
-                    </svg>
-                ) : atEnd ? (
-                    <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 16 16"
-                        fill="currentColor"
-                    >
-                        <path d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z" />
-                        <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z" />
-                    </svg>
-                ) : (
-                    <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 16 16"
-                        fill="currentColor"
-                    >
-                        <path d="M11.596 8.697l-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393z" />
-                    </svg>
-                )}
-            </button>
         </div>
     )
 }

--- a/app/src/components/Charts/LabCharts/Common/useRacePlayback.test.ts
+++ b/app/src/components/Charts/LabCharts/Common/useRacePlayback.test.ts
@@ -1,0 +1,173 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useRacePlayback } from './useRacePlayback'
+
+beforeEach(() => {
+    vi.useFakeTimers()
+    // The global setupFiles mock fires on observe(), but containerRef.current is null
+    // in renderHook (no DOM rendered), so observe() is never called and isVisible stays
+    // false. This override fires in the constructor instead so isVisible=true without DOM.
+    vi.stubGlobal(
+        'IntersectionObserver',
+        class {
+            constructor(private cb: IntersectionObserverCallback) {
+                cb(
+                    [{ isIntersecting: true } as IntersectionObserverEntry],
+                    this as unknown as IntersectionObserver
+                )
+            }
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        }
+    )
+})
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+})
+
+const defaultOptions = { frameCount: 5, baseSpeed: 100, entityType: 'artists' }
+
+describe('useRacePlayback', () => {
+    it('returns initial state', () => {
+        const { result } = renderHook(() => useRacePlayback(defaultOptions))
+
+        expect(result.current.currentFrameIdx).toBe(0)
+        expect(result.current.isPlaying).toBe(false)
+        expect(result.current.speedMultiplier).toBe(1)
+    })
+
+    it('does not auto-play on initial render', () => {
+        const { result } = renderHook(() => useRacePlayback(defaultOptions))
+
+        expect(result.current.isPlaying).toBe(false)
+    })
+
+    describe('onFrameChange', () => {
+        it('sets current frame index', () => {
+            const { result } = renderHook(() => useRacePlayback(defaultOptions))
+
+            act(() => result.current.onFrameChange(3))
+
+            expect(result.current.currentFrameIdx).toBe(3)
+        })
+
+        it('stops playback', () => {
+            const { result } = renderHook(() => useRacePlayback(defaultOptions))
+
+            act(() => result.current.onPlayPause())
+            act(() => result.current.onFrameChange(2))
+
+            expect(result.current.isPlaying).toBe(false)
+        })
+    })
+
+    describe('onSpeedChange', () => {
+        it('updates speed multiplier', () => {
+            const { result } = renderHook(() => useRacePlayback(defaultOptions))
+
+            act(() => result.current.onSpeedChange(4))
+
+            expect(result.current.speedMultiplier).toBe(4)
+        })
+    })
+
+    describe('onPlayPause', () => {
+        it('starts playback when paused at start', () => {
+            const { result } = renderHook(() => useRacePlayback(defaultOptions))
+
+            act(() => result.current.onPlayPause())
+
+            expect(result.current.isPlaying).toBe(true)
+        })
+
+        it('pauses when playing', () => {
+            const { result } = renderHook(() => useRacePlayback(defaultOptions))
+
+            act(() => result.current.onPlayPause())
+            act(() => result.current.onPlayPause())
+
+            expect(result.current.isPlaying).toBe(false)
+        })
+
+        it('resets to frame 0 and plays when at last frame', () => {
+            const { result } = renderHook(() => useRacePlayback(defaultOptions))
+
+            act(() => result.current.onFrameChange(4))
+            act(() => result.current.onPlayPause())
+
+            expect(result.current.currentFrameIdx).toBe(0)
+            expect(result.current.isPlaying).toBe(true)
+        })
+    })
+
+    describe('playback', () => {
+        it('advances frames on interval', () => {
+            const { result } = renderHook(() => useRacePlayback(defaultOptions))
+
+            act(() => result.current.onPlayPause())
+            // baseSpeed=100ms, 2 intervals
+            act(() => vi.advanceTimersByTime(250))
+
+            expect(result.current.currentFrameIdx).toBe(2)
+        })
+
+        it('stops at last frame and sets isPlaying=false', () => {
+            const { result } = renderHook(() => useRacePlayback(defaultOptions))
+
+            act(() => result.current.onPlayPause())
+            // frameCount=5, last index=4: needs 5 intervals (t=500 triggers stop)
+            act(() => vi.advanceTimersByTime(600))
+
+            expect(result.current.currentFrameIdx).toBe(4)
+            expect(result.current.isPlaying).toBe(false)
+        })
+
+        it('speed multiplier reduces interval duration', () => {
+            const { result } = renderHook(() => useRacePlayback(defaultOptions))
+
+            act(() => result.current.onSpeedChange(2))
+            act(() => result.current.onPlayPause())
+            // At 2x: interval = 100/2 = 50ms. After 100ms: 2 frames advanced
+            act(() => vi.advanceTimersByTime(100))
+
+            expect(result.current.currentFrameIdx).toBe(2)
+        })
+
+        it('does not advance when frameCount is 0', () => {
+            const { result } = renderHook(() =>
+                useRacePlayback({ ...defaultOptions, frameCount: 0 })
+            )
+
+            act(() => result.current.onPlayPause())
+            act(() => vi.advanceTimersByTime(500))
+
+            expect(result.current.currentFrameIdx).toBe(0)
+        })
+    })
+
+    describe('entityType change', () => {
+        it('resets frame to 0 and starts playing', () => {
+            const { result, rerender } = renderHook(
+                ({ entityType }) =>
+                    useRacePlayback({ ...defaultOptions, entityType }),
+                { initialProps: { entityType: 'artists' } }
+            )
+
+            act(() => result.current.onFrameChange(3))
+            rerender({ entityType: 'tracks' })
+
+            expect(result.current.currentFrameIdx).toBe(0)
+            expect(result.current.isPlaying).toBe(true)
+        })
+
+        it('does not reset on initial render', () => {
+            const { result } = renderHook(() => useRacePlayback(defaultOptions))
+
+            expect(result.current.currentFrameIdx).toBe(0)
+            expect(result.current.isPlaying).toBe(false)
+        })
+    })
+})

--- a/app/src/components/Charts/LabCharts/Common/useRacePlayback.ts
+++ b/app/src/components/Charts/LabCharts/Common/useRacePlayback.ts
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from 'react'
+
+type Options = {
+    frameCount: number
+    baseSpeed: number
+    entityType: string
+}
+
+type RacePlayback = {
+    containerRef: React.RefObject<HTMLDivElement | null>
+    currentFrameIdx: number
+    isPlaying: boolean
+    speedMultiplier: number
+    onFrameChange: (idx: number) => void
+    onSpeedChange: (speed: number) => void
+    onPlayPause: () => void
+}
+
+export function useRacePlayback({
+    frameCount,
+    baseSpeed,
+    entityType,
+}: Options): RacePlayback {
+    const [currentFrameIdx, setCurrentFrameIdx] = useState(0)
+    const [isPlaying, setIsPlaying] = useState(false)
+    const [speedMultiplier, setSpeedMultiplier] = useState(1)
+    const [isVisible, setIsVisible] = useState(false)
+    const containerRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                setIsVisible(entry.isIntersecting)
+            },
+            { threshold: 0.1 }
+        )
+
+        const el = containerRef.current
+        if (el) observer.observe(el)
+        return () => {
+            if (el) observer.unobserve(el)
+        }
+    }, [])
+
+    const hasInitialized = useRef(false)
+    useEffect(() => {
+        if (!hasInitialized.current) {
+            hasInitialized.current = true
+            return
+        }
+        setCurrentFrameIdx(0)
+        setIsPlaying(true)
+    }, [entityType])
+
+    useEffect(() => {
+        if (!isPlaying || !isVisible || frameCount === 0) return
+
+        const interval = setInterval(() => {
+            setCurrentFrameIdx((prev) => {
+                if (prev >= frameCount - 1) {
+                    setIsPlaying(false)
+                    return prev
+                }
+                return prev + 1
+            })
+        }, baseSpeed / speedMultiplier)
+
+        return () => clearInterval(interval)
+    }, [isPlaying, isVisible, frameCount, baseSpeed, speedMultiplier])
+
+    const onFrameChange = (idx: number) => {
+        setIsPlaying(false)
+        setCurrentFrameIdx(idx)
+    }
+
+    const onPlayPause = () => {
+        if (currentFrameIdx >= frameCount - 1) {
+            setCurrentFrameIdx(0)
+            setIsPlaying(true)
+        } else {
+            setIsPlaying((prev) => !prev)
+        }
+    }
+
+    return {
+        containerRef,
+        currentFrameIdx,
+        isPlaying,
+        speedMultiplier,
+        onFrameChange,
+        onSpeedChange: setSpeedMultiplier,
+        onPlayPause,
+    }
+}

--- a/app/src/components/Charts/LabCharts/Top10BillboardRace/Top10BillboardRaceView.test.tsx
+++ b/app/src/components/Charts/LabCharts/Top10BillboardRace/Top10BillboardRaceView.test.tsx
@@ -47,32 +47,6 @@ describe('Top10BillboardRaceView', () => {
         expect(screen.getAllByText(/\dw$/).length).toBeGreaterThan(0)
     })
 
-    it('renders the lambda selector with five buttons', () => {
-        render(<Top10BillboardRaceView data={mockData} entityType="artists" />)
-
-        expect(screen.getByRole('button', { name: 'λ0.1' })).toBeDefined()
-        expect(screen.getByRole('button', { name: 'λ0.2' })).toBeDefined()
-        expect(screen.getByRole('button', { name: 'λ0.3' })).toBeDefined()
-        expect(screen.getByRole('button', { name: 'λ0.4' })).toBeDefined()
-        expect(screen.getByRole('button', { name: 'λ0.5' })).toBeDefined()
-
-        const defaultButton = screen.getByRole('button', { name: 'λ0.2' })
-        expect(defaultButton.className).toContain('bg-blue-500')
-    })
-
-    it('allows changing lambda value', () => {
-        render(<Top10BillboardRaceView data={mockData} entityType="artists" />)
-
-        const lambda02 = screen.getByRole('button', { name: 'λ0.2' })
-        const lambda03 = screen.getByRole('button', { name: 'λ0.3' })
-
-        expect(lambda02.className).toContain('bg-blue-500')
-
-        fireEvent.click(lambda03)
-        expect(lambda03.className).toContain('bg-blue-500')
-        expect(lambda02.className).not.toContain('bg-blue-500')
-    })
-
     it('allows changing animation speed', () => {
         render(<Top10BillboardRaceView data={mockData} entityType="artists" />)
 
@@ -139,19 +113,5 @@ describe('Top10BillboardRaceView', () => {
         fireEvent.change(slider, { target: { value: '1' } })
 
         expect(screen.getByRole('button', { name: 'Replay' })).toBeDefined()
-    })
-
-    it('resets to frame 0 but preserves play state when lambda changes', () => {
-        vi.useFakeTimers()
-        render(<Top10BillboardRaceView data={mockData} entityType="artists" />)
-
-        expect(screen.getByRole('button', { name: 'Play' })).toBeDefined()
-
-        const lambda05 = screen.getByRole('button', { name: 'λ0.5' })
-        fireEvent.click(lambda05)
-
-        expect(screen.getByRole('button', { name: 'Play' })).toBeDefined()
-
-        vi.useRealTimers()
     })
 })

--- a/app/src/components/Charts/LabCharts/Top10BillboardRace/Top10BillboardRaceView.tsx
+++ b/app/src/components/Charts/LabCharts/Top10BillboardRace/Top10BillboardRaceView.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState, useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 import type { EntityType, Top10BillboardRaceQueryResult } from './query'
 import { GhostLeaderboard, type GhostEntry } from './GhostLeaderboard'
 import { InsightCard } from '../../SimpleCharts/shared'
 import { BAR_CHART_COLORS } from '../barChartColors'
 import { RaceControlBar } from '../Common/RaceControlBar'
+import { useRacePlayback } from '../Common/useRacePlayback'
 
 type Props = {
     data: Top10BillboardRaceQueryResult[]
@@ -29,12 +30,6 @@ const SCORE_COL_WIDTH = 62
 const LAMBDA = 0.2
 
 export function Top10BillboardRaceView({ data, entityType }: Props) {
-    const [currentFrameIdx, setCurrentFrameIdx] = useState(0)
-    const [isPlaying, setIsPlaying] = useState(false)
-    const [speedMultiplier, setSpeedMultiplier] = useState(1)
-    const [isVisible, setIsVisible] = useState(false)
-    const containerRef = useRef<HTMLDivElement>(null)
-
     const { frames, entityColors, streakRecord } = useMemo(() => {
         const uniquePeriods = [...new Set(data.map((d) => d.period_ts))].sort(
             (a, b) => a - b
@@ -146,58 +141,26 @@ export function Top10BillboardRaceView({ data, entityType }: Props) {
         return { frames: allFrames, entityColors: colorMap, streakRecord }
     }, [data])
 
+    const {
+        containerRef,
+        currentFrameIdx,
+        isPlaying,
+        speedMultiplier,
+        onFrameChange,
+        onSpeedChange,
+        onPlayPause,
+    } = useRacePlayback({
+        frameCount: frames.length,
+        baseSpeed: BASE_SPEED,
+        entityType,
+    })
+
     const currentFrame = frames[currentFrameIdx]
 
     const activeLabels = useMemo(
         () => new Set(currentFrame?.top10.map((e) => e.label) ?? []),
         [currentFrame]
     )
-
-    useEffect(() => {
-        const observer = new IntersectionObserver(
-            ([entry]) => {
-                setIsVisible(entry.isIntersecting)
-            },
-            { threshold: 0.1 }
-        )
-
-        const currentRef = containerRef.current
-        if (currentRef) {
-            observer.observe(currentRef)
-        }
-
-        return () => {
-            if (currentRef) {
-                observer.unobserve(currentRef)
-            }
-        }
-    }, [])
-
-    const hasInitializedEntity = useRef(false)
-    useEffect(() => {
-        if (!hasInitializedEntity.current) {
-            hasInitializedEntity.current = true
-            return
-        }
-        setCurrentFrameIdx(0)
-        setIsPlaying(true)
-    }, [entityType])
-
-    useEffect(() => {
-        if (!isPlaying || !isVisible || frames.length === 0) return
-
-        const interval = setInterval(() => {
-            setCurrentFrameIdx((prev) => {
-                if (prev >= frames.length - 1) {
-                    setIsPlaying(false)
-                    return prev
-                }
-                return prev + 1
-            })
-        }, BASE_SPEED / speedMultiplier)
-
-        return () => clearInterval(interval)
-    }, [isPlaying, isVisible, frames.length, speedMultiplier])
 
     if (!currentFrame) return null
 
@@ -312,7 +275,7 @@ export function Top10BillboardRaceView({ data, entityType }: Props) {
                     </div>
 
                     <p className="text-[10px] text-gray-400 dark:text-gray-600 text-center mt-2">
-                        Score = Σ streams × e^(−λ×Δweeks) · λ = 0.2
+                        Score = Σ streams × e^(−0.2×Δweeks)
                     </p>
                 </div>
             </div>
@@ -325,19 +288,9 @@ export function Top10BillboardRaceView({ data, entityType }: Props) {
                     currentFrameIdx={currentFrameIdx}
                     speedMultiplier={speedMultiplier}
                     isPlaying={isPlaying}
-                    onFrameChange={(idx) => {
-                        setIsPlaying(false)
-                        setCurrentFrameIdx(idx)
-                    }}
-                    onSpeedChange={setSpeedMultiplier}
-                    onPlayPause={() => {
-                        if (currentFrameIdx >= frames.length - 1) {
-                            setCurrentFrameIdx(0)
-                            setIsPlaying(true)
-                        } else {
-                            setIsPlaying((prev) => !prev)
-                        }
-                    }}
+                    onFrameChange={onFrameChange}
+                    onSpeedChange={onSpeedChange}
+                    onPlayPause={onPlayPause}
                 />
             )}
         </div>

--- a/app/src/components/Charts/LabCharts/Top10BillboardRace/Top10BillboardRaceView.tsx
+++ b/app/src/components/Charts/LabCharts/Top10BillboardRace/Top10BillboardRaceView.tsx
@@ -3,6 +3,7 @@ import type { EntityType, Top10BillboardRaceQueryResult } from './query'
 import { GhostLeaderboard, type GhostEntry } from './GhostLeaderboard'
 import { InsightCard } from '../../SimpleCharts/shared'
 import { BAR_CHART_COLORS } from '../barChartColors'
+import { RaceControlBar } from '../Common/RaceControlBar'
 
 type Props = {
     data: Top10BillboardRaceQueryResult[]
@@ -317,117 +318,27 @@ export function Top10BillboardRaceView({ data, entityType }: Props) {
             </div>
 
             {frames.length > 1 && (
-                <div className="flex items-center gap-2 w-full bg-gray-100/50 dark:bg-slate-800/60 p-2 rounded-xl border border-gray-200/30 dark:border-slate-700/40">
-                    <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none shrink-0">
-                        {new Date(frames[0].periodTs).toLocaleDateString(
-                            undefined,
-                            { year: 'numeric', month: 'short' }
-                        )}
-                    </span>
-                    <input
-                        type="range"
-                        aria-label="Animation timeline"
-                        min={0}
-                        max={frames.length - 1}
-                        value={currentFrameIdx}
-                        onChange={(e) => {
-                            setIsPlaying(false)
-                            setCurrentFrameIdx(Number(e.target.value))
-                        }}
-                        className="flex-1 h-1.5 bg-gray-200 dark:bg-slate-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
-                    />
-                    <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none shrink-0">
-                        {new Date(
-                            frames[frames.length - 1].periodTs
-                        ).toLocaleDateString(undefined, {
-                            year: 'numeric',
-                            month: 'short',
-                        })}
-                    </span>
-                    <div className="flex items-center bg-gray-200/80 dark:bg-slate-700/80 rounded-lg p-1 shrink-0">
-                        {([0.5, 1, 2, 4] as const).map((speed) => (
-                            <button
-                                key={speed}
-                                onClick={() => setSpeedMultiplier(speed)}
-                                className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
-                                    speedMultiplier === speed
-                                        ? 'bg-blue-500 text-white shadow-sm'
-                                        : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-                                }`}
-                            >
-                                {speed}x
-                            </button>
-                        ))}
-                    </div>
-                    <button
-                        onClick={() => {
-                            if (currentFrameIdx >= frames.length - 1) {
-                                setCurrentFrameIdx(0)
-                                setIsPlaying(true)
-                            } else {
-                                setIsPlaying(!isPlaying)
-                            }
-                        }}
-                        aria-label={
-                            isPlaying
-                                ? 'Pause'
-                                : currentFrameIdx >= frames.length - 1
-                                  ? 'Replay'
-                                  : 'Play'
+                <RaceControlBar
+                    frameCount={frames.length}
+                    startTs={frames[0].periodTs}
+                    endTs={frames[frames.length - 1].periodTs}
+                    currentFrameIdx={currentFrameIdx}
+                    speedMultiplier={speedMultiplier}
+                    isPlaying={isPlaying}
+                    onFrameChange={(idx) => {
+                        setIsPlaying(false)
+                        setCurrentFrameIdx(idx)
+                    }}
+                    onSpeedChange={setSpeedMultiplier}
+                    onPlayPause={() => {
+                        if (currentFrameIdx >= frames.length - 1) {
+                            setCurrentFrameIdx(0)
+                            setIsPlaying(true)
+                        } else {
+                            setIsPlaying(!isPlaying)
                         }
-                        title={
-                            isPlaying
-                                ? 'Pause'
-                                : currentFrameIdx >= frames.length - 1
-                                  ? 'Replay'
-                                  : 'Play'
-                        }
-                        className="p-2 bg-gray-200 dark:bg-slate-700 hover:bg-gray-300 dark:hover:bg-slate-600 rounded-lg transition-colors shrink-0"
-                    >
-                        {isPlaying ? (
-                            <svg
-                                width="16"
-                                height="16"
-                                viewBox="0 0 16 16"
-                                fill="currentColor"
-                            >
-                                <rect
-                                    x="3"
-                                    y="2"
-                                    width="4"
-                                    height="12"
-                                    rx="1"
-                                />
-                                <rect
-                                    x="9"
-                                    y="2"
-                                    width="4"
-                                    height="12"
-                                    rx="1"
-                                />
-                            </svg>
-                        ) : currentFrameIdx >= frames.length - 1 ? (
-                            <svg
-                                width="16"
-                                height="16"
-                                viewBox="0 0 16 16"
-                                fill="currentColor"
-                            >
-                                <path d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z" />
-                                <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z" />
-                            </svg>
-                        ) : (
-                            <svg
-                                width="16"
-                                height="16"
-                                viewBox="0 0 16 16"
-                                fill="currentColor"
-                            >
-                                <path d="M11.596 8.697l-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393z" />
-                            </svg>
-                        )}
-                    </button>
-                </div>
+                    }}
+                />
             )}
         </div>
     )

--- a/app/src/components/Charts/LabCharts/Top10BillboardRace/Top10BillboardRaceView.tsx
+++ b/app/src/components/Charts/LabCharts/Top10BillboardRace/Top10BillboardRaceView.tsx
@@ -335,7 +335,7 @@ export function Top10BillboardRaceView({ data, entityType }: Props) {
                             setCurrentFrameIdx(0)
                             setIsPlaying(true)
                         } else {
-                            setIsPlaying(!isPlaying)
+                            setIsPlaying((prev) => !prev)
                         }
                     }}
                 />

--- a/app/src/components/Charts/LabCharts/Top10BillboardRace/Top10BillboardRaceView.tsx
+++ b/app/src/components/Charts/LabCharts/Top10BillboardRace/Top10BillboardRaceView.tsx
@@ -25,12 +25,12 @@ type Frame = {
 const BASE_SPEED = 240
 const BAR_STRIDE = 44
 const SCORE_COL_WIDTH = 62
+const LAMBDA = 0.2
 
 export function Top10BillboardRaceView({ data, entityType }: Props) {
     const [currentFrameIdx, setCurrentFrameIdx] = useState(0)
     const [isPlaying, setIsPlaying] = useState(false)
     const [speedMultiplier, setSpeedMultiplier] = useState(1)
-    const [lambda, setLambda] = useState(0.2)
     const [isVisible, setIsVisible] = useState(false)
     const containerRef = useRef<HTMLDivElement>(null)
 
@@ -38,7 +38,7 @@ export function Top10BillboardRaceView({ data, entityType }: Props) {
         const uniquePeriods = [...new Set(data.map((d) => d.period_ts))].sort(
             (a, b) => a - b
         )
-        const decay = Math.exp(-lambda)
+        const decay = Math.exp(-LAMBDA)
 
         const dataByPeriod = new Map<
             number,
@@ -143,7 +143,7 @@ export function Top10BillboardRaceView({ data, entityType }: Props) {
         }
 
         return { frames: allFrames, entityColors: colorMap, streakRecord }
-    }, [data, lambda])
+    }, [data])
 
     const currentFrame = frames[currentFrameIdx]
 
@@ -182,15 +182,6 @@ export function Top10BillboardRaceView({ data, entityType }: Props) {
         setIsPlaying(true)
     }, [entityType])
 
-    const hasInitializedLambda = useRef(false)
-    useEffect(() => {
-        if (!hasInitializedLambda.current) {
-            hasInitializedLambda.current = true
-            return
-        }
-        setCurrentFrameIdx(0)
-    }, [lambda])
-
     useEffect(() => {
         if (!isPlaying || !isVisible || frames.length === 0) return
 
@@ -211,157 +202,20 @@ export function Top10BillboardRaceView({ data, entityType }: Props) {
 
     return (
         <div ref={containerRef} className="flex flex-col gap-4 w-full">
-            <div className="flex items-center justify-between flex-wrap gap-4">
-                <h4 className="text-2xl font-bold font-mono tracking-tight text-gray-800 dark:text-gray-100">
-                    {'Week of ' +
-                        new Date(currentFrame.periodTs).toLocaleDateString(
-                            undefined,
-                            {
-                                year: 'numeric',
-                                month: 'long',
-                                day: 'numeric',
-                            }
-                        )}
-                    <span className="text-sm font-normal text-gray-400 dark:text-gray-500 ml-2 font-sans">
-                        · weekly
-                    </span>
-                </h4>
-                <div className="flex items-center gap-4 flex-wrap">
-                    <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30">
-                        {([0.1, 0.2, 0.3, 0.4, 0.5] as const).map((l) => (
-                            <button
-                                key={l}
-                                onClick={() => setLambda(l)}
-                                className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
-                                    lambda === l
-                                        ? 'bg-blue-500 text-white shadow-sm'
-                                        : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-                                }`}
-                            >
-                                λ{l}
-                            </button>
-                        ))}
-                    </div>
-
-                    <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30">
-                        {([0.5, 1, 2, 4] as const).map((speed) => (
-                            <button
-                                key={speed}
-                                onClick={() => setSpeedMultiplier(speed)}
-                                className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
-                                    speedMultiplier === speed
-                                        ? 'bg-blue-500 text-white shadow-sm'
-                                        : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-                                }`}
-                            >
-                                {speed}x
-                            </button>
-                        ))}
-                    </div>
-
-                    <div className="flex items-center gap-2">
-                        <button
-                            onClick={() => {
-                                if (currentFrameIdx >= frames.length - 1) {
-                                    setCurrentFrameIdx(0)
-                                    setIsPlaying(true)
-                                } else {
-                                    setIsPlaying(!isPlaying)
-                                }
-                            }}
-                            aria-label={
-                                isPlaying
-                                    ? 'Pause'
-                                    : currentFrameIdx >= frames.length - 1
-                                      ? 'Replay'
-                                      : 'Play'
-                            }
-                            title={
-                                isPlaying
-                                    ? 'Pause'
-                                    : currentFrameIdx >= frames.length - 1
-                                      ? 'Replay'
-                                      : 'Play'
-                            }
-                            className="p-2 bg-gray-200 dark:bg-slate-700 hover:bg-gray-300 dark:hover:bg-slate-600 rounded-lg transition-colors"
-                        >
-                            {isPlaying ? (
-                                <svg
-                                    width="16"
-                                    height="16"
-                                    viewBox="0 0 16 16"
-                                    fill="currentColor"
-                                >
-                                    <rect
-                                        x="3"
-                                        y="2"
-                                        width="4"
-                                        height="12"
-                                        rx="1"
-                                    />
-                                    <rect
-                                        x="9"
-                                        y="2"
-                                        width="4"
-                                        height="12"
-                                        rx="1"
-                                    />
-                                </svg>
-                            ) : currentFrameIdx >= frames.length - 1 ? (
-                                <svg
-                                    width="16"
-                                    height="16"
-                                    viewBox="0 0 16 16"
-                                    fill="currentColor"
-                                >
-                                    <path d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z" />
-                                    <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z" />
-                                </svg>
-                            ) : (
-                                <svg
-                                    width="16"
-                                    height="16"
-                                    viewBox="0 0 16 16"
-                                    fill="currentColor"
-                                >
-                                    <path d="M11.596 8.697l-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393z" />
-                                </svg>
-                            )}
-                        </button>
-                    </div>
-                </div>
-            </div>
-
-            {frames.length > 1 && (
-                <div className="flex items-center gap-3 w-full bg-gray-50/50 dark:bg-slate-800/20 p-2.5 rounded-xl border border-gray-200/50 dark:border-slate-800/50">
-                    <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none">
-                        {new Date(frames[0].periodTs).toLocaleDateString(
-                            undefined,
-                            { year: 'numeric', month: 'short' }
-                        )}
-                    </span>
-                    <input
-                        type="range"
-                        aria-label="Animation timeline"
-                        min={0}
-                        max={frames.length - 1}
-                        value={currentFrameIdx}
-                        onChange={(e) => {
-                            setIsPlaying(false)
-                            setCurrentFrameIdx(Number(e.target.value))
-                        }}
-                        className="flex-grow h-1.5 bg-gray-200 dark:bg-slate-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
-                    />
-                    <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none">
-                        {new Date(
-                            frames[frames.length - 1].periodTs
-                        ).toLocaleDateString(undefined, {
+            <h4 className="text-2xl font-bold font-mono tracking-tight text-gray-800 dark:text-gray-100">
+                {'Week of ' +
+                    new Date(currentFrame.periodTs).toLocaleDateString(
+                        undefined,
+                        {
                             year: 'numeric',
-                            month: 'short',
-                        })}
-                    </span>
-                </div>
-            )}
+                            month: 'long',
+                            day: 'numeric',
+                        }
+                    )}
+                <span className="text-sm font-normal text-gray-400 dark:text-gray-500 ml-2 font-sans">
+                    · weekly
+                </span>
+            </h4>
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <div className="md:col-span-1 border-b md:border-b-0 md:border-r border-gray-200 dark:border-slate-700/50 pb-4 md:pb-0 md:pr-6 flex flex-col gap-4">
@@ -457,11 +311,124 @@ export function Top10BillboardRaceView({ data, entityType }: Props) {
                     </div>
 
                     <p className="text-[10px] text-gray-400 dark:text-gray-600 text-center mt-2">
-                        Score = Σ streams × e^(−λ×Δweeks) · Higher λ = faster
-                        decay
+                        Score = Σ streams × e^(−λ×Δweeks) · λ = 0.2
                     </p>
                 </div>
             </div>
+
+            {frames.length > 1 && (
+                <div className="flex items-center gap-2 w-full bg-gray-100/50 dark:bg-slate-800/60 p-2 rounded-xl border border-gray-200/30 dark:border-slate-700/40">
+                    <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none shrink-0">
+                        {new Date(frames[0].periodTs).toLocaleDateString(
+                            undefined,
+                            { year: 'numeric', month: 'short' }
+                        )}
+                    </span>
+                    <input
+                        type="range"
+                        aria-label="Animation timeline"
+                        min={0}
+                        max={frames.length - 1}
+                        value={currentFrameIdx}
+                        onChange={(e) => {
+                            setIsPlaying(false)
+                            setCurrentFrameIdx(Number(e.target.value))
+                        }}
+                        className="flex-1 h-1.5 bg-gray-200 dark:bg-slate-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
+                    />
+                    <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none shrink-0">
+                        {new Date(
+                            frames[frames.length - 1].periodTs
+                        ).toLocaleDateString(undefined, {
+                            year: 'numeric',
+                            month: 'short',
+                        })}
+                    </span>
+                    <div className="flex items-center bg-gray-200/80 dark:bg-slate-700/80 rounded-lg p-1 shrink-0">
+                        {([0.5, 1, 2, 4] as const).map((speed) => (
+                            <button
+                                key={speed}
+                                onClick={() => setSpeedMultiplier(speed)}
+                                className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
+                                    speedMultiplier === speed
+                                        ? 'bg-blue-500 text-white shadow-sm'
+                                        : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
+                                }`}
+                            >
+                                {speed}x
+                            </button>
+                        ))}
+                    </div>
+                    <button
+                        onClick={() => {
+                            if (currentFrameIdx >= frames.length - 1) {
+                                setCurrentFrameIdx(0)
+                                setIsPlaying(true)
+                            } else {
+                                setIsPlaying(!isPlaying)
+                            }
+                        }}
+                        aria-label={
+                            isPlaying
+                                ? 'Pause'
+                                : currentFrameIdx >= frames.length - 1
+                                  ? 'Replay'
+                                  : 'Play'
+                        }
+                        title={
+                            isPlaying
+                                ? 'Pause'
+                                : currentFrameIdx >= frames.length - 1
+                                  ? 'Replay'
+                                  : 'Play'
+                        }
+                        className="p-2 bg-gray-200 dark:bg-slate-700 hover:bg-gray-300 dark:hover:bg-slate-600 rounded-lg transition-colors shrink-0"
+                    >
+                        {isPlaying ? (
+                            <svg
+                                width="16"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                fill="currentColor"
+                            >
+                                <rect
+                                    x="3"
+                                    y="2"
+                                    width="4"
+                                    height="12"
+                                    rx="1"
+                                />
+                                <rect
+                                    x="9"
+                                    y="2"
+                                    width="4"
+                                    height="12"
+                                    rx="1"
+                                />
+                            </svg>
+                        ) : currentFrameIdx >= frames.length - 1 ? (
+                            <svg
+                                width="16"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                fill="currentColor"
+                            >
+                                <path d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z" />
+                                <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z" />
+                            </svg>
+                        ) : (
+                            <svg
+                                width="16"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                fill="currentColor"
+                            >
+                                <path d="M11.596 8.697l-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393z" />
+                            </svg>
+                        )}
+                    </button>
+                </div>
+            )}
         </div>
     )
 }

--- a/app/src/components/Charts/LabCharts/Top10Race/Top10RaceView.tsx
+++ b/app/src/components/Charts/LabCharts/Top10Race/Top10RaceView.tsx
@@ -129,138 +129,16 @@ export function Top10RaceView({ data, entityType }: Props) {
 
     return (
         <div ref={containerRef} className="flex flex-col gap-4 w-full">
-            <div className="flex items-center justify-between flex-wrap gap-4">
-                <h4 className="text-2xl font-bold font-mono tracking-tight text-gray-800 dark:text-gray-100">
-                    {new Date(currentFrame.dateTs).toLocaleDateString(
-                        undefined,
-                        { year: 'numeric', month: 'long', day: 'numeric' }
-                    )}
-                    <span className="text-sm font-normal text-gray-400 dark:text-gray-500 ml-2 font-sans">
-                        · daily
-                    </span>
-                </h4>
-                <div className="flex items-center gap-4 flex-wrap">
-                    {/* Speed selector */}
-                    <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30">
-                        {([0.5, 1, 2, 4] as const).map((speed) => (
-                            <button
-                                key={speed}
-                                onClick={() => setSpeedMultiplier(speed)}
-                                className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
-                                    speedMultiplier === speed
-                                        ? 'bg-blue-500 text-white shadow-sm'
-                                        : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-                                }`}
-                            >
-                                {speed}x
-                            </button>
-                        ))}
-                    </div>
-
-                    {/* Controls (Play/Pause) */}
-                    <div className="flex items-center gap-2">
-                        <button
-                            onClick={() => {
-                                if (currentFrameIdx >= frames.length - 1) {
-                                    setCurrentFrameIdx(0)
-                                    setIsPlaying(true)
-                                } else {
-                                    setIsPlaying(!isPlaying)
-                                }
-                            }}
-                            aria-label={
-                                isPlaying
-                                    ? 'Pause'
-                                    : currentFrameIdx >= frames.length - 1
-                                      ? 'Replay'
-                                      : 'Play'
-                            }
-                            title={
-                                isPlaying
-                                    ? 'Pause'
-                                    : currentFrameIdx >= frames.length - 1
-                                      ? 'Replay'
-                                      : 'Play'
-                            }
-                            className="p-2 bg-gray-200 dark:bg-slate-700 hover:bg-gray-300 dark:hover:bg-slate-600 rounded-lg transition-colors"
-                        >
-                            {isPlaying ? (
-                                <svg
-                                    width="16"
-                                    height="16"
-                                    viewBox="0 0 16 16"
-                                    fill="currentColor"
-                                >
-                                    <rect
-                                        x="3"
-                                        y="2"
-                                        width="4"
-                                        height="12"
-                                        rx="1"
-                                    />
-                                    <rect
-                                        x="9"
-                                        y="2"
-                                        width="4"
-                                        height="12"
-                                        rx="1"
-                                    />
-                                </svg>
-                            ) : currentFrameIdx >= frames.length - 1 ? (
-                                <svg
-                                    width="16"
-                                    height="16"
-                                    viewBox="0 0 16 16"
-                                    fill="currentColor"
-                                >
-                                    <path d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z" />
-                                    <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z" />
-                                </svg>
-                            ) : (
-                                <svg
-                                    width="16"
-                                    height="16"
-                                    viewBox="0 0 16 16"
-                                    fill="currentColor"
-                                >
-                                    <path d="M11.596 8.697l-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393z" />
-                                </svg>
-                            )}
-                        </button>
-                    </div>
-                </div>
-            </div>
-
-            {frames.length > 1 && (
-                <div className="flex items-center gap-3 w-full bg-gray-50/50 dark:bg-slate-800/20 p-2.5 rounded-xl border border-gray-200/50 dark:border-slate-800/50">
-                    <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none">
-                        {new Date(frames[0].dateTs).toLocaleDateString(
-                            undefined,
-                            { year: 'numeric', month: 'short' }
-                        )}
-                    </span>
-                    <input
-                        type="range"
-                        aria-label="Animation timeline"
-                        min={0}
-                        max={frames.length - 1}
-                        value={currentFrameIdx}
-                        onChange={(e) => {
-                            setIsPlaying(false)
-                            setCurrentFrameIdx(Number(e.target.value))
-                        }}
-                        className="flex-grow h-1.5 bg-gray-200 dark:bg-slate-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
-                    />
-                    <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none">
-                        {new Date(
-                            frames[frames.length - 1].dateTs
-                        ).toLocaleDateString(undefined, {
-                            year: 'numeric',
-                            month: 'short',
-                        })}
-                    </span>
-                </div>
-            )}
+            <h4 className="text-2xl font-bold font-mono tracking-tight text-gray-800 dark:text-gray-100">
+                {new Date(currentFrame.dateTs).toLocaleDateString(undefined, {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                })}
+                <span className="text-sm font-normal text-gray-400 dark:text-gray-500 ml-2 font-sans">
+                    · daily
+                </span>
+            </h4>
 
             <div
                 className="flex justify-end"
@@ -272,7 +150,7 @@ export function Top10RaceView({ data, entityType }: Props) {
             </div>
 
             <div
-                className="relative w-full mt-4"
+                className="relative w-full"
                 style={{ height: currentFrame.top10.length * BAR_STRIDE }}
             >
                 {currentFrame.top10.map((item, index) => {
@@ -317,6 +195,120 @@ export function Top10RaceView({ data, entityType }: Props) {
                     )
                 })}
             </div>
+
+            {frames.length > 1 && (
+                <div className="flex items-center gap-2 w-full bg-gray-100/50 dark:bg-slate-800/60 p-2 rounded-xl border border-gray-200/30 dark:border-slate-700/40">
+                    <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none shrink-0">
+                        {new Date(frames[0].dateTs).toLocaleDateString(
+                            undefined,
+                            { year: 'numeric', month: 'short' }
+                        )}
+                    </span>
+                    <input
+                        type="range"
+                        aria-label="Animation timeline"
+                        min={0}
+                        max={frames.length - 1}
+                        value={currentFrameIdx}
+                        onChange={(e) => {
+                            setIsPlaying(false)
+                            setCurrentFrameIdx(Number(e.target.value))
+                        }}
+                        className="flex-1 h-1.5 bg-gray-200 dark:bg-slate-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
+                    />
+                    <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none shrink-0">
+                        {new Date(
+                            frames[frames.length - 1].dateTs
+                        ).toLocaleDateString(undefined, {
+                            year: 'numeric',
+                            month: 'short',
+                        })}
+                    </span>
+                    <div className="flex items-center bg-gray-200/80 dark:bg-slate-700/80 rounded-lg p-1 shrink-0">
+                        {([0.5, 1, 2, 4] as const).map((speed) => (
+                            <button
+                                key={speed}
+                                onClick={() => setSpeedMultiplier(speed)}
+                                className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
+                                    speedMultiplier === speed
+                                        ? 'bg-blue-500 text-white shadow-sm'
+                                        : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
+                                }`}
+                            >
+                                {speed}x
+                            </button>
+                        ))}
+                    </div>
+                    <button
+                        onClick={() => {
+                            if (currentFrameIdx >= frames.length - 1) {
+                                setCurrentFrameIdx(0)
+                                setIsPlaying(true)
+                            } else {
+                                setIsPlaying(!isPlaying)
+                            }
+                        }}
+                        aria-label={
+                            isPlaying
+                                ? 'Pause'
+                                : currentFrameIdx >= frames.length - 1
+                                  ? 'Replay'
+                                  : 'Play'
+                        }
+                        title={
+                            isPlaying
+                                ? 'Pause'
+                                : currentFrameIdx >= frames.length - 1
+                                  ? 'Replay'
+                                  : 'Play'
+                        }
+                        className="p-2 bg-gray-200 dark:bg-slate-700 hover:bg-gray-300 dark:hover:bg-slate-600 rounded-lg transition-colors shrink-0"
+                    >
+                        {isPlaying ? (
+                            <svg
+                                width="16"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                fill="currentColor"
+                            >
+                                <rect
+                                    x="3"
+                                    y="2"
+                                    width="4"
+                                    height="12"
+                                    rx="1"
+                                />
+                                <rect
+                                    x="9"
+                                    y="2"
+                                    width="4"
+                                    height="12"
+                                    rx="1"
+                                />
+                            </svg>
+                        ) : currentFrameIdx >= frames.length - 1 ? (
+                            <svg
+                                width="16"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                fill="currentColor"
+                            >
+                                <path d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z" />
+                                <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z" />
+                            </svg>
+                        ) : (
+                            <svg
+                                width="16"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                fill="currentColor"
+                            >
+                                <path d="M11.596 8.697l-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393z" />
+                            </svg>
+                        )}
+                    </button>
+                </div>
+            )}
         </div>
     )
 }

--- a/app/src/components/Charts/LabCharts/Top10Race/Top10RaceView.tsx
+++ b/app/src/components/Charts/LabCharts/Top10Race/Top10RaceView.tsx
@@ -215,7 +215,7 @@ export function Top10RaceView({ data, entityType }: Props) {
                             setCurrentFrameIdx(0)
                             setIsPlaying(true)
                         } else {
-                            setIsPlaying(!isPlaying)
+                            setIsPlaying((prev) => !prev)
                         }
                     }}
                 />

--- a/app/src/components/Charts/LabCharts/Top10Race/Top10RaceView.tsx
+++ b/app/src/components/Charts/LabCharts/Top10Race/Top10RaceView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo, useRef } from 'react'
 import type { EntityType, Top10RaceQueryResult } from './query'
 import { BAR_CHART_COLORS } from '../barChartColors'
+import { RaceControlBar } from '../Common/RaceControlBar'
 
 type Props = {
     data: Top10RaceQueryResult[]
@@ -197,117 +198,27 @@ export function Top10RaceView({ data, entityType }: Props) {
             </div>
 
             {frames.length > 1 && (
-                <div className="flex items-center gap-2 w-full bg-gray-100/50 dark:bg-slate-800/60 p-2 rounded-xl border border-gray-200/30 dark:border-slate-700/40">
-                    <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none shrink-0">
-                        {new Date(frames[0].dateTs).toLocaleDateString(
-                            undefined,
-                            { year: 'numeric', month: 'short' }
-                        )}
-                    </span>
-                    <input
-                        type="range"
-                        aria-label="Animation timeline"
-                        min={0}
-                        max={frames.length - 1}
-                        value={currentFrameIdx}
-                        onChange={(e) => {
-                            setIsPlaying(false)
-                            setCurrentFrameIdx(Number(e.target.value))
-                        }}
-                        className="flex-1 h-1.5 bg-gray-200 dark:bg-slate-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
-                    />
-                    <span className="text-xs text-gray-500 dark:text-gray-400 font-mono select-none shrink-0">
-                        {new Date(
-                            frames[frames.length - 1].dateTs
-                        ).toLocaleDateString(undefined, {
-                            year: 'numeric',
-                            month: 'short',
-                        })}
-                    </span>
-                    <div className="flex items-center bg-gray-200/80 dark:bg-slate-700/80 rounded-lg p-1 shrink-0">
-                        {([0.5, 1, 2, 4] as const).map((speed) => (
-                            <button
-                                key={speed}
-                                onClick={() => setSpeedMultiplier(speed)}
-                                className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
-                                    speedMultiplier === speed
-                                        ? 'bg-blue-500 text-white shadow-sm'
-                                        : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-                                }`}
-                            >
-                                {speed}x
-                            </button>
-                        ))}
-                    </div>
-                    <button
-                        onClick={() => {
-                            if (currentFrameIdx >= frames.length - 1) {
-                                setCurrentFrameIdx(0)
-                                setIsPlaying(true)
-                            } else {
-                                setIsPlaying(!isPlaying)
-                            }
-                        }}
-                        aria-label={
-                            isPlaying
-                                ? 'Pause'
-                                : currentFrameIdx >= frames.length - 1
-                                  ? 'Replay'
-                                  : 'Play'
+                <RaceControlBar
+                    frameCount={frames.length}
+                    startTs={frames[0].dateTs}
+                    endTs={frames[frames.length - 1].dateTs}
+                    currentFrameIdx={currentFrameIdx}
+                    speedMultiplier={speedMultiplier}
+                    isPlaying={isPlaying}
+                    onFrameChange={(idx) => {
+                        setIsPlaying(false)
+                        setCurrentFrameIdx(idx)
+                    }}
+                    onSpeedChange={setSpeedMultiplier}
+                    onPlayPause={() => {
+                        if (currentFrameIdx >= frames.length - 1) {
+                            setCurrentFrameIdx(0)
+                            setIsPlaying(true)
+                        } else {
+                            setIsPlaying(!isPlaying)
                         }
-                        title={
-                            isPlaying
-                                ? 'Pause'
-                                : currentFrameIdx >= frames.length - 1
-                                  ? 'Replay'
-                                  : 'Play'
-                        }
-                        className="p-2 bg-gray-200 dark:bg-slate-700 hover:bg-gray-300 dark:hover:bg-slate-600 rounded-lg transition-colors shrink-0"
-                    >
-                        {isPlaying ? (
-                            <svg
-                                width="16"
-                                height="16"
-                                viewBox="0 0 16 16"
-                                fill="currentColor"
-                            >
-                                <rect
-                                    x="3"
-                                    y="2"
-                                    width="4"
-                                    height="12"
-                                    rx="1"
-                                />
-                                <rect
-                                    x="9"
-                                    y="2"
-                                    width="4"
-                                    height="12"
-                                    rx="1"
-                                />
-                            </svg>
-                        ) : currentFrameIdx >= frames.length - 1 ? (
-                            <svg
-                                width="16"
-                                height="16"
-                                viewBox="0 0 16 16"
-                                fill="currentColor"
-                            >
-                                <path d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z" />
-                                <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z" />
-                            </svg>
-                        ) : (
-                            <svg
-                                width="16"
-                                height="16"
-                                viewBox="0 0 16 16"
-                                fill="currentColor"
-                            >
-                                <path d="M11.596 8.697l-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393z" />
-                            </svg>
-                        )}
-                    </button>
-                </div>
+                    }}
+                />
             )}
         </div>
     )

--- a/app/src/components/Charts/LabCharts/Top10Race/Top10RaceView.tsx
+++ b/app/src/components/Charts/LabCharts/Top10Race/Top10RaceView.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState, useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 import type { EntityType, Top10RaceQueryResult } from './query'
 import { BAR_CHART_COLORS } from '../barChartColors'
 import { RaceControlBar } from '../Common/RaceControlBar'
+import { useRacePlayback } from '../Common/useRacePlayback'
 
 type Props = {
     data: Top10RaceQueryResult[]
@@ -24,12 +25,6 @@ const BAR_STRIDE = 44
 const STREAMS_COL_WIDTH = 60
 
 export function Top10RaceView({ data, entityType }: Props) {
-    const [currentFrameIdx, setCurrentFrameIdx] = useState(0)
-    const [isPlaying, setIsPlaying] = useState(false)
-    const [speedMultiplier, setSpeedMultiplier] = useState(1)
-    const [isVisible, setIsVisible] = useState(false)
-    const containerRef = useRef<HTMLDivElement>(null)
-
     const { frames, entityColors } = useMemo(() => {
         const uniqueDates = Array.from(
             new Set(data.map((d) => d.stream_date_ts))
@@ -78,53 +73,21 @@ export function Top10RaceView({ data, entityType }: Props) {
         return { frames: allFrames, entityColors: colorMap }
     }, [data])
 
+    const {
+        containerRef,
+        currentFrameIdx,
+        isPlaying,
+        speedMultiplier,
+        onFrameChange,
+        onSpeedChange,
+        onPlayPause,
+    } = useRacePlayback({
+        frameCount: frames.length,
+        baseSpeed: BASE_SPEED,
+        entityType,
+    })
+
     const currentFrame = frames[currentFrameIdx]
-
-    useEffect(() => {
-        const observer = new IntersectionObserver(
-            ([entry]) => {
-                setIsVisible(entry.isIntersecting)
-            },
-            { threshold: 0.1 }
-        )
-
-        const currentRef = containerRef.current
-        if (currentRef) {
-            observer.observe(currentRef)
-        }
-
-        return () => {
-            if (currentRef) {
-                observer.unobserve(currentRef)
-            }
-        }
-    }, [])
-
-    const hasInitialized = useRef(false)
-    useEffect(() => {
-        if (!hasInitialized.current) {
-            hasInitialized.current = true
-            return
-        }
-        setCurrentFrameIdx(0)
-        setIsPlaying(true)
-    }, [entityType])
-
-    useEffect(() => {
-        if (!isPlaying || !isVisible || frames.length === 0) return
-
-        const interval = setInterval(() => {
-            setCurrentFrameIdx((prev) => {
-                if (prev >= frames.length - 1) {
-                    setIsPlaying(false)
-                    return prev
-                }
-                return prev + 1
-            })
-        }, BASE_SPEED / speedMultiplier)
-
-        return () => clearInterval(interval)
-    }, [isPlaying, isVisible, frames.length, speedMultiplier])
 
     if (!currentFrame) return null
 
@@ -205,19 +168,9 @@ export function Top10RaceView({ data, entityType }: Props) {
                     currentFrameIdx={currentFrameIdx}
                     speedMultiplier={speedMultiplier}
                     isPlaying={isPlaying}
-                    onFrameChange={(idx) => {
-                        setIsPlaying(false)
-                        setCurrentFrameIdx(idx)
-                    }}
-                    onSpeedChange={setSpeedMultiplier}
-                    onPlayPause={() => {
-                        if (currentFrameIdx >= frames.length - 1) {
-                            setCurrentFrameIdx(0)
-                            setIsPlaying(true)
-                        } else {
-                            setIsPlaying((prev) => !prev)
-                        }
-                    }}
+                    onFrameChange={onFrameChange}
+                    onSpeedChange={onSpeedChange}
+                    onPlayPause={onPlayPause}
                 />
             )}
         </div>


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The Top 10 Race and Top 10 Billboard Race charts had their playback controls (speed selector, play/pause, timeline slider) split across two separate rows at the top of the chart, making the layout feel cluttered and inconsistent with the rest of the Lab charts.

The Billboard Race also exposed a lambda decay parameter that added complexity without clear benefit for most users.

## 🎹 Proposal

Both race charts now have a single unified control bar placed at the bottom of the chart, in the style of StreamVariety, StreamTimeline and StreamDiscovery. The bar contains the timeline slider, speed selector and play/pause button in one pill container.

The lambda parameter is removed from the Billboard Race UI and fixed at 0.2. On mobile, the bar splits into two rows: the slider on top, the speed and play controls centered below.

The control bar is extracted into a shared `RaceControlBar` component to avoid duplication.

## 🎶 Comments

The bottom placement was chosen intentionally for the race charts, as the timeline slider and playback controls naturally map to a media player pattern. The other Lab charts keep their parameter bars at the top since they contain only static selectors.

## 🎤 Test

Load the Lab view with a Spotify or Deezer dataset. Open Top 10 Race and Top 10 Billboard Race. Verify the control bar appears at the bottom, the slider scrubs the animation, the speed buttons work, and the play/pause/replay button cycles correctly. Resize to mobile width and confirm the bar stacks into two rows without overflow.