### PR TITLE
feat(charts): responsive mobile layout for Listening Bingo

### DIFF
--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import { StreamPerDayOfWeekView } from './StreamPerDayOfWeekView'
 import type { StreamPerDayOfWeekQueryResult } from './query'
 import * as useRacePlaybackModule from '../Common/useRacePlayback'
@@ -171,17 +171,19 @@ describe('StreamPerDayOfWeekView', () => {
 
     it('renders sparse day labels', () => {
         render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)
-        screen.getByText('Mon')
-        screen.getByText('Wed')
-        screen.getByText('Fri')
+        const grid = screen.getByTestId('bingo-grid-desktop')
+        within(grid).getByText('Mon')
+        within(grid).getByText('Wed')
+        within(grid).getByText('Fri')
     })
 
     it('renders sparse hour labels at multiples of 6', () => {
         render(<StreamPerDayOfWeekView data={sampleData} year={2024} />)
-        screen.getByText('0')
-        screen.getByText('6')
-        screen.getByText('12')
-        screen.getByText('18')
+        const grid = screen.getByTestId('bingo-grid-desktop')
+        within(grid).getByText('0')
+        within(grid).getByText('6')
+        within(grid).getByText('12')
+        within(grid).getByText('18')
     })
 
     it('renders 168 cells (7 days x 24 hours)', () => {
@@ -270,12 +272,14 @@ describe('StreamPerDayOfWeekView', () => {
     describe('marginal totals', () => {
         it('renders TOTAL header label', () => {
             render(<StreamPerDayOfWeekView data={twoDatesData} year={2024} />)
-            screen.getByText('TOTAL')
+            const grid = screen.getByTestId('bingo-grid-desktop')
+            within(grid).getByText('TOTAL')
         })
 
         it('renders TOT row label', () => {
             render(<StreamPerDayOfWeekView data={twoDatesData} year={2024} />)
-            screen.getByText('TOT')
+            const grid = screen.getByTestId('bingo-grid-desktop')
+            within(grid).getByText('TOT')
         })
 
         it('shows correct day total at frame 0', () => {
@@ -529,9 +533,7 @@ describe('StreamPerDayOfWeekView', () => {
             )
             fireEvent.mouseEnter(getCell(container, 0, 10))
             expect(document.body.textContent).toContain('streams')
-            const grid = container.querySelector<HTMLElement>(
-                '[style*="display: grid"]'
-            )!
+            const grid = screen.getByTestId('bingo-grid-desktop')
             fireEvent.mouseLeave(grid)
             expect(document.body.textContent).not.toContain('streams')
         })

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
@@ -10,7 +10,6 @@ const MIN_CELL_WIDTH = 10
 const TOTAL_WIDTH = 40
 const BASE_SPEED = 120
 
-const DAY_LABELS = ['', 'Mon', '', 'Wed', '', 'Fri', '']
 // Jan 5, 2025 is a Sunday (dayofweek=0); UTC timezone avoids offset edge cases
 const DAY_NAMES = Array.from({ length: 7 }, (_, i) =>
     new Date(Date.UTC(2025, 0, 5 + i)).toLocaleDateString(undefined, {
@@ -366,10 +365,12 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                             </div>
 
                             {/* Day rows */}
-                            {DAY_LABELS.map((dayLabel, d) => (
+                            {DAY_SHORT_NAMES.map((shortName, d) => (
                                 <Fragment key={d}>
                                     <div className="text-[8px] flex items-center justify-end pr-1 text-gray-400 dark:text-gray-600">
-                                        {dayLabel}
+                                        {d === 1 || d === 3 || d === 5
+                                            ? shortName
+                                            : ''}
                                     </div>
                                     {Array.from({ length: 24 }, (_, h) => {
                                         const count =

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
@@ -18,6 +18,12 @@ const DAY_NAMES = Array.from({ length: 7 }, (_, i) =>
         timeZone: 'UTC',
     })
 )
+const DAY_SHORT_NAMES = Array.from({ length: 7 }, (_, i) =>
+    new Date(Date.UTC(2025, 0, 5 + i)).toLocaleDateString(undefined, {
+        weekday: 'short',
+        timeZone: 'UTC',
+    })
+)
 const HOUR_LABELS = Array.from({ length: 24 }, (_, h) =>
     h % 6 === 0 ? String(h) : ''
 )
@@ -244,8 +250,99 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                 isLoading={isLoading}
             >
                 <div className="flex flex-col gap-3">
-                    <div className="overflow-x-auto">
+                    <div className="md:hidden" data-testid="bingo-grid-mobile">
                         <div
+                            style={{
+                                display: 'grid',
+                                gridTemplateColumns: `${LABEL_WIDTH}px repeat(7, 1fr) ${TOTAL_WIDTH}px`,
+                                gap: `${CELL_GAP}px`,
+                            }}
+                            onMouseLeave={() => setTooltip(null)}
+                        >
+                            {/* Day labels header */}
+                            <div />
+                            {DAY_SHORT_NAMES.map((label, d) => (
+                                <div
+                                    key={d}
+                                    className="text-[8px] text-center text-gray-400 dark:text-gray-600"
+                                >
+                                    {label}
+                                </div>
+                            ))}
+                            <div className="text-[8px] text-right text-gray-400 dark:text-gray-600 pl-1 border-l border-gray-200 dark:border-gray-700">
+                                TOTAL
+                            </div>
+
+                            {/* Hour rows */}
+                            {Array.from({ length: 24 }, (_, h) => (
+                                <Fragment key={h}>
+                                    <div className="text-[8px] flex items-center justify-end pr-1 text-gray-400 dark:text-gray-600">
+                                        {HOUR_LABELS[h]}
+                                    </div>
+                                    {Array.from({ length: 7 }, (_, d) => {
+                                        const count =
+                                            currentCells.get(`${d},${h}`) ?? 0
+                                        const revealed = count > 0
+                                        return (
+                                            <div
+                                                key={`${d}-${count}`}
+                                                style={{
+                                                    height: 12,
+                                                    ...(revealed && {
+                                                        backgroundColor: `rgba(20, 184, 166, ${Math.max(0.15, count / maxCount)})`,
+                                                        animation:
+                                                            'cellPop 0.2s ease-out',
+                                                    }),
+                                                }}
+                                                className={`rounded-xs ${revealed ? '' : 'bg-slate-200/50 dark:bg-slate-700/30'}`}
+                                                onMouseEnter={(e) => {
+                                                    const rect =
+                                                        e.currentTarget.getBoundingClientRect()
+                                                    setTooltip({
+                                                        x:
+                                                            rect.left +
+                                                            rect.width / 2,
+                                                        y: rect.top,
+                                                        day: d,
+                                                        hour: h,
+                                                        count,
+                                                        firstPlayedTs: revealed
+                                                            ? (firstPlayedByCell.get(
+                                                                  `${d},${h}`
+                                                              ) ?? null)
+                                                            : null,
+                                                    })
+                                                }}
+                                            />
+                                        )
+                                    })}
+                                    <div
+                                        className={`text-[8px] text-right flex items-center justify-end pl-1 border-l border-gray-200 dark:border-gray-700 font-medium ${h === topHour ? 'text-teal-500' : 'text-gray-500 dark:text-gray-400'}`}
+                                    >
+                                        {hourTotals[h] > 0 ? hourTotals[h] : ''}
+                                    </div>
+                                </Fragment>
+                            ))}
+
+                            {/* Day totals footer */}
+                            <div className="text-[8px] flex items-center justify-end pr-1 text-gray-400 dark:text-gray-600">
+                                TOT
+                            </div>
+                            {dayTotals.map((total, d) => (
+                                <div
+                                    key={d}
+                                    className={`text-[8px] text-center font-medium ${d === topDay ? 'text-teal-500' : 'text-gray-500 dark:text-gray-400'}`}
+                                >
+                                    {total > 0 ? total : ''}
+                                </div>
+                            ))}
+                            <div />
+                        </div>
+                    </div>
+
+                    <div className="hidden md:block overflow-x-auto">
+                        <div
+                            data-testid="bingo-grid-desktop"
                             style={{
                                 display: 'grid',
                                 gridTemplateColumns: `${LABEL_WIDTH}px repeat(24, 1fr) ${TOTAL_WIDTH}px`,


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

On mobile, the Listening Bingo grid (7 days x 24 hours) forces horizontal scrolling to see all 24 hour columns. Horizontal scrolling is unnatural on mobile and makes the chart hard to read at a glance.

## 🎹 Proposal

On screens narrower than the `md` breakpoint, the grid is transposed: days become columns (7) and hours become rows (24). Seven columns fit comfortably on any phone width, and 24 rows scroll vertically, which is native mobile behavior. The desktop layout (hours as columns) is unchanged.

Cells in the mobile layout use a fixed height instead of a 1:1 aspect ratio to keep the grid compact. Day labels are derived from locale using the `short` weekday format, showing all 7 days since the column count is small.

## 🎤 Test

1. Open the app and upload a streaming history file.
2. Navigate to the Listening Bingo chart.
3. On desktop: grid shows hours as columns (0-23) across the top, days as rows. Behavior unchanged.
4. Resize the browser below the `md` breakpoint (or use DevTools mobile emulation): grid transposes to days as columns (Sun-Sat) across the top, hours as rows (0-23) down the side.
5. Verify teal cells, hover tooltips, animation controls, and achievement milestones all work on both layouts.