### PR TITLE
feat(charts): add achievements panel and cell tooltip to Listening Bingo

### DIFF
--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
@@ -505,14 +505,22 @@ describe('StreamPerDayOfWeekView', () => {
             expect(document.body.textContent).toContain('10h')
         })
 
-        it('no tooltip on unrevealed cell', () => {
+        it('unrevealed cell shows tooltip with 0 streams', () => {
             const { container } = render(
                 <StreamPerDayOfWeekView data={sampleData} year={2024} />
             )
             const cell = getCell(container, 0, 0)
             expect(isRevealed(cell)).toBe(false)
             fireEvent.mouseEnter(cell)
-            expect(document.body.textContent).not.toContain('streams')
+            expect(document.body.textContent).toContain('0 streams')
+        })
+
+        it('unrevealed cell tooltip has no first played line', () => {
+            const { container } = render(
+                <StreamPerDayOfWeekView data={sampleData} year={2024} />
+            )
+            fireEvent.mouseEnter(getCell(container, 0, 0))
+            expect(document.body.textContent).not.toContain('first played')
         })
 
         it('tooltip disappears on mouseleave of grid', () => {

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
@@ -39,6 +39,56 @@ const sampleData: StreamPerDayOfWeekQueryResult[] = [
     },
 ]
 
+// 7 rows: same hour (10) across all 7 days → firstCompleteHour at frame 0
+const completeHourData: StreamPerDayOfWeekQueryResult[] = Array.from(
+    { length: 7 },
+    (_, d) => ({
+        stream_date_ts: 1000,
+        day_of_week: d,
+        play_hour: 10,
+        cumulative_count: 1,
+    })
+)
+
+// 24 rows: same day (Mon=1) across all 24 hours → firstCompleteDay at frame 0
+const completeDayData: StreamPerDayOfWeekQueryResult[] = Array.from(
+    { length: 24 },
+    (_, h) => ({
+        stream_date_ts: 1000,
+        day_of_week: 1,
+        play_hour: h,
+        cumulative_count: 1,
+    })
+)
+
+// 168 rows: all cells → bingo at frame 0
+const bingoData: StreamPerDayOfWeekQueryResult[] = Array.from(
+    { length: 7 },
+    (_, d) =>
+        Array.from({ length: 24 }, (_, h) => ({
+            stream_date_ts: 1000,
+            day_of_week: d,
+            play_hour: h,
+            cumulative_count: 1,
+        }))
+).flat()
+
+// hour 10 gets all 7 days spread over 2 dates; milestone at frame 1
+const completeHourTwoDatesData: StreamPerDayOfWeekQueryResult[] = [
+    ...Array.from({ length: 6 }, (_, d) => ({
+        stream_date_ts: 1000,
+        day_of_week: d,
+        play_hour: 10,
+        cumulative_count: 1,
+    })),
+    {
+        stream_date_ts: 2000,
+        day_of_week: 6,
+        play_hour: 10,
+        cumulative_count: 1,
+    },
+]
+
 // Two dates: frame 0 reveals (1,10), frame 1 adds (3,14)
 const twoDatesData: StreamPerDayOfWeekQueryResult[] = [
     {
@@ -297,6 +347,92 @@ describe('StreamPerDayOfWeekView', () => {
                     'text-teal-500'
                 )
             })
+        })
+    })
+
+    describe('achievements panel', () => {
+        it('renders all three achievement labels', () => {
+            render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)
+            screen.getByText('First complete hour')
+            screen.getByText('First complete day')
+            screen.getByText('Bingo')
+        })
+
+        it('shows "N cells uncovered" for bingo when fewer than 168 cells', () => {
+            render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)
+            screen.getByText('166 cells uncovered')
+        })
+
+        it('hides first complete hour value at frame 0 when not yet reached', () => {
+            render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)
+            // sampleData has only 2 cells; no hour has all 7 days covered
+            expect(screen.queryByText(/h · /)).toBeNull()
+        })
+
+        it('shows first complete hour value when milestone frame reached', () => {
+            render(
+                <StreamPerDayOfWeekView data={completeHourData} year={2024} />
+            )
+            // milestone at frame 0, currentFrameIdx=0 → value should be visible
+            expect(screen.getByText(/10h/)).toBeTruthy()
+        })
+
+        it('hides first complete hour value before milestone frame', () => {
+            // completeHourTwoDatesData: milestone at frame 1; mock at frame 0
+            render(
+                <StreamPerDayOfWeekView
+                    data={completeHourTwoDatesData}
+                    year={2024}
+                />
+            )
+            expect(screen.queryByText(/10h/)).toBeNull()
+        })
+
+        it('shows first complete hour value at milestone frame', () => {
+            vi.spyOn(useRacePlaybackModule, 'useRacePlayback').mockReturnValue(
+                makePlaybackMock(1)
+            )
+            render(
+                <StreamPerDayOfWeekView
+                    data={completeHourTwoDatesData}
+                    year={2024}
+                />
+            )
+            expect(screen.getByText(/10h/)).toBeTruthy()
+        })
+
+        it('shows bingo date when all 168 cells reached at frame 0', () => {
+            render(<StreamPerDayOfWeekView data={bingoData} year={2024} />)
+            expect(screen.queryByText(/cells uncovered/)).toBeNull()
+            // bingo date should be rendered (toLocaleDateString of ts=1000)
+            const bingoDate = new Date(1000).toLocaleDateString()
+            expect(screen.getByText(bingoDate)).toBeTruthy()
+        })
+
+        it('shows "N cells uncovered" when bingo is never reached', () => {
+            // completeHourData has only 7 cells → 161 uncovered
+            render(
+                <StreamPerDayOfWeekView data={completeHourData} year={2024} />
+            )
+            screen.getByText('161 cells uncovered')
+        })
+
+        it('hides first complete day value before milestone frame', () => {
+            // sampleData has no complete day
+            render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)
+            expect(
+                screen.queryByText(
+                    /Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday/
+                )
+            ).toBeNull()
+        })
+
+        it('shows first complete day value when milestone frame reached', () => {
+            render(
+                <StreamPerDayOfWeekView data={completeDayData} year={2024} />
+            )
+            // day 1 = Monday, milestone at frame 0
+            expect(screen.getByText(/Monday/)).toBeTruthy()
         })
     })
 })

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { StreamPerDayOfWeekView } from './StreamPerDayOfWeekView'
 import type { StreamPerDayOfWeekQueryResult } from './query'
 import * as useRacePlaybackModule from '../Common/useRacePlayback'
