### PR TITLE
style(charts): polish fun facts copy and emojis

### DIFF
--- a/app/src/components/Charts/SimpleCharts/ConcentrationScore/ConcentrationScore.tsx
+++ b/app/src/components/Charts/SimpleCharts/ConcentrationScore/ConcentrationScore.tsx
@@ -11,7 +11,7 @@ export const ConcentrationScore: FC<Props> = ({ data, isLoading }) => {
     return (
         <ChartCard
             title="Focus Mode"
-            emoji="🔥"
+            emoji="🎯"
             isLoading={isLoading}
             question="Is my listening concentrated on just a few artists?"
         >

--- a/app/src/components/Charts/SimpleCharts/FunFacts/AbsoluteLoyalty.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/AbsoluteLoyalty.sql
@@ -12,9 +12,6 @@ artist_counts as (
     select
         artist_name,
         count(*) filter (where reason_end = 'trackdone') as completed_count,
-        count(*) filter (
-            where reason_end in ('fwdbtn', 'click-row', 'clickrow')
-        ) as skipped_count,
         count(*) as total_events
     from ${table}
     where artist_name is not null
@@ -25,8 +22,6 @@ artist_counts as (
 artist_loyalty as (
     select
         artist_name,
-        completed_count,
-        skipped_count,
         total_events,
         completed_count::double precision
         / nullif(total_events, 0) as loyalty_ratio
@@ -37,11 +32,7 @@ select
     artist_name as main_text,
     (loyalty_ratio * 100)::integer as fact_value,
     '%' as unit,
-    'of your completed ('
-    || completed_count
-    || ') vs skipped ('
-    || skipped_count
-    || ')' as context
+    'of your plays went all the way' as context
 from artist_loyalty
 order by fact_value desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FirstArtist.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FirstArtist.sql
@@ -1,7 +1,7 @@
 select
     artist_name as main_text,
     min(year(ts::date)) as fact_value,
-    'Do you still listen to it?' as context
+    'still in your rotation today?' as context
 from ${table}
 where artist_name is not null
 group by artist_name

--- a/app/src/components/Charts/SimpleCharts/FunFacts/ForgottenArtist.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/ForgottenArtist.sql
@@ -54,11 +54,6 @@ select
         'day', last_listen, (select max_date from recent_date)
     )::integer as fact_value,
     'days' as unit,
-    'without listening to artist with more than '
-    || (
-        select limit_streams
-        from threshold
-    )
-    || ' streams' as context
+    'off your radar' as context
 from artist_stats
 USING SAMPLE 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/Marathon.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/Marathon.sql
@@ -31,7 +31,7 @@ select
     artist_name as main_text,
     stream_count::double as fact_value,
     'streams in a row' as unit,
-    'on ' || listen_date::varchar as context
+    'one uninterrupted run on ' || listen_date::varchar as context
 from group_sizes
 order by stream_count desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/MusicalAnniversary.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/MusicalAnniversary.sql
@@ -38,6 +38,6 @@ select
     artist_years.artist_name as main_text,
     year(recent_date.max_date) - artist_years.first_year as fact_value,
     'years' as unit,
-    'with you' as context
+    'strong' as context
 from artist_years, recent_date
 USING SAMPLE 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/NostalgicReturn.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/NostalgicReturn.sql
@@ -40,8 +40,6 @@ previous_listens as (
 artist_gaps as (
     select
         artist,
-        recent_artists.last_listen,
-        previous_listens.previous_listen,
         date_diff(
             'day', previous_listens.previous_listen, recent_artists.last_listen
         ) as gap
@@ -55,10 +53,6 @@ select
     artist as main_text,
     gap::integer as fact_value,
     'days' as unit,
-    'days since last listen ('
-    || previous_listen
-    || ' - '
-    || last_listen
-    || ')' as context
+    'later, it''s back' as context
 from artist_gaps
 USING SAMPLE 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/OneHitWonder.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/OneHitWonder.sql
@@ -32,6 +32,6 @@ select
     track_name as main_text,
     percentage as fact_value,
     '%' as unit,
-    'of total streams of ' || artist_name as context
+    'of your streams of ' || artist_name as context
 from track_stats
 USING SAMPLE 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/RecentDiscovery.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/RecentDiscovery.sql
@@ -17,7 +17,7 @@ select
     artist_name as main_text,
     count(*)::integer as fact_value,
     'streams' as unit,
-    'discovered during the last 3 months' as context
+    'discovered in the last 3 months' as context
 from ${table}
 inner join artist_first_listen using (artist_name)
 where

--- a/app/src/components/Charts/SimpleCharts/FunFacts/SubscribedArtist.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/SubscribedArtist.sql
@@ -2,7 +2,7 @@ select
     artist_name as main_text,
     count(distinct strftime(ts::date, '%Y-%m'))::integer as fact_value,
     'months' as unit,
-    'of presence' as context
+    'in your rotation' as context
 from ${table}
 where artist_name is not null
 group by artist_name

--- a/app/src/components/Charts/SimpleCharts/FunFacts/TrackProposition.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/TrackProposition.sql
@@ -1,6 +1,7 @@
 select
     track_name as main_text,
-    'by ' || artist_name as fact_value
+    artist_name as second_text,
+    'your next listen is already waiting' as context
 from ${table}
 where track_name is not null
 USING SAMPLE 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/WeekendFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/WeekendFavorite.sql
@@ -2,7 +2,7 @@ select
     artist_name as main_text,
     count(*) as fact_value,
     'streams' as unit,
-    'during the weekend' as context
+    'on weekends' as context
 from ${table}
 where
     (

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
@@ -125,7 +125,7 @@ describe('FunFacts queries', () => {
             expect(row.main_text).toBe('consecutive_stream_artist')
             expect(row.fact_value).toBe(3)
             expect(row.unit).toBe('streams in a row')
-            expect(row.context).toBe('on 2024-01-01')
+            expect(row.context).toBe('one uninterrupted run on 2024-01-01')
         })
     })
 
@@ -145,9 +145,7 @@ describe('FunFacts queries', () => {
             expect(row.main_text).toBe('hit_track')
             expect(row.fact_value).toBe(100)
             expect(row.unit).toBe('%')
-            expect(row.context).toBe(
-                'of total streams of one_hit_wonder_artist'
-            )
+            expect(row.context).toBe('of your streams of one_hit_wonder_artist')
         })
     })
 
@@ -174,7 +172,7 @@ describe('FunFacts queries', () => {
             expect(row.main_text).toBe('weekend_artist')
             expect(row.fact_value).toBe('2')
             expect(row.unit).toBe('streams')
-            expect(row.context).toBe('during the weekend')
+            expect(row.context).toBe('on weekends')
         })
     })
 
@@ -201,7 +199,7 @@ describe('FunFacts queries', () => {
             expect(row.main_text).toBe('loyal_artist')
             expect(row.fact_value).toBe(75)
             expect(row.unit).toBe('%')
-            expect(row.context).toBe('of your completed (3) vs skipped (1)')
+            expect(row.context).toBe('of your plays went all the way')
         })
     })
 
