### PR TITLE
refactor(charts): make entityType optional in useRacePlayback

### DIFF
--- a/app/src/components/Charts/LabCharts/Common/useRacePlayback.test.ts
+++ b/app/src/components/Charts/LabCharts/Common/useRacePlayback.test.ts
@@ -169,5 +169,14 @@ describe('useRacePlayback', () => {
             expect(result.current.currentFrameIdx).toBe(0)
             expect(result.current.isPlaying).toBe(false)
         })
+
+        it('does not auto-reset on mount when entityType is omitted', () => {
+            const { result } = renderHook(() =>
+                useRacePlayback({ frameCount: 5, baseSpeed: 100 })
+            )
+
+            expect(result.current.currentFrameIdx).toBe(0)
+            expect(result.current.isPlaying).toBe(false)
+        })
     })
 })

--- a/app/src/components/Charts/LabCharts/Common/useRacePlayback.ts
+++ b/app/src/components/Charts/LabCharts/Common/useRacePlayback.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 type Options = {
     frameCount: number
     baseSpeed: number
-    entityType: string
+    entityType?: string
 }
 
 type RacePlayback = {


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Some animated chart cards do not have an entity toggle (artists / tracks / albums). Previously, these cards had to pass a dummy string as `entityType` to `useRacePlayback`, even though the parameter is only meaningful for cards that switch between entity types.

## 🎹 Proposal

`entityType` is now optional in the `Options` type. Callers without an entity toggle can omit it entirely. Existing callers that pass `entityType` explicitly are unaffected.

## 🎶 Comments

The reset logic (`useEffect([entityType])`) remains unchanged. A stable `undefined` value never retriggers the effect, which is the correct behavior for cards with no toggle.

## 🎤 Test

Existing tests for `Top10Race` and `Top10BillboardRace` pass unchanged. New test in `useRacePlayback.test.ts` verifies no auto-reset occurs when `entityType` is omitted.