@@ -433,6 +433,57 @@ describe('StreamPerDayOfWeekView', () => {
             )
             // day 1 = Monday, milestone at frame 0
             expect(screen.getByText(/Monday/)).toBeTruthy()
+        })
+    })
+
+    describe('tooltip', () => {
+        it('no tooltip initially', () => {
+            render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)
+            expect(document.body.textContent).not.toContain('streams')
+        })
+
+        it('tooltip appears on mouseenter of revealed cell', () => {
+            const { container } = render(
+                <StreamPerDayOfWeekView data={sampleData} year={2024} />
+            )
+            const cell = getCell(container, 0, 10)
+            expect(isRevealed(cell)).toBe(true)
+            fireEvent.mouseEnter(cell)
+            expect(document.body.textContent).toContain('streams')
+            expect(document.body.textContent).toContain('first played')
+        })
+
+        it('tooltip shows day name and hour', () => {
+            const { container } = render(
+                <StreamPerDayOfWeekView data={sampleData} year={2024} />
+            )
+            // sampleData: (0,10) = Sunday 10h
+            fireEvent.mouseEnter(getCell(container, 0, 10))
+            expect(document.body.textContent).toContain('Sunday')
+            expect(document.body.textContent).toContain('10h')
+        })
+
+        it('no tooltip on unrevealed cell', () => {
+            const { container } = render(
+                <StreamPerDayOfWeekView data={sampleData} year={2024} />
+            )
+            const cell = getCell(container, 0, 0)
+            expect(isRevealed(cell)).toBe(false)
+            fireEvent.mouseEnter(cell)
+            expect(document.body.textContent).not.toContain('streams')
+        })
+
+        it('tooltip disappears on mouseleave of grid', () => {
+            const { container } = render(
+                <StreamPerDayOfWeekView data={sampleData} year={2024} />
+            )
+            fireEvent.mouseEnter(getCell(container, 0, 10))
+            expect(document.body.textContent).toContain('streams')
+            const grid = container.querySelector<HTMLElement>(
+                '[style*="display: grid"]'
+            )!
+            fireEvent.mouseLeave(grid)
+            expect(document.body.textContent).not.toContain('streams')
         })
     })
 })

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
@@ -159,6 +159,16 @@ describe('StreamPerDayOfWeekView', () => {
         expect(getCells(container)).toHaveLength(168)
     })
 