@@ -225,9 +223,7 @@ describe('FunFacts queries', () => {
             expect(row.main_text).toBe('nostalgic_artist')
             expect(row.fact_value).toBe(366)
             expect(row.unit).toBe('days')
-            expect(row.context).toBe(
-                'days since last listen (2024-01-01 - 2025-01-01)'
-            )
+            expect(row.context).toBe("later, it's back")
         })
     })
 
@@ -280,7 +276,7 @@ describe('FunFacts queries', () => {
             expect(row.main_text).toBe('recent_discovery_artist')
             expect(row.fact_value).toBe(1)
             expect(row.unit).toBe('streams')
-            expect(row.context).toBe('discovered during the last 3 months')
+            expect(row.context).toBe('discovered in the last 3 months')
         })
     })
 
@@ -306,7 +302,7 @@ describe('FunFacts queries', () => {
             expect(row.main_text).toBe('subscribed_artist')
             expect(row.fact_value).toBe(3)
             expect(row.unit).toBe('months')
-            expect(row.context).toBe('of presence')
+            expect(row.context).toBe('in your rotation')
         })
     })
 
@@ -329,7 +325,7 @@ describe('FunFacts queries', () => {
             expect(row.main_text).toBe('first_artist')
             expect(row.fact_value).toBe('2006')
             expect(row.unit).toBeUndefined()
-            expect(row.context).toBe('Do you still listen to it?')
+            expect(row.context).toBe('still in your rotation today?')
         })
 
         it('queryMusicalAnniversary returns artist listened to for longest time', async () => {
@@ -342,7 +338,7 @@ describe('FunFacts queries', () => {
             expect(row.main_text).toBeDefined()
             expect(row.fact_value).toBeDefined()
             expect(row.unit).toBe('years')
-            expect(row.context).toBe('with you')
+            expect(row.context).toBe('strong')
         })
     })
 
@@ -368,9 +364,7 @@ describe('FunFacts queries', () => {
             expect(row.main_text).toBe('forgotten_artist')
             expect(row.fact_value).toBe(366)
             expect(row.unit).toBe('days')
-            expect(row.context).toBe(
-                'without listening to artist with more than 1 streams'
-            )
+            expect(row.context).toBe('off your radar')
         })
     })
 
