### PR TITLE
feat(charts): add live marginal totals to Listening Bingo

### DIFF
--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
@@ -194,4 +194,109 @@ describe('StreamPerDayOfWeekView', () => {
             expect(isRevealed(getCell(container, 1, 10))).toBe(true)
         })
     })
+
+    // twoDatesData frame layout:
+    //   frame 0 (ts=1000): (day1, hr10) = 3
+    //   frame 1 (ts=2000): (day1, hr10) = 5, (day3, hr14) = 2
+    //   final frame: day1=5, day3=2 -> topDay=1 | hr10=5, hr14=2 -> topHour=10
+    describe('marginal totals', () => {
+        it('renders TOTAL header label', () => {
+            render(<StreamPerDayOfWeekView data={twoDatesData} year={2024} />)
+            screen.getByText('TOTAL')
+        })
+
+        it('renders TOT row label', () => {
+            render(<StreamPerDayOfWeekView data={twoDatesData} year={2024} />)
+            screen.getByText('TOT')
+        })
+
+        it('shows correct day total at frame 0', () => {
+            render(<StreamPerDayOfWeekView data={twoDatesData} year={2024} />)
+            const el = screen.getByTestId('day-total-1')
+            expect(el.textContent).toBe('3')
+        })
+
+        it('shows empty day total for day with no streams at frame 0', () => {
+            render(<StreamPerDayOfWeekView data={twoDatesData} year={2024} />)
+            const el = screen.getByTestId('day-total-3')
+            expect(el.textContent).toBe('')
+        })
+
+        it('shows correct hour total at frame 0', () => {
+            render(<StreamPerDayOfWeekView data={twoDatesData} year={2024} />)
+            const el = screen.getByTestId('hour-total-10')
+            expect(el.textContent).toBe('3')
+        })
+
+        it('top day cell has accent class at frame 0', () => {
+            render(<StreamPerDayOfWeekView data={twoDatesData} year={2024} />)
+            const el = screen.getByTestId('day-total-1')
+            expect(el.className).toContain('text-teal-500')
+        })
+
+        it('non-top day cells do not have accent class', () => {
+            render(<StreamPerDayOfWeekView data={twoDatesData} year={2024} />)
+            const el = screen.getByTestId('day-total-3')
+            expect(el.className).not.toContain('text-teal-500')
+        })
+
+        it('top hour cell has accent class', () => {
+            render(<StreamPerDayOfWeekView data={twoDatesData} year={2024} />)
+            const el = screen.getByTestId('hour-total-10')
+            expect(el.className).toContain('text-teal-500')
+        })
+
+        it('non-top hour cells do not have accent class', () => {
+            render(<StreamPerDayOfWeekView data={twoDatesData} year={2024} />)
+            const el = screen.getByTestId('hour-total-14')
+            expect(el.className).not.toContain('text-teal-500')
+        })
+
+        describe('at frame 1', () => {
+            beforeEach(() => {
+                vi.spyOn(
+                    useRacePlaybackModule,
+                    'useRacePlayback'
+                ).mockReturnValue(makePlaybackMock(1))
+            })
+
+            it('day totals update at frame 1', () => {
+                render(
+                    <StreamPerDayOfWeekView data={twoDatesData} year={2024} />
+                )
+                expect(screen.getByTestId('day-total-1').textContent).toBe('5')
+                expect(screen.getByTestId('day-total-3').textContent).toBe('2')
+            })
+
+            it('hour totals update at frame 1', () => {
+                render(
+                    <StreamPerDayOfWeekView data={twoDatesData} year={2024} />
+                )
+                expect(screen.getByTestId('hour-total-10').textContent).toBe(
+                    '5'
+                )
+                expect(screen.getByTestId('hour-total-14').textContent).toBe(
+                    '2'
+                )
+            })
+
+            it('top day accent persists regardless of frame', () => {
+                render(
+                    <StreamPerDayOfWeekView data={twoDatesData} year={2024} />
+                )
+                expect(screen.getByTestId('day-total-1').className).toContain(
+                    'text-teal-500'
+                )
+            })
+
+            it('top hour accent persists regardless of frame', () => {
+                render(
+                    <StreamPerDayOfWeekView data={twoDatesData} year={2024} />
+                )
+                expect(screen.getByTestId('hour-total-10').className).toContain(
+                    'text-teal-500'
+                )
+            })
+        })
+    })
 })

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
@@ -7,6 +7,7 @@ import { useRacePlayback } from '../Common/useRacePlayback'
 const CELL_GAP = 3
 const LABEL_WIDTH = 24
 const MIN_CELL_WIDTH = 10
+const TOTAL_WIDTH = 40
 const BASE_SPEED = 120
 
 const DAY_LABELS = ['', 'Mon', '', 'Wed', '', 'Fri', '']
@@ -26,9 +27,14 @@ type Props = {
 }
 
 export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