+    it('does not show "cells uncovered" when data is empty', () => {
+        render(<StreamPerDayOfWeekView data={[]} year={2024} />)
+        expect(screen.queryByText(/cells uncovered/)).toBeNull()
+    })
+
+    it('does not show "cells uncovered" when data is undefined', () => {
+        render(<StreamPerDayOfWeekView data={undefined} year={2024} />)
+        expect(screen.queryByText(/cells uncovered/)).toBeNull()
+    })
+
     it('renders sparse day labels', () => {
         render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)
         screen.getByText('Mon')

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
@@ -111,6 +111,14 @@ const twoDatesData: StreamPerDayOfWeekQueryResult[] = [
     },
 ]
 
+// Same logic as the component — locale-aware day names
+function localeDayName(dayOfWeek: number) {
+    return new Date(Date.UTC(2025, 0, 5 + dayOfWeek)).toLocaleDateString(
+        undefined,
+        { weekday: 'long', timeZone: 'UTC' }
+    )
+}
+
 function getCells(container: HTMLElement) {
     return Array.from(
         container.querySelectorAll<HTMLElement>('[style*="aspect-ratio"]')
@@ -445,19 +453,18 @@ describe('StreamPerDayOfWeekView', () => {
         it('hides first complete day value before milestone frame', () => {
             // sampleData has no complete day
             render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)
-            expect(
-                screen.queryByText(
-                    /Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday/
-                )
-            ).toBeNull()
+            const allDayNames = Array.from({ length: 7 }, (_, i) =>
+                localeDayName(i)
+            ).join('|')
+            expect(screen.queryByText(new RegExp(allDayNames))).toBeNull()
         })
 
         it('shows first complete day value when milestone frame reached', () => {
             render(
                 <StreamPerDayOfWeekView data={completeDayData} year={2024} />
             )
-            // day 1 = Monday, milestone at frame 0
-            expect(screen.getByText(/Monday/)).toBeTruthy()
+            // completeDayData uses day_of_week=1 (Monday-equivalent in locale)
+            expect(screen.getByText(new RegExp(localeDayName(1)))).toBeTruthy()
         })
     })
 
@@ -482,9 +489,9 @@ describe('StreamPerDayOfWeekView', () => {
             const { container } = render(
                 <StreamPerDayOfWeekView data={sampleData} year={2024} />
             )
-            // sampleData: (0,10) = Sunday 10h
+            // sampleData: (0,10) = day 0 (Sunday-equivalent in locale), hour 10
             fireEvent.mouseEnter(getCell(container, 0, 10))
-            expect(document.body.textContent).toContain('Sunday')
+            expect(document.body.textContent).toContain(localeDayName(0))
             expect(document.body.textContent).toContain('10h')
         })
 

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
@@ -417,6 +417,31 @@ describe('StreamPerDayOfWeekView', () => {
             screen.getByText('161 cells uncovered')
         })
 
+        it('hides "N cells uncovered" before the final frame', () => {
+            // completeHourTwoDatesData spans 2 frames; bingo never reached
+            // at frame 0 (not final), "N cells uncovered" should not appear
+            render(
+                <StreamPerDayOfWeekView
+                    data={completeHourTwoDatesData}
+                    year={2024}
+                />
+            )
+            expect(screen.queryByText(/cells uncovered/)).toBeNull()
+        })
+
+        it('shows "N cells uncovered" at the final frame when bingo never reached', () => {
+            vi.spyOn(useRacePlaybackModule, 'useRacePlayback').mockReturnValue(
+                makePlaybackMock(1)
+            )
+            render(
+                <StreamPerDayOfWeekView
+                    data={completeHourTwoDatesData}
+                    year={2024}
+                />
+            )
+            screen.getByText(/cells uncovered/)
+        })
+
         it('hides first complete day value before milestone frame', () => {
             // sampleData has no complete day
             render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
@@ -33,7 +33,7 @@ type TooltipState = {
     day: number
     hour: number
     count: number
-    firstPlayedTs: number
+    firstPlayedTs: number | null
 }
 
 type Props = {
@@ -290,28 +290,24 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                                                     }),
                                                 }}
                                                 className={`rounded-xs ${revealed ? '' : 'bg-slate-200/50 dark:bg-slate-700/30'}`}