@@ -389,9 +383,10 @@ describe('FunFacts queries', () => {
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.main_text).toBeOneOf(['track1', 'track2'])
-            expect(row.fact_value).toBeOneOf(['by artist1', 'by artist2'])
+            expect(row.fact_value).toBeUndefined()
+            expect(row.second_text).toBeOneOf(['artist1', 'artist2'])
             expect(row.unit).toBeUndefined()
-            expect(row.context).toBeUndefined()
+            expect(row.context).toBe('your next listen is already waiting')
         })
     })
 

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.tsx
@@ -36,7 +36,7 @@ export const facts = [
     },
     {
         fact_type: 'afternoon_favorite',
-        title: '☀️ Afternoon Boost',
+        title: '🏞️ Afternoon Boost',
         emoji: '⚡️',
         sql: build(sqlQueryAfternoonFavorite),
     },
@@ -48,37 +48,37 @@ export const facts = [
     },
     {
         fact_type: 'night_favorite',
-        title: '🌙 Musical Insomnia',
+        title: '🌌 Musical Insomnia',
         emoji: '💤',
         sql: build(sqlQueryNightFavorite),
     },
     {
         fact_type: 'weekend_favorite',
-        title: '🎉 Weekend Vibes',
+        title: '🧉 Weekend Vibes',
         emoji: '🕺',
         sql: build(sqlQueryWeekendFavorite),
     },
     {
         fact_type: 'nostalgic_return',
-        title: '🕰️ Nostalgic Return',
-        emoji: '📼',
+        title: '📻 Signal Found',
+        emoji: '🛰️',
         sql: build(sqlQueryNostalgicReturn),
     },
     {
         fact_type: 'forgotten_artist',
-        title: '🕰️ Forgotten Artist',
-        emoji: '💔',
+        title: '🥀 Fading Away',
+        emoji: '🌫️',
         sql: build(sqlQueryForgottenArtist),
     },
     {
         fact_type: 'absolute_loyalty',
-        title: '❤️ Absolute Loyalty',
+        title: '💎 Absolute Loyalty',
         emoji: '💍',
         sql: build(sqlQueryAbsoluteLoyalty),
     },
     {
         fact_type: 'subscribed_artist',
-        title: '🎸 Monthly Subscription',
+        title: '🎟️ Monthly Subscription',
         emoji: '📬',
         sql: build(sqlQuerySubscribedArtist),
     },
@@ -90,14 +90,14 @@ export const facts = [
     },
     {
         fact_type: 'first_artist',
-        title: '🦖 The Very First',
-        emoji: '1️⃣',
+        title: '1️⃣ The Very First',
+        emoji: '🦖',
         sql: build(sqlQueryFirstArtist),
     },
     {
         fact_type: 'one_hit_wonder',
-        title: '⭐ One-Hit Wonder',
-        emoji: '🎵',
+        title: '⭐ One Hit Wonder',
+        emoji: '📼',
         sql: build(sqlQueryOneHitWonder),
     },
     {
@@ -108,7 +108,7 @@ export const facts = [
     },
     {
         fact_type: 'recent_discovery',
-        title: '🎵 Recent Discovery',
+        title: '🔍 Recent Discovery',
         emoji: '✨',
         sql: build(sqlQueryRecentDiscovery),
     },
@@ -120,8 +120,8 @@ export const facts = [
     },
     {
         fact_type: 'track_proposition',
-        title: '🔮 Listening Proposition',
-        emoji: '🐙',
+        title: '▶️ Up Next',
+        emoji: '🔮',
         sql: build(sqlQueryTrackProposition),
     },
     {

--- a/app/src/components/Charts/SimpleView.test.tsx
+++ b/app/src/components/Charts/SimpleView.test.tsx
@@ -274,7 +274,7 @@ it('renders all SimpleView', async () => {
     await screen.findByRole('heading', { name: '🎵Top Tracks' })
     await screen.findByRole('heading', { name: '🎤Top Artists' })
     await screen.findByRole('heading', { name: '💿Top Albums' })
-    await screen.findByRole('heading', { name: '🔥Focus Mode' })
+    await screen.findByRole('heading', { name: '🎯Focus Mode' })
     await screen.findByRole('heading', { name: '🤝Artist Loyalty' })
     await screen.findByRole('heading', { name: '⏰Daily Vibes' })
     await screen.findByRole('heading', { name: '⏳Consistency Meter' })


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Fun facts card copy was verbose and inconsistent. Some context strings exposed raw SQL internals (counts, dates, thresholds). Emojis were duplicated between cards.

## 🎹 Proposal

Simplified all context strings to short, natural phrases. Updated titles and emojis across fun facts cards for visual consistency. Restructured TrackProposition to split artist name into a dedicated `second_text` column. Updated ConcentrationScore emoji from 🔥 to 🎯.

## 🎶 Comments

<!-- Additional information, tips or problems encountered. -->

## 🎤 Test

Run fun facts tests:
```
moon run app:test -- FunFacts
```