-    const { frames, maxCount } = useMemo(() => {
+    const { frames, maxCount, topDay, topHour } = useMemo(() => {
         if (!data || data.length === 0)
-            return { frames: [] as BingoFrame[], maxCount: 1 }
+            return {
+                frames: [] as BingoFrame[],
+                maxCount: 1,
+                topDay: -1,
+                topHour: -1,
+            }
 
         const uniqueDates = [
             ...new Set(data.map((r) => r.stream_date_ts)),
@@ -57,7 +63,26 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
         const lastCells = allFrames[allFrames.length - 1].cells
         const computedMax = Math.max(1, ...lastCells.values())
 
-        return { frames: allFrames, maxCount: computedMax }
+        const finalDayTotals = Array.from({ length: 7 }, (_, d) => {
+            let sum = 0
+            for (let h = 0; h < 24; h++) sum += lastCells.get(`${d},${h}`) ?? 0
+            return sum
+        })
+        const finalHourTotals = Array.from({ length: 24 }, (_, h) => {
+            let sum = 0
+            for (let d = 0; d < 7; d++) sum += lastCells.get(`${d},${h}`) ?? 0
+            return sum
+        })
+
+        const topDayIdx = finalDayTotals.indexOf(Math.max(...finalDayTotals))
+        const topHourIdx = finalHourTotals.indexOf(Math.max(...finalHourTotals))
+
+        return {
+            frames: allFrames,
+            maxCount: computedMax,
+            topDay: topDayIdx,
+            topHour: topHourIdx,
+        }
     }, [data])
 
     const {
@@ -74,8 +99,26 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
         entityType: String(year),
     })
 
-    const currentCells =
-        frames[currentFrameIdx]?.cells ?? new Map<string, number>()
+    const currentCells = useMemo(
+        () => frames[currentFrameIdx]?.cells ?? new Map<string, number>(),
+        [frames, currentFrameIdx]
+    )
+
+    const { dayTotals, hourTotals } = useMemo(() => {
+        const dt = Array.from({ length: 7 }, (_, d) => {
+            let sum = 0
+            for (let h = 0; h < 24; h++)
+                sum += currentCells.get(`${d},${h}`) ?? 0
+            return sum
+        })
+        const ht = Array.from({ length: 24 }, (_, h) => {
+            let sum = 0
+            for (let d = 0; d < 7; d++)
+                sum += currentCells.get(`${d},${h}`) ?? 0
+            return sum
+        })
+        return { dayTotals: dt, hourTotals: ht }
+    }, [currentCells])
 
     return (
         <div ref={containerRef}>
@@ -90,9 +133,9 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                         <div
                             style={{
                                 display: 'grid',
-                                gridTemplateColumns: `${LABEL_WIDTH}px repeat(24, 1fr)`,
+                                gridTemplateColumns: `${LABEL_WIDTH}px repeat(24, 1fr) ${TOTAL_WIDTH}px`,
                                 gap: `${CELL_GAP}px`,
-                                minWidth: `${LABEL_WIDTH + 24 * (CELL_GAP + MIN_CELL_WIDTH)}px`,
+                                minWidth: `${LABEL_WIDTH + 24 * (CELL_GAP + MIN_CELL_WIDTH) + TOTAL_WIDTH}px`,
                             }}
                         >
                             {/* Hour labels row */}
@@ -105,6 +148,9 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                                     {label}
                                 </div>
                             ))}
+                            <div className="text-[8px] text-right text-gray-400 dark:text-gray-600 pl-1 border-l border-gray-200 dark:border-gray-700">
+                                TOTAL
+                            </div>
 
                             {/* Day rows */}
                             {DAY_LABELS.map((dayLabel, d) => (
@@ -131,8 +177,29 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                                             />
                                         )
                                     })}
+                                    <div
+                                        data-testid={`day-total-${d}`}
+                                        className={`text-[8px] text-right flex items-center justify-end pl-1 border-l border-gray-200 dark:border-gray-700 font-medium ${d === topDay ? 'text-teal-500' : 'text-gray-500 dark:text-gray-400'}`}
+                                    >
+                                        {dayTotals[d] > 0 ? dayTotals[d] : ''}
+                                    </div>
                                 </Fragment>
                             ))}
+
+                            {/* Hour totals row */}
+                            <div className="text-[8px] flex items-center justify-end pr-1 text-gray-400 dark:text-gray-600">
+                                TOT
+                            </div>
+                            {hourTotals.map((total, h) => (
+                                <div
+                                    key={h}
+                                    data-testid={`hour-total-${h}`}
+                                    className={`text-[8px] text-center font-medium ${h === topHour ? 'text-teal-500' : 'text-gray-500 dark:text-gray-400'}`}
+                                >
+                                    {total > 0 ? total : ''}
+                                </div>
+                            ))}
+                            <div />
                         </div>
                     </div>
 


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The Listening Bingo grid reveals which day/hour slots have been listened to, but gives no sense of which slots accumulate the most streams. To find the most active day or hour, you would have to mentally sum across rows or columns during the animation.

## 🎹 Proposal

A right column (TOTAL) shows the cumulative stream count per day of week, and a bottom row (TOT) shows the cumulative count per hour. Both update live with each animation frame, so the counters grow as new cells are revealed. The day and hour with the highest final totals are identified at load time and stay highlighted in teal throughout the animation, making the winning slots immediately visible even mid-playback.

## 🎶 Comments

Zero totals are rendered blank rather than "0" to keep the grid readable during the early frames of the animation when most cells are still unrevealed.

## 🎤 Test

1. Load streaming data (file upload or demo)
2. Navigate to the Listening Bingo card in LabView
3. Play the animation and watch the right column and bottom row counters grow frame by frame
4. Confirm the top day (right column) and top hour (bottom row) are highlighted in teal from the start
5. Scrub the timeline slider backwards and forwards -- verify all totals update to match the current frame
6. Change the year filter -- verify totals reset and replay correctly