-                                                onMouseEnter={
-                                                    revealed
-                                                        ? (e) => {
-                                                              const rect =
-                                                                  e.currentTarget.getBoundingClientRect()
-                                                              setTooltip({
-                                                                  x:
-                                                                      rect.left +
-                                                                      rect.width /
-                                                                          2,
-                                                                  y: rect.top,
-                                                                  day: d,
-                                                                  hour: h,
-                                                                  count,
-                                                                  firstPlayedTs:
-                                                                      firstPlayedByCell.get(
-                                                                          `${d},${h}`
-                                                                      ) ?? 0,
-                                                              })
-                                                          }
-                                                        : undefined
-                                                }
+                                                onMouseEnter={(e) => {
+                                                    const rect =
+                                                        e.currentTarget.getBoundingClientRect()
+                                                    setTooltip({
+                                                        x:
+                                                            rect.left +
+                                                            rect.width / 2,
+                                                        y: rect.top,
+                                                        day: d,
+                                                        hour: h,
+                                                        count,
+                                                        firstPlayedTs: revealed
+                                                            ? (firstPlayedByCell.get(
+                                                                  `${d},${h}`
+                                                              ) ?? null)
+                                                            : null,
+                                                    })
+                                                }}
                                             />
                                         )
                                     })}
@@ -406,12 +402,14 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                         <div className="text-gray-300 dark:text-gray-400">
                             {tooltip.count.toLocaleString()} streams
                         </div>
-                        <div className="text-gray-300 dark:text-gray-400">
-                            first played{' '}
-                            {new Date(
-                                tooltip.firstPlayedTs
-                            ).toLocaleDateString()}
-                        </div>
+                        {tooltip.firstPlayedTs !== null && (
+                            <div className="text-gray-300 dark:text-gray-400">
+                                first played{' '}
+                                {new Date(
+                                    tooltip.firstPlayedTs
+                                ).toLocaleDateString()}
+                            </div>
+                        )}
                     </ChartTooltip>
                 )}
             </ChartCard>

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
@@ -11,15 +11,13 @@ const TOTAL_WIDTH = 40
 const BASE_SPEED = 120
 
 const DAY_LABELS = ['', 'Mon', '', 'Wed', '', 'Fri', '']
-const DAY_NAMES = [
-    'Sunday',
-    'Monday',
-    'Tuesday',
-    'Wednesday',
-    'Thursday',
-    'Friday',
-    'Saturday',
-]
+// Jan 5, 2025 is a Sunday (dayofweek=0); UTC timezone avoids offset edge cases
+const DAY_NAMES = Array.from({ length: 7 }, (_, i) =>
+    new Date(Date.UTC(2025, 0, 5 + i)).toLocaleDateString(undefined, {
+        weekday: 'long',
+        timeZone: 'UTC',
+    })
+)
 const HOUR_LABELS = Array.from({ length: 24 }, (_, h) =>
     h % 6 === 0 ? String(h) : ''
 )

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
@@ -11,6 +11,15 @@ const TOTAL_WIDTH = 40
 const BASE_SPEED = 120
 
 const DAY_LABELS = ['', 'Mon', '', 'Wed', '', 'Fri', '']
+const DAY_NAMES = [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+]
 const HOUR_LABELS = Array.from({ length: 24 }, (_, h) =>
     h % 6 === 0 ? String(h) : ''
 )
@@ -27,13 +36,30 @@ type Props = {
 }
 
 export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
