### PR TITLE
feat(charts): animate Listening Bingo grid with date-based frames

### DIFF
--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
@@ -1,7 +1,28 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { StreamPerDayOfWeekView } from './StreamPerDayOfWeekView'
 import type { StreamPerDayOfWeekQueryResult } from './query'
+import * as useRacePlaybackModule from '../Common/useRacePlayback'
+
+const makePlaybackMock = (currentFrameIdx = 0) => ({
+    containerRef: { current: null } as React.RefObject<HTMLDivElement | null>,
+    currentFrameIdx,
+    isPlaying: false,
+    speedMultiplier: 1,
+    onFrameChange: vi.fn(),
+    onSpeedChange: vi.fn(),
+    onPlayPause: vi.fn(),
+})
+
+beforeEach(() => {
+    vi.spyOn(useRacePlaybackModule, 'useRacePlayback').mockReturnValue(
+        makePlaybackMock(0)
+    )
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
 
 const sampleData: StreamPerDayOfWeekQueryResult[] = [
     {
@@ -18,6 +39,43 @@ const sampleData: StreamPerDayOfWeekQueryResult[] = [
     },
 ]
 
+// Two dates: frame 0 reveals (1,10), frame 1 adds (3,14)
+const twoDatesData: StreamPerDayOfWeekQueryResult[] = [
+    {
+        stream_date_ts: 1000,
+        day_of_week: 1,
+        play_hour: 10,
+        cumulative_count: 3,
+    },
+    {
+        stream_date_ts: 2000,
+        day_of_week: 1,
+        play_hour: 10,
+        cumulative_count: 5,
+    },
+    {
+        stream_date_ts: 2000,
+        day_of_week: 3,
+        play_hour: 14,
+        cumulative_count: 2,
+    },
+]
+
+function getCells(container: HTMLElement) {
+    return Array.from(
+        container.querySelectorAll<HTMLElement>('[style*="aspect-ratio"]')
+    )
+}
+
+// Cell (d, h) is at index d*24 + h in the flat cells array
+function getCell(container: HTMLElement, d: number, h: number) {
+    return getCells(container)[d * 24 + h]
+}
+
+function isRevealed(cell: HTMLElement) {
+    return cell.style.backgroundColor !== ''
+}
+
 describe('StreamPerDayOfWeekView', () => {
     it('renders chart title', () => {
         render(<StreamPerDayOfWeekView data={sampleData} />)
@@ -29,18 +87,16 @@ describe('StreamPerDayOfWeekView', () => {
         screen.getByText('Have you listened at every hour of every day?')
     })
 
-    it('renders grid even when data is empty', () => {
+    it('renders grid when data is empty', () => {
         const { container } = render(<StreamPerDayOfWeekView data={[]} />)
-        const cells = container.querySelectorAll('[style*="aspect-ratio"]')
-        expect(cells).toHaveLength(168)
+        expect(getCells(container)).toHaveLength(168)
     })
 
     it('renders grid when data is undefined', () => {
         const { container } = render(
             <StreamPerDayOfWeekView data={undefined} />
         )
-        const cells = container.querySelectorAll('[style*="aspect-ratio"]')
-        expect(cells).toHaveLength(168)
+        expect(getCells(container)).toHaveLength(168)
     })
 
     it('renders sparse day labels', () => {
@@ -62,7 +118,78 @@ describe('StreamPerDayOfWeekView', () => {
         const { container } = render(
             <StreamPerDayOfWeekView data={sampleData} />
         )
-        const cells = container.querySelectorAll('[style*="aspect-ratio"]')
-        expect(cells).toHaveLength(168)
+        expect(getCells(container)).toHaveLength(168)
+    })
+
+    describe('animation controls', () => {
+        it('no RaceControlBar when data is empty', () => {
+            render(<StreamPerDayOfWeekView data={[]} />)
+            expect(
+                screen.queryByRole('slider', { name: /timeline/i })
+            ).toBeNull()
+        })
+
+        it('no RaceControlBar when data spans a single date', () => {
+            render(<StreamPerDayOfWeekView data={sampleData} />)
+            expect(
+                screen.queryByRole('slider', { name: /timeline/i })
+            ).toBeNull()
+        })
+
+        it('RaceControlBar rendered when data spans multiple dates', () => {
+            render(<StreamPerDayOfWeekView data={twoDatesData} />)
+            screen.getByRole('slider', { name: /timeline/i })
+        })
+    })
+
+    describe('cell state at frame 0', () => {
+        it('revealed cells have teal background color', () => {
+            const { container } = render(
+                <StreamPerDayOfWeekView data={sampleData} />
+            )
+            // sampleData frame 0: (0,10) and (3,22) revealed
+            expect(isRevealed(getCell(container, 0, 10))).toBe(true)
+            expect(isRevealed(getCell(container, 3, 22))).toBe(true)
+        })
+
+        it('unrevealed cells have no background color', () => {
+            const { container } = render(
+                <StreamPerDayOfWeekView data={sampleData} />
+            )
+            expect(isRevealed(getCell(container, 0, 0))).toBe(false)
+            expect(isRevealed(getCell(container, 6, 23))).toBe(false)
+        })
+
+        it('at frame 0 of two-date data: only first-date cell revealed', () => {
+            const { container } = render(
+                <StreamPerDayOfWeekView data={twoDatesData} />
+            )
+            // frame 0 has (1,10), NOT (3,14)
+            expect(isRevealed(getCell(container, 1, 10))).toBe(true)
+            expect(isRevealed(getCell(container, 3, 14))).toBe(false)
+        })
+    })
+
+    describe('cell state at frame 1', () => {
+        beforeEach(() => {
+            vi.spyOn(useRacePlaybackModule, 'useRacePlayback').mockReturnValue(
+                makePlaybackMock(1)
+            )
+        })
+
+        it('at frame 1 of two-date data: both cells revealed', () => {
+            const { container } = render(
+                <StreamPerDayOfWeekView data={twoDatesData} />
+            )
+            expect(isRevealed(getCell(container, 1, 10))).toBe(true)
+            expect(isRevealed(getCell(container, 3, 14))).toBe(true)
+        })
+
+        it('previously revealed cell remains revealed at frame 1', () => {
+            const { container } = render(
+                <StreamPerDayOfWeekView data={twoDatesData} />
+            )
+            expect(isRevealed(getCell(container, 1, 10))).toBe(true)
+        })
     })
 })

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
@@ -78,36 +78,38 @@ function isRevealed(cell: HTMLElement) {
 
 describe('StreamPerDayOfWeekView', () => {
     it('renders chart title', () => {
-        render(<StreamPerDayOfWeekView data={sampleData} />)
+        render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)
         screen.getByText(/Listening Bingo/)
     })
 
     it('renders the question subtitle', () => {
-        render(<StreamPerDayOfWeekView data={sampleData} />)
+        render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)
         screen.getByText('Have you listened at every hour of every day?')
     })
 
     it('renders grid when data is empty', () => {
-        const { container } = render(<StreamPerDayOfWeekView data={[]} />)
+        const { container } = render(
+            <StreamPerDayOfWeekView data={[]} year={2024} />
+        )
         expect(getCells(container)).toHaveLength(168)
     })
 
     it('renders grid when data is undefined', () => {
         const { container } = render(
-            <StreamPerDayOfWeekView data={undefined} />
+            <StreamPerDayOfWeekView data={undefined} year={2024} />
         )
         expect(getCells(container)).toHaveLength(168)
     })
 
     it('renders sparse day labels', () => {
-        render(<StreamPerDayOfWeekView data={sampleData} />)
+        render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)
         screen.getByText('Mon')
         screen.getByText('Wed')
         screen.getByText('Fri')
     })
 
     it('renders sparse hour labels at multiples of 6', () => {
-        render(<StreamPerDayOfWeekView data={sampleData} />)
+        render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)
         screen.getByText('0')
         screen.getByText('6')
         screen.getByText('12')
@@ -116,28 +118,28 @@ describe('StreamPerDayOfWeekView', () => {
 
     it('renders 168 cells (7 days x 24 hours)', () => {
         const { container } = render(
-            <StreamPerDayOfWeekView data={sampleData} />
+            <StreamPerDayOfWeekView data={sampleData} year={2024} />
         )
         expect(getCells(container)).toHaveLength(168)
     })
 
     describe('animation controls', () => {
         it('no RaceControlBar when data is empty', () => {
-            render(<StreamPerDayOfWeekView data={[]} />)
+            render(<StreamPerDayOfWeekView data={[]} year={2024} />)
             expect(
                 screen.queryByRole('slider', { name: /timeline/i })
             ).toBeNull()
         })
 
         it('no RaceControlBar when data spans a single date', () => {
-            render(<StreamPerDayOfWeekView data={sampleData} />)
+            render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)
             expect(
                 screen.queryByRole('slider', { name: /timeline/i })
             ).toBeNull()
         })
 
         it('RaceControlBar rendered when data spans multiple dates', () => {
-            render(<StreamPerDayOfWeekView data={twoDatesData} />)
+            render(<StreamPerDayOfWeekView data={twoDatesData} year={2024} />)
             screen.getByRole('slider', { name: /timeline/i })
         })
     })
@@ -145,7 +147,7 @@ describe('StreamPerDayOfWeekView', () => {
     describe('cell state at frame 0', () => {
         it('revealed cells have teal background color', () => {
             const { container } = render(
-                <StreamPerDayOfWeekView data={sampleData} />
+                <StreamPerDayOfWeekView data={sampleData} year={2024} />
             )
             // sampleData frame 0: (0,10) and (3,22) revealed
             expect(isRevealed(getCell(container, 0, 10))).toBe(true)
@@ -154,7 +156,7 @@ describe('StreamPerDayOfWeekView', () => {
 
         it('unrevealed cells have no background color', () => {
             const { container } = render(
-                <StreamPerDayOfWeekView data={sampleData} />
+                <StreamPerDayOfWeekView data={sampleData} year={2024} />
             )
             expect(isRevealed(getCell(container, 0, 0))).toBe(false)
             expect(isRevealed(getCell(container, 6, 23))).toBe(false)
@@ -162,7 +164,7 @@ describe('StreamPerDayOfWeekView', () => {
 
         it('at frame 0 of two-date data: only first-date cell revealed', () => {
             const { container } = render(
-                <StreamPerDayOfWeekView data={twoDatesData} />
+                <StreamPerDayOfWeekView data={twoDatesData} year={2024} />
             )
             // frame 0 has (1,10), NOT (3,14)
             expect(isRevealed(getCell(container, 1, 10))).toBe(true)
@@ -179,7 +181,7 @@ describe('StreamPerDayOfWeekView', () => {
 
         it('at frame 1 of two-date data: both cells revealed', () => {
             const { container } = render(
-                <StreamPerDayOfWeekView data={twoDatesData} />
+                <StreamPerDayOfWeekView data={twoDatesData} year={2024} />
             )
             expect(isRevealed(getCell(container, 1, 10))).toBe(true)
             expect(isRevealed(getCell(container, 3, 14))).toBe(true)
@@ -187,7 +189,7 @@ describe('StreamPerDayOfWeekView', () => {
 
         it('previously revealed cell remains revealed at frame 1', () => {
             const { container } = render(
-                <StreamPerDayOfWeekView data={twoDatesData} />
+                <StreamPerDayOfWeekView data={twoDatesData} year={2024} />
             )
             expect(isRevealed(getCell(container, 1, 10))).toBe(true)
         })

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
@@ -21,10 +21,11 @@ type BingoFrame = {
 
 type Props = {
     data: StreamPerDayOfWeekQueryResult[] | undefined
+    year: number | undefined
     isLoading?: boolean
 }
 
-export function StreamPerDayOfWeekView({ data, isLoading }: Props) {
+export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
     const { frames, maxCount } = useMemo(() => {
         if (!data || data.length === 0)
             return { frames: [] as BingoFrame[], maxCount: 1 }
@@ -67,7 +68,11 @@ export function StreamPerDayOfWeekView({ data, isLoading }: Props) {
         onFrameChange,
         onSpeedChange,
         onPlayPause,
-    } = useRacePlayback({ frameCount: frames.length, baseSpeed: BASE_SPEED })
+    } = useRacePlayback({
+        frameCount: frames.length,
+        baseSpeed: BASE_SPEED,
+        entityType: String(year),
+    })
 
     const currentCells =
         frames[currentFrameIdx]?.cells ?? new Map<string, number>()

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
@@ -113,11 +113,13 @@ export function StreamPerDayOfWeekView({ data, isLoading }: Props) {
                                         const revealed = count > 0
                                         return (
                                             <div
-                                                key={h}
+                                                key={`${h}-${count}`}
                                                 style={{
                                                     aspectRatio: '1',
                                                     ...(revealed && {
                                                         backgroundColor: `rgba(20, 184, 166, ${Math.max(0.15, count / maxCount)})`,
+                                                        animation:
+                                                            'cellPop 0.2s ease-out',
                                                     }),
                                                 }}
                                                 className={`rounded-xs ${revealed ? '' : 'bg-slate-200/50 dark:bg-slate-700/30'}`}

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
@@ -1,66 +1,149 @@
-import { Fragment } from 'react'
+import { Fragment, useMemo } from 'react'
 import type { StreamPerDayOfWeekQueryResult } from './query'
 import { ChartCard } from '../../SimpleCharts/shared'
+import { RaceControlBar } from '../Common/RaceControlBar'
+import { useRacePlayback } from '../Common/useRacePlayback'
 
 const CELL_GAP = 3
 const LABEL_WIDTH = 24
 const MIN_CELL_WIDTH = 10
+const BASE_SPEED = 120
 
 const DAY_LABELS = ['', 'Mon', '', 'Wed', '', 'Fri', '']
 const HOUR_LABELS = Array.from({ length: 24 }, (_, h) =>
     h % 6 === 0 ? String(h) : ''
 )
 
+type BingoFrame = {
+    dateTs: number
+    cells: Map<string, number>
+}
+
 type Props = {
     data: StreamPerDayOfWeekQueryResult[] | undefined
     isLoading?: boolean
 }
 
-export function StreamPerDayOfWeekView({ isLoading }: Props) {
-    return (
-        <ChartCard
-            title="Listening Bingo"
-            emoji="🎰"
-            question="Have you listened at every hour of every day?"
-            isLoading={isLoading}
-        >
-            <div className="overflow-x-auto">
-                <div
-                    style={{
-                        display: 'grid',
-                        gridTemplateColumns: `${LABEL_WIDTH}px repeat(24, 1fr)`,
-                        gap: `${CELL_GAP}px`,
-                        minWidth: `${LABEL_WIDTH + 24 * (CELL_GAP + MIN_CELL_WIDTH)}px`,
-                    }}
-                >
-                    {/* Hour labels row */}
-                    <div />
-                    {HOUR_LABELS.map((label, h) => (
-                        <div
-                            key={h}
-                            className="text-[8px] text-center text-gray-400 dark:text-gray-600"
-                        >
-                            {label}
-                        </div>
-                    ))}
+export function StreamPerDayOfWeekView({ data, isLoading }: Props) {
+    const { frames, maxCount } = useMemo(() => {
+        if (!data || data.length === 0)
+            return { frames: [] as BingoFrame[], maxCount: 1 }
 
-                    {/* Day rows */}
-                    {DAY_LABELS.map((dayLabel, d) => (
-                        <Fragment key={d}>
-                            <div className="text-[8px] flex items-center justify-end pr-1 text-gray-400 dark:text-gray-600">
-                                {dayLabel}
-                            </div>
-                            {Array.from({ length: 24 }, (_, h) => (
+        const uniqueDates = [
+            ...new Set(data.map((r) => r.stream_date_ts)),
+        ].sort((a, b) => a - b)
+
+        const byDate = new Map<number, StreamPerDayOfWeekQueryResult[]>()
+        for (const row of data) {
+            if (!byDate.has(row.stream_date_ts))
+                byDate.set(row.stream_date_ts, [])
+            byDate.get(row.stream_date_ts)!.push(row)
+        }
+
+        const cellState = new Map<string, number>()
+        const allFrames: BingoFrame[] = []
+
+        for (const dateTs of uniqueDates) {
+            for (const row of byDate.get(dateTs) ?? []) {
+                cellState.set(
+                    `${row.day_of_week},${row.play_hour}`,
+                    row.cumulative_count
+                )
+            }
+            allFrames.push({ dateTs, cells: new Map(cellState) })
+        }
+
+        const lastCells = allFrames[allFrames.length - 1].cells
+        const computedMax = Math.max(1, ...lastCells.values())
+
+        return { frames: allFrames, maxCount: computedMax }
+    }, [data])
+
+    const {
+        containerRef,
+        currentFrameIdx,
+        isPlaying,
+        speedMultiplier,
+        onFrameChange,
+        onSpeedChange,
+        onPlayPause,
+    } = useRacePlayback({ frameCount: frames.length, baseSpeed: BASE_SPEED })
+
+    const currentCells =
+        frames[currentFrameIdx]?.cells ?? new Map<string, number>()
+
+    return (
+        <div ref={containerRef}>
+            <ChartCard
+                title="Listening Bingo"
+                emoji="🎰"
+                question="Have you listened at every hour of every day?"
+                isLoading={isLoading}
+            >
+                <div className="flex flex-col gap-3">
+                    <div className="overflow-x-auto">
+                        <div
+                            style={{
+                                display: 'grid',
+                                gridTemplateColumns: `${LABEL_WIDTH}px repeat(24, 1fr)`,
+                                gap: `${CELL_GAP}px`,
+                                minWidth: `${LABEL_WIDTH + 24 * (CELL_GAP + MIN_CELL_WIDTH)}px`,
+                            }}
+                        >
+                            {/* Hour labels row */}
+                            <div />
+                            {HOUR_LABELS.map((label, h) => (
                                 <div
                                     key={h}
-                                    style={{ aspectRatio: '1' }}
-                                    className="rounded-xs bg-gray-100 dark:bg-slate-700/50"
-                                />
+                                    className="text-[8px] text-center text-gray-400 dark:text-gray-600"
+                                >
+                                    {label}
+                                </div>
                             ))}
-                        </Fragment>
-                    ))}
+
+                            {/* Day rows */}
+                            {DAY_LABELS.map((dayLabel, d) => (
+                                <Fragment key={d}>
+                                    <div className="text-[8px] flex items-center justify-end pr-1 text-gray-400 dark:text-gray-600">
+                                        {dayLabel}
+                                    </div>
+                                    {Array.from({ length: 24 }, (_, h) => {
+                                        const count =
+                                            currentCells.get(`${d},${h}`) ?? 0
+                                        const revealed = count > 0
+                                        return (
+                                            <div
+                                                key={h}
+                                                style={{
+                                                    aspectRatio: '1',
+                                                    ...(revealed && {
+                                                        backgroundColor: `rgba(20, 184, 166, ${Math.max(0.15, count / maxCount)})`,
+                                                    }),
+                                                }}
+                                                className={`rounded-xs ${revealed ? '' : 'bg-slate-200/50 dark:bg-slate-700/30'}`}
+                                            />
+                                        )
+                                    })}
+                                </Fragment>
+                            ))}
+                        </div>
+                    </div>
+
+                    {frames.length > 1 && (
+                        <RaceControlBar
+                            frameCount={frames.length}
+                            startTs={frames[0].dateTs}
+                            endTs={frames[frames.length - 1].dateTs}
+                            currentFrameIdx={currentFrameIdx}
+                            speedMultiplier={speedMultiplier}
+                            isPlaying={isPlaying}
+                            onFrameChange={onFrameChange}
+                            onSpeedChange={onSpeedChange}
+                            onPlayPause={onPlayPause}
+                        />
+                    )}
                 </div>
-            </div>
-        </ChartCard>
+            </ChartCard>
+        </div>
     )
 }

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/index.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/index.tsx
@@ -15,5 +15,7 @@ export function StreamPerDayOfWeek({ year }: StreamPerDayOfWeekProps) {
         year,
     })
 
-    return <StreamPerDayOfWeekView data={data} isLoading={isLoading} />
+    return (
+        <StreamPerDayOfWeekView data={data} year={year} isLoading={isLoading} />
+    )
 }

--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -69,3 +69,18 @@
         }
     }
 }
+
+@keyframes cellPop {
+    0% {
+        transform: scale(1);
+        filter: brightness(1);
+    }
+    40% {
+        transform: scale(1.4);
+        filter: brightness(1.8);
+    }
+    100% {
+        transform: scale(1);
+        filter: brightness(1);
+    }
+}


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The Listening Bingo card needed animation: streams should accumulate visually across calendar dates so the grid fills in over time, revealing which (day, hour) cells were active and how intensely.

## 🎹 Proposal

At mount, the full dataset is pre-computed into a `frames[]` array, one snapshot per unique calendar date, each a `Map(day,hour -> cumulative_count)`. Frame lookup is O(1) so backwards scrubbing never recomputes. `useRacePlayback` drives auto-play on viewport entry, play/pause, and scrubbing. `RaceControlBar` appears when the data spans more than one date.

Cells use a teal color at opacity proportional to `count / maxCount` (min 0.15). Unrevealed cells stay dim until their first stream appears.

## 🎶 Comments

This branch builds on both the data layer PR (cumulative window function query) and the `useRacePlayback` refactor (optional `entityType`). Both #445 and #446 PRs must merge first.

## 🎤 Test

Load the app with data, navigate to the Lab view. The Listening Bingo card should auto-play when scrolled into view, filling teal cells date by date. Use the scrubber and speed buttons to navigate. The control bar is hidden when all streams fall on a single date.