-    const { frames, maxCount, topDay, topHour } = useMemo(() => {
+    const {
+        frames,
+        maxCount,
+        topDay,
+        topHour,
+        firstCompleteHourFrame,
+        firstCompleteHourLabel,
+        firstCompleteDayFrame,
+        firstCompleteDayLabel,
+        bingoFrame,
+        uncoveredCells,
+    } = useMemo(() => {
         if (!data || data.length === 0)
             return {
                 frames: [] as BingoFrame[],
                 maxCount: 1,
                 topDay: -1,
                 topHour: -1,
+                firstCompleteHourFrame: null,
+                firstCompleteHourLabel: '',
+                firstCompleteDayFrame: null,
+                firstCompleteDayLabel: '',
+                bingoFrame: null,
+                uncoveredCells: 168,
             }
 
         const uniqueDates = [
@@ -50,15 +76,65 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
         const cellState = new Map<string, number>()
         const allFrames: BingoFrame[] = []
 
-        for (const dateTs of uniqueDates) {
-            for (const row of byDate.get(dateTs) ?? []) {
-                cellState.set(
-                    `${row.day_of_week},${row.play_hour}`,
-                    row.cumulative_count
-                )
+        const hourSeenDays = new Map<number, Set<number>>()
+        const daySeenHours = new Map<number, Set<number>>()
+        let totalRevealed = 0
+
+        let firstCompleteHourFrame: number | null = null
+        let firstCompleteHourLabel = ''
+        let firstCompleteDayFrame: number | null = null
+        let firstCompleteDayLabel = ''
+        let bingoFrame: number | null = null
+
+        for (let fi = 0; fi < uniqueDates.length; fi++) {
+            const dateTs = uniqueDates[fi]
+            const rows = byDate.get(dateTs) ?? []
+
+            for (const row of rows) {
+                const key = `${row.day_of_week},${row.play_hour}`
+                if (!cellState.has(key)) {
+                    totalRevealed++
+
+                    const d = row.day_of_week
+                    const h = row.play_hour
+
+                    if (!hourSeenDays.has(h)) hourSeenDays.set(h, new Set())
+                    hourSeenDays.get(h)!.add(d)
+
+                    if (!daySeenHours.has(d)) daySeenHours.set(d, new Set())
+                    daySeenHours.get(d)!.add(h)
+                }
+                cellState.set(key, row.cumulative_count)
             }
+
             allFrames.push({ dateTs, cells: new Map(cellState) })
+
+            if (firstCompleteHourFrame === null) {
+                for (const [h, days] of hourSeenDays) {
+                    if (days.size === 7) {
+                        firstCompleteHourFrame = fi
+                        firstCompleteHourLabel = `${h}h · ${new Date(dateTs).toLocaleDateString()}`
+                        break
+                    }
+                }
+            }
+
+            if (firstCompleteDayFrame === null) {
+                for (const [d, hours] of daySeenHours) {
+                    if (hours.size === 24) {
+                        firstCompleteDayFrame = fi
+                        firstCompleteDayLabel = `${DAY_NAMES[d]} · ${new Date(dateTs).toLocaleDateString()}`
+                        break
+                    }
+                }
+            }
+
+            if (bingoFrame === null && totalRevealed === 168) {
+                bingoFrame = fi
+            }
         }
+
+        const uncoveredCells = 168 - totalRevealed
 
         const lastCells = allFrames[allFrames.length - 1].cells
         const computedMax = Math.max(1, ...lastCells.values())
@@ -82,6 +158,12 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
             maxCount: computedMax,
             topDay: topDayIdx,
             topHour: topHourIdx,
+            firstCompleteHourFrame,
+            firstCompleteHourLabel,
+            firstCompleteDayFrame,
+            firstCompleteDayLabel,
+            bingoFrame,
+            uncoveredCells,
         }
     }, [data])
 
@@ -216,6 +298,61 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                             onPlayPause={onPlayPause}
                         />
                     )}
+
+                    <ul
+                        className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700"
+                        role="list"
+                    >
+                        <li
+                            className="flex justify-between items-center"
+                            role="listitem"
+                        >
+                            <span className="text-sm text-gray-600 dark:text-gray-400">
+                                First complete hour
+                            </span>
+                            {firstCompleteHourFrame !== null &&
+                                currentFrameIdx >= firstCompleteHourFrame && (
+                                    <span className="font-bold text-sm">
+                                        {firstCompleteHourLabel}
+                                    </span>
+                                )}
+                        </li>
+                        <li
+                            className="flex justify-between items-center mt-1"
+                            role="listitem"
+                        >
+                            <span className="text-sm text-gray-600 dark:text-gray-400">
+                                First complete day
+                            </span>
+                            {firstCompleteDayFrame !== null &&
+                                currentFrameIdx >= firstCompleteDayFrame && (
+                                    <span className="font-bold text-sm">
+                                        {firstCompleteDayLabel}
+                                    </span>
+                                )}
+                        </li>
+                        <li
+                            className="flex justify-between items-center mt-1"
+                            role="listitem"
+                        >
+                            <span className="text-sm text-gray-600 dark:text-gray-400">
+                                Bingo
+                            </span>
+                            {bingoFrame !== null ? (
+                                currentFrameIdx >= bingoFrame ? (
+                                    <span className="font-bold text-sm">
+                                        {new Date(
+                                            frames[bingoFrame].dateTs
+                                        ).toLocaleDateString()}
+                                    </span>
+                                ) : null
+                            ) : (
+                                <span className="text-sm text-gray-500">
+                                    {uncoveredCells} cells uncovered
+                                </span>
+                            )}
+                        </li>
+                    </ul>
                 </div>
             </ChartCard>
         </div>

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
@@ -385,11 +385,11 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                                         ).toLocaleDateString()}
                                     </span>
                                 ) : null
-                            ) : (
+                            ) : currentFrameIdx >= frames.length - 1 ? (
                                 <span className="text-sm text-gray-500">
                                     {uncoveredCells} cells uncovered
                                 </span>
-                            )}
+                            ) : null}
                         </li>
                     </ul>
                 </div>

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo, useState } from 'react'
+import { Fragment, type ReactNode, useMemo, useState } from 'react'
 import type { StreamPerDayOfWeekQueryResult } from './query'
 import { ChartCard, ChartTooltip } from '../../SimpleCharts/shared'
 import { RaceControlBar } from '../Common/RaceControlBar'
@@ -216,6 +216,25 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
 
     const [tooltip, setTooltip] = useState<TooltipState | null>(null)
 
+    let bingoValue: ReactNode = null
+    if (bingoFrame !== null && currentFrameIdx >= bingoFrame) {
+        bingoValue = (
+            <span className="font-bold text-sm">
+                {new Date(frames[bingoFrame].dateTs).toLocaleDateString()}
+            </span>
+        )
+    } else if (
+        bingoFrame === null &&
+        frames.length > 0 &&
+        currentFrameIdx >= frames.length - 1
+    ) {
+        bingoValue = (
+            <span className="text-sm text-gray-500">
+                {uncoveredCells} cells uncovered
+            </span>
+        )
+    }
+
     return (
         <div ref={containerRef}>
             <ChartCard
@@ -375,19 +394,7 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                             <span className="text-sm text-gray-600 dark:text-gray-400">
                                 Bingo
                             </span>
-                            {bingoFrame !== null ? (
-                                currentFrameIdx >= bingoFrame ? (
-                                    <span className="font-bold text-sm">
-                                        {new Date(
-                                            frames[bingoFrame].dateTs
-                                        ).toLocaleDateString()}
-                                    </span>
-                                ) : null
-                            ) : currentFrameIdx >= frames.length - 1 ? (
-                                <span className="text-sm text-gray-500">
-                                    {uncoveredCells} cells uncovered
-                                </span>
-                            ) : null}
+                            {bingoValue}
                         </li>
                     </ul>
                 </div>

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
@@ -1,6 +1,6 @@
-import { Fragment, useMemo } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import type { StreamPerDayOfWeekQueryResult } from './query'
-import { ChartCard } from '../../SimpleCharts/shared'
+import { ChartCard, ChartTooltip } from '../../SimpleCharts/shared'
 import { RaceControlBar } from '../Common/RaceControlBar'
 import { useRacePlayback } from '../Common/useRacePlayback'
 
@@ -29,6 +29,15 @@ type BingoFrame = {
     cells: Map<string, number>
 }
 
+type TooltipState = {
+    x: number
+    y: number
+    day: number
+    hour: number
+    count: number
+    firstPlayedTs: number
+}
+
 type Props = {
     data: StreamPerDayOfWeekQueryResult[] | undefined
     year: number | undefined
@@ -41,6 +50,7 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
         maxCount,
         topDay,
         topHour,
+        firstPlayedByCell,
         firstCompleteHourFrame,
         firstCompleteHourLabel,
         firstCompleteDayFrame,
@@ -54,6 +64,7 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                 maxCount: 1,
                 topDay: -1,
                 topHour: -1,
+                firstPlayedByCell: new Map<string, number>(),
                 firstCompleteHourFrame: null,
                 firstCompleteHourLabel: '',
                 firstCompleteDayFrame: null,
@@ -76,6 +87,7 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
         const cellState = new Map<string, number>()
         const allFrames: BingoFrame[] = []
 
+        const firstPlayedByCell = new Map<string, number>()
         const hourSeenDays = new Map<number, Set<number>>()
         const daySeenHours = new Map<number, Set<number>>()
         let totalRevealed = 0
@@ -93,6 +105,7 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
             for (const row of rows) {
                 const key = `${row.day_of_week},${row.play_hour}`
                 if (!cellState.has(key)) {
+                    firstPlayedByCell.set(key, dateTs)
                     totalRevealed++
 
                     const d = row.day_of_week
@@ -158,6 +171,7 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
             maxCount: computedMax,
             topDay: topDayIdx,
             topHour: topHourIdx,
+            firstPlayedByCell,
             firstCompleteHourFrame,
             firstCompleteHourLabel,
             firstCompleteDayFrame,
@@ -202,6 +216,8 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
         return { dayTotals: dt, hourTotals: ht }
     }, [currentCells])
 
+    const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+
     return (
         <div ref={containerRef}>
             <ChartCard
@@ -219,6 +235,7 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                                 gap: `${CELL_GAP}px`,
                                 minWidth: `${LABEL_WIDTH + 24 * (CELL_GAP + MIN_CELL_WIDTH) + TOTAL_WIDTH}px`,
                             }}
+                            onMouseLeave={() => setTooltip(null)}
                         >
                             {/* Hour labels row */}
                             <div />
@@ -256,6 +273,28 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                                                     }),
                                                 }}
                                                 className={`rounded-xs ${revealed ? '' : 'bg-slate-200/50 dark:bg-slate-700/30'}`}
+                                                onMouseEnter={
+                                                    revealed
+                                                        ? (e) => {
+                                                              const rect =
+                                                                  e.currentTarget.getBoundingClientRect()
+                                                              setTooltip({
+                                                                  x:
+                                                                      rect.left +
+                                                                      rect.width /
+                                                                          2,
+                                                                  y: rect.top,
+                                                                  day: d,
+                                                                  hour: h,
+                                                                  count,
+                                                                  firstPlayedTs:
+                                                                      firstPlayedByCell.get(
+                                                                          `${d},${h}`
+                                                                      ) ?? 0,
+                                                              })
+                                                          }
+                                                        : undefined
+                                                }
                                             />
                                         )
                                     })}
@@ -354,6 +393,22 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                         </li>
                     </ul>
                 </div>
+                {tooltip && (
+                    <ChartTooltip x={tooltip.x} y={tooltip.y}>
+                        <div className="font-semibold">
+                            {DAY_NAMES[tooltip.day]} {tooltip.hour}h
+                        </div>
+                        <div className="text-gray-300 dark:text-gray-400">
+                            {tooltip.count.toLocaleString()} streams
+                        </div>
+                        <div className="text-gray-300 dark:text-gray-400">
+                            first played{' '}
+                            {new Date(
+                                tooltip.firstPlayedTs
+                            ).toLocaleDateString()}
+                        </div>
+                    </ChartTooltip>
+                )}
             </ChartCard>
         </div>
     )


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The Listening Bingo animation revealed cells progressively but gave no indication of when key milestones were reached, and hovering a cell showed nothing.

## 🎹 Proposal

An achievements section now appears below the grid with three rows, always visible:

- **First complete hour**: the moment one time slot was covered across every day of the week. The date appears when the animation reaches that point.
- **First complete day**: the moment one day of the week had every hour covered. The date appears when the animation reaches that point.
- **Bingo**: the moment all 168 cells were covered. The date appears at that frame. If bingo was never reached in the selected year, the number of uncovered cells is shown at the end of the animation.

Hovering any revealed cell now shows a tooltip with the day, the hour, how many streams were played in that slot up to the current frame, and the date of the very first stream in that slot. Day names adapt to the browser language.

## 🎤 Test

1. Upload a Spotify or Deezer export covering at least several months
2. Open the Listening Bingo card and watch the animation play
3. Verify achievement values appear progressively as milestones are reached
4. Scrub back to before a milestone and verify the value disappears
5. Hover a revealed (teal) cell and verify the tooltip shows day, hour, stream count, and first played date
6. Hover an unrevealed (grey) cell and verify no tooltip appears
7. Switch the year filter and verify achievements reset