### PR TITLE
refactor(charts): extract shared UI components to LabCharts/shared

### DIFF
--- a/app/src/components/Charts/LabCharts/Streaks/StreaksView.tsx
+++ b/app/src/components/Charts/LabCharts/Streaks/StreaksView.tsx
@@ -5,6 +5,7 @@ import {
     ChartCardEmpty,
     ChartTooltip,
 } from '../../SimpleCharts/shared'
+import { InsightList, InsightRow } from '../shared/InsightList'
 
 const CELL_GAP = 3
 const LABEL_WIDTH = 24
@@ -330,47 +331,33 @@ export function StreaksView({ data, year, isLatestYear, isLoading }: Props) {
                         </div>
                     </div>
 
-                    <ul
-                        className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700"
-                        role="list"
-                    >
-                        <li
-                            className="flex justify-between items-center"
-                            role="listitem"
-                        >
-                            <span className="text-sm text-gray-600 dark:text-gray-400">
-                                Best streak
-                            </span>
-                            <span className="font-bold text-sm">
-                                {maxStreak} day{maxStreak === 1 ? '' : 's'}
-                                {bestStreakStart && bestStreakEnd && (
-                                    <span className="font-normal text-gray-500 dark:text-gray-400">
-                                        {' '}
-                                        &middot;{' '}
-                                        {formatDisplayDate(
-                                            bestStreakStart
-                                        )}{' '}
-                                        &ndash;{' '}
-                                        {formatDisplayDate(bestStreakEnd)}
-                                    </span>
-                                )}
-                            </span>
-                        </li>
+                    <InsightList>
+                        <InsightRow
+                            label="Best streak"
+                            value={
+                                <>
+                                    {maxStreak} day{maxStreak === 1 ? '' : 's'}
+                                    {bestStreakStart && bestStreakEnd && (
+                                        <span className="font-normal text-gray-500 dark:text-gray-400">
+                                            {' '}
+                                            &middot;{' '}
+                                            {formatDisplayDate(
+                                                bestStreakStart
+                                            )}{' '}
+                                            &ndash;{' '}
+                                            {formatDisplayDate(bestStreakEnd)}
+                                        </span>
+                                    )}
+                                </>
+                            }
+                        />
                         {isLatestYear && (
-                            <li
-                                className="flex justify-between items-center mt-1"
-                                role="listitem"
-                            >
-                                <span className="text-sm text-gray-600 dark:text-gray-400">
-                                    Current streak
-                                </span>
-                                <span className="font-bold text-sm">
-                                    {currentStreak} day
-                                    {currentStreak === 1 ? '' : 's'}
-                                </span>
-                            </li>
+                            <InsightRow
+                                label="Current streak"
+                                value={`${currentStreak} day${currentStreak === 1 ? '' : 's'}`}
+                            />
                         )}
-                    </ul>
+                    </InsightList>
                 </>
             )}
             {tooltip && (

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -11,6 +11,7 @@ import {
     ChartCardEmpty,
     ChartTooltip,
 } from '../../SimpleCharts/shared'
+import { EntityTabs } from '../shared/EntityTabs'
 
 type TooltipState = {
     x: number
@@ -38,12 +39,6 @@ const GRAN_LABELS: Record<Granularity, string> = {
     month: 'Month',
     week: 'Week',
     day: 'Day',
-}
-
-const ENTITY_LABELS: Record<Entity, string> = {
-    tracks: 'Tracks',
-    artists: 'Artists',
-    albums: 'Albums',
 }
 
 const ENTITY_SINGULAR: Record<Entity, string> = {
@@ -124,31 +119,15 @@ export const StreamDiscovery: FC<Props> = ({
         : 0
     const sparseLabelLayout = granularity !== 'month' || year === undefined
 
-    const entityTabs = (
-        <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30">
-            {(['tracks', 'artists', 'albums'] as const).map((e) => (
-                <button
-                    key={e}
-                    onClick={() => onEntityChange(e)}
-                    className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
-                        entity === e
-                            ? 'bg-blue-500 text-white shadow-sm'
-                            : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-                    }`}
-                >
-                    {ENTITY_LABELS[e]}
-                </button>
-            ))}
-        </div>
-    )
-
     return (
         <ChartCard
             title="Stream Discovery"
             emoji="🔭"
             isLoading={isLoading}
             question="How many new artists, tracks, or albums did I discover?"
-            headerActions={entityTabs}
+            headerActions={
+                <EntityTabs value={entity} onChange={onEntityChange} />
+            }
         >
             <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30 self-start mb-3">
                 {(['year', 'month', 'week', 'day'] as const).map((g) => {

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../SimpleCharts/shared'
 import { EntityTabs } from '../shared/EntityTabs'
 import { GranularityTabs } from '../shared/GranularityTabs'
+import { InsightList, InsightRow } from '../shared/InsightList'
 
 type TooltipState = {
     x: number
@@ -219,34 +220,23 @@ export const StreamDiscovery: FC<Props> = ({
                         </span>
                     </div>
 
-                    <ul
-                        className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700"
-                        role="list"
-                    >
-                        <li
-                            className="flex justify-between items-center"
-                            role="listitem"
-                        >
-                            <span className="text-sm text-gray-600 dark:text-gray-400">
-                                New {ENTITY_SINGULAR[entity]}s discovered
-                            </span>
-                            <span className="font-bold">
-                                {totalNew.toLocaleString()}
-                            </span>
-                        </li>
-                        <li
-                            className="flex justify-between items-center mt-1"
-                            role="listitem"
-                        >
-                            <span className="text-sm text-gray-600 dark:text-gray-400">
-                                Discovery rate
-                                <span className="ml-1 text-xs font-normal text-gray-400 dark:text-gray-500">
-                                    (new / total distinct)
-                                </span>
-                            </span>
-                            <span className="font-bold">{discoveryRate}%</span>
-                        </li>
-                    </ul>
+                    <InsightList>
+                        <InsightRow
+                            label={`New ${ENTITY_SINGULAR[entity]}s discovered`}
+                            value={totalNew.toLocaleString()}
+                        />
+                        <InsightRow
+                            label={
+                                <>
+                                    Discovery rate
+                                    <span className="ml-1 text-xs font-normal text-gray-400 dark:text-gray-500">
+                                        (new / total distinct)
+                                    </span>
+                                </>
+                            }
+                            value={`${discoveryRate}%`}
+                        />
+                    </InsightList>
                     {entity !== 'tracks' && (
                         <p className="mt-2 text-xs italic text-gray-400 dark:text-gray-500">
                             Artist and album counts rely on names, not unique

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -142,7 +142,7 @@ export const StreamDiscovery: FC<Props> = ({
                         >
                             {data.map((d, i) => {
                                 const label = formatBarLabel(
-                                    d,
+                                    d.ts,
                                     i,
                                     data,
                                     year,
@@ -200,7 +200,7 @@ export const StreamDiscovery: FC<Props> = ({
             {tooltip && (
                 <ChartTooltip x={tooltip.x} y={tooltip.y}>
                     <div className="font-semibold">
-                        {formatTooltipDate(new Date(tooltip.ts), granularity)}
+                        {formatTooltipDate(tooltip.ts, granularity)}
                     </div>
                     <div className="text-gray-300 dark:text-gray-400">
                         {tooltip.new_count.toLocaleString()} new

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -7,6 +7,7 @@ import type {
 import type { Granularity, EntityType } from '../shared/types'
 import { formatTooltipDate } from '../shared/formatTooltipDate'
 import { formatBarLabel } from '../shared/formatBarLabel'
+import { ChartLegend } from '../shared/ChartLegend'
 import {
     ChartCard,
     ChartCardEmpty,
@@ -163,16 +164,12 @@ export const StreamDiscovery: FC<Props> = ({
                         </div>
                     </div>
 
-                    <div className="mt-1 mb-3 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
-                        <span className="flex items-center gap-1">
-                            <span className="inline-block w-2 h-2 rounded-sm bg-rose-800" />
-                            New
-                        </span>
-                        <span className="flex items-center gap-1">
-                            <span className="inline-block w-2 h-2 rounded-sm bg-rose-500" />
-                            Known
-                        </span>
-                    </div>
+                    <ChartLegend
+                        items={[
+                            { color: 'bg-rose-800', label: 'New' },
+                            { color: 'bg-rose-500', label: 'Known' },
+                        ]}
+                    />
 
                     <InsightList>
                         <InsightRow

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -12,6 +12,7 @@ import {
     ChartTooltip,
 } from '../../SimpleCharts/shared'
 import { EntityTabs } from '../shared/EntityTabs'
+import { GranularityTabs } from '../shared/GranularityTabs'
 
 type TooltipState = {
     x: number
@@ -32,13 +33,6 @@ type Props = {
     entity: Entity
     onEntityChange: (e: Entity) => void
     isLoading?: boolean
-}
-
-const GRAN_LABELS: Record<Granularity, string> = {
-    year: 'Year',
-    month: 'Month',
-    week: 'Week',
-    day: 'Day',
 }
 
 const ENTITY_SINGULAR: Record<Entity, string> = {
@@ -129,28 +123,11 @@ export const StreamDiscovery: FC<Props> = ({
                 <EntityTabs value={entity} onChange={onEntityChange} />
             }
         >
-            <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30 self-start mb-3">
-                {(['year', 'month', 'week', 'day'] as const).map((g) => {
-                    const available = availableGranularities.includes(g)
-                    const active = granularity === g
-                    return (
-                        <button
-                            key={g}
-                            onClick={() => available && onGranularityChange(g)}
-                            disabled={!available}
-                            className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
-                                active
-                                    ? 'bg-blue-500 text-white shadow-sm'
-                                    : available
-                                      ? 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-                                      : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
-                            }`}
-                        >
-                            {GRAN_LABELS[g]}
-                        </button>
-                    )
-                })}
-            </div>
+            <GranularityTabs
+                value={granularity}
+                available={availableGranularities}
+                onChange={onGranularityChange}
+            />
 
             {!data?.length || (stats?.total_distinct ?? 0) === 0 ? (
                 <ChartCardEmpty

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react'
 import { useState } from 'react'
 import type {
-    Entity,
+    EntityType,
     Granularity,
     StreamDiscoveryQueryResult,
     StreamDiscoveryStatsQueryResult,
@@ -31,12 +31,12 @@ type Props = {
     granularity: Granularity
     availableGranularities: Granularity[]
     onGranularityChange: (g: Granularity) => void
-    entity: Entity
-    onEntityChange: (e: Entity) => void
+    entity: EntityType
+    onEntityChange: (e: EntityType) => void
     isLoading?: boolean
 }
 
-const ENTITY_SINGULAR: Record<Entity, string> = {
+const ENTITY_SINGULAR: Record<EntityType, string> = {
     tracks: 'track',
     artists: 'artist',
     albums: 'album',

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -1,11 +1,11 @@
 import type { FC } from 'react'
 import { useState } from 'react'
 import type {
-    EntityType,
-    Granularity,
     StreamDiscoveryQueryResult,
     StreamDiscoveryStatsQueryResult,
 } from './query'
+import type { Granularity } from '../shared/useGranularity'
+import type { EntityType } from '../types'
 import {
     ChartCard,
     ChartCardEmpty,

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -5,6 +5,7 @@ import type {
     StreamDiscoveryStatsQueryResult,
 } from './query'
 import type { Granularity, EntityType } from '../shared/types'
+import { formatTooltipDate } from '../shared/formatTooltipDate'
 import {
     ChartCard,
     ChartCardEmpty,
@@ -39,21 +40,6 @@ const ENTITY_SINGULAR: Record<EntityType, string> = {
     tracks: 'track',
     artists: 'artist',
     albums: 'album',
-}
-
-function formatTooltipDate(date: Date, granularity: Granularity): string {
-    if (granularity === 'year')
-        return date.toLocaleDateString(undefined, { year: 'numeric' })
-    if (granularity === 'month')
-        return date.toLocaleDateString(undefined, {
-            month: 'long',
-            year: 'numeric',
-        })
-    return date.toLocaleDateString(undefined, {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-    })
 }
 
 function getBarLabel(

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -4,8 +4,7 @@ import type {
     StreamDiscoveryQueryResult,
     StreamDiscoveryStatsQueryResult,
 } from './query'
-import type { Granularity } from '../shared/useGranularity'
-import type { EntityType } from '../types'
+import type { Granularity, EntityType } from '../shared/types'
 import {
     ChartCard,
     ChartCardEmpty,

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -6,6 +6,7 @@ import type {
 } from './query'
 import type { Granularity, EntityType } from '../shared/types'
 import { formatTooltipDate } from '../shared/formatTooltipDate'
+import { formatBarLabel } from '../shared/formatBarLabel'
 import {
     ChartCard,
     ChartCardEmpty,
@@ -40,38 +41,6 @@ const ENTITY_SINGULAR: Record<EntityType, string> = {
     tracks: 'track',
     artists: 'artist',
     albums: 'album',
-}
-
-function getBarLabel(
-    d: StreamDiscoveryQueryResult,
-    index: number,
-    data: StreamDiscoveryQueryResult[],
-    year: number | undefined,
-    granularity: Granularity
-): string {
-    const date = new Date(d.ts)
-
-    if (granularity === 'year') return String(date.getUTCFullYear())
-
-    if (granularity === 'month') {
-        if (year !== undefined)
-            return date.toLocaleDateString(undefined, { month: 'short' })
-        return date.getUTCMonth() === 0 ? String(date.getUTCFullYear()) : ''
-    }
-
-    if (granularity === 'week') {
-        if (index === 0)
-            return date.toLocaleDateString(undefined, { month: 'short' })
-        const prev = new Date(data[index - 1].ts)
-        return date.getUTCMonth() !== prev.getUTCMonth()
-            ? date.toLocaleDateString(undefined, { month: 'short' })
-            : ''
-    }
-
-    // day
-    return date.getUTCDate() === 1
-        ? date.toLocaleDateString(undefined, { month: 'short' })
-        : ''
 }
 
 export const StreamDiscovery: FC<Props> = ({
@@ -171,7 +140,7 @@ export const StreamDiscovery: FC<Props> = ({
                             style={{ minWidth: `${data.length * 4}px` }}
                         >
                             {data.map((d, i) => {
-                                const label = getBarLabel(
+                                const label = formatBarLabel(
                                     d,
                                     i,
                                     data,

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/index.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/index.tsx
@@ -3,7 +3,7 @@ import { useDBQueryMany } from '../../../../hooks/useDBQuery'
 import {
     queryStreamDiscovery,
     queryStreamDiscoveryStats,
-    type Entity,
+    type EntityType,
     type StreamDiscoveryQueryResult,
     type StreamDiscoveryStatsQueryResult,
 } from './query'
@@ -17,7 +17,7 @@ interface StreamDiscoveryProps {
 export function StreamDiscovery({ year }: StreamDiscoveryProps) {
     const { setGranularity, availableGranularities, effectiveGranularity } =
         useGranularity(year)
-    const [entity, setEntity] = useState<Entity>('tracks')
+    const [entity, setEntity] = useState<EntityType>('tracks')
 
     const { data, isLoading } = useDBQueryMany<StreamDiscoveryQueryResult>({
         query: queryStreamDiscovery(year, effectiveGranularity, entity),

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/index.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/index.tsx
@@ -3,12 +3,12 @@ import { useDBQueryMany } from '../../../../hooks/useDBQuery'
 import {
     queryStreamDiscovery,
     queryStreamDiscoveryStats,
-    type EntityType,
     type StreamDiscoveryQueryResult,
     type StreamDiscoveryStatsQueryResult,
 } from './query'
 import { StreamDiscovery as StreamDiscoveryView } from './StreamDiscovery'
 import { useGranularity } from '../shared/useGranularity'
+import type { EntityType } from '../types'
 
 interface StreamDiscoveryProps {
     year: number | undefined

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/index.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/index.tsx
@@ -4,30 +4,20 @@ import {
     queryStreamDiscovery,
     queryStreamDiscoveryStats,
     type Entity,
-    type Granularity,
     type StreamDiscoveryQueryResult,
     type StreamDiscoveryStatsQueryResult,
 } from './query'
 import { StreamDiscovery as StreamDiscoveryView } from './StreamDiscovery'
-
-const ALL_TIME_GRANULARITIES: Granularity[] = ['year', 'month']
-const PER_YEAR_GRANULARITIES: Granularity[] = ['month', 'week', 'day']
+import { useGranularity } from '../shared/useGranularity'
 
 interface StreamDiscoveryProps {
     year: number | undefined
 }
 
 export function StreamDiscovery({ year }: StreamDiscoveryProps) {
-    const [granularity, setGranularity] = useState<Granularity>('month')
+    const { setGranularity, availableGranularities, effectiveGranularity } =
+        useGranularity(year)
     const [entity, setEntity] = useState<Entity>('tracks')
-
-    const availableGranularities =
-        year !== undefined ? PER_YEAR_GRANULARITIES : ALL_TIME_GRANULARITIES
-
-    // Avoids double-fetch: derived fallback instead of useEffect resetting granularity.
-    const effectiveGranularity = availableGranularities.includes(granularity)
-        ? granularity
-        : availableGranularities[0]
 
     const { data, isLoading } = useDBQueryMany<StreamDiscoveryQueryResult>({
         query: queryStreamDiscovery(year, effectiveGranularity, entity),

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/index.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/index.tsx
@@ -8,7 +8,7 @@ import {
 } from './query'
 import { StreamDiscovery as StreamDiscoveryView } from './StreamDiscovery'
 import { useGranularity } from '../shared/useGranularity'
-import type { EntityType } from '../types'
+import type { EntityType } from '../shared/types'
 
 interface StreamDiscoveryProps {
     year: number | undefined

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/query.ts
@@ -3,10 +3,10 @@ import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryStreamDiscovery from './StreamDiscovery.sql?raw'
 import sqlQueryStreamDiscoveryStats from './StreamDiscoveryStats.sql?raw'
 import type { Granularity } from '../shared/useGranularity'
+import type { EntityType } from '../types'
 
 export type { Granularity }
-
-export type Entity = 'tracks' | 'artists' | 'albums'
+export type { EntityType }
 
 export type StreamDiscoveryQueryResult = {
     ts: string
@@ -21,7 +21,7 @@ export type StreamDiscoveryStatsQueryResult = {
     total_distinct: number
 }
 
-const ENTITY_COLUMN: Record<Entity, string> = {
+const ENTITY_COLUMN: Record<EntityType, string> = {
     tracks: 'track_uri',
     artists: 'artist_name',
     albums: 'album_name',
@@ -75,7 +75,7 @@ const GRAN_CONFIG: Record<Granularity, GranConfig> = {
 
 export function queryStreamDiscoveryStats(
     year: number | undefined,
-    entity: Entity
+    entity: EntityType
 ): string {
     const yearCondition = buildYearCondition(year)
     const newCondition =
@@ -90,7 +90,7 @@ export function queryStreamDiscoveryStats(
 export function queryStreamDiscovery(
     year: number | undefined,
     granularity: Granularity,
-    entity: Entity
+    entity: EntityType
 ): string {
     const yearCondition = buildYearCondition(year)
     const perYear = year !== undefined

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/query.ts
@@ -2,8 +2,9 @@ import { TABLE } from '../../../../db/queries/constants'
 import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryStreamDiscovery from './StreamDiscovery.sql?raw'
 import sqlQueryStreamDiscoveryStats from './StreamDiscoveryStats.sql?raw'
+import type { Granularity } from '../shared/useGranularity'
 
-export type Granularity = 'year' | 'month' | 'week' | 'day'
+export type { Granularity }
 
 export type Entity = 'tracks' | 'artists' | 'albums'
 

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/query.ts
@@ -5,9 +5,6 @@ import sqlQueryStreamDiscoveryStats from './StreamDiscoveryStats.sql?raw'
 import type { Granularity } from '../shared/useGranularity'
 import type { EntityType } from '../types'
 
-export type { Granularity }
-export type { EntityType }
-
 export type StreamDiscoveryQueryResult = {
     ts: string
     new_count: number

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/query.ts
@@ -2,8 +2,7 @@ import { TABLE } from '../../../../db/queries/constants'
 import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryStreamDiscovery from './StreamDiscovery.sql?raw'
 import sqlQueryStreamDiscoveryStats from './StreamDiscoveryStats.sql?raw'
-import type { Granularity } from '../shared/useGranularity'
-import type { EntityType } from '../types'
+import type { Granularity, EntityType } from '../shared/types'
 
 export type StreamDiscoveryQueryResult = {
     ts: string

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
@@ -1,6 +1,7 @@
 import { Fragment, type ReactNode, useMemo, useState } from 'react'
 import type { StreamPerDayOfWeekQueryResult } from './query'
 import { ChartCard, ChartTooltip } from '../../SimpleCharts/shared'
+import { InsightList, InsightRow } from '../shared/InsightList'
 import { RaceControlBar } from '../Common/RaceControlBar'
 import { useRacePlayback } from '../Common/useRacePlayback'
 
@@ -449,48 +450,27 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                         />
                     )}
 
-                    <ul
-                        className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700"
-                        role="list"
-                    >
-                        <li
-                            className="flex justify-between items-center"
-                            role="listitem"
-                        >
-                            <span className="text-sm text-gray-600 dark:text-gray-400">
-                                First complete hour
-                            </span>
-                            {firstCompleteHourFrame !== null &&
-                                currentFrameIdx >= firstCompleteHourFrame && (
-                                    <span className="font-bold text-sm">
-                                        {firstCompleteHourLabel}
-                                    </span>
-                                )}
-                        </li>
-                        <li
-                            className="flex justify-between items-center mt-1"
-                            role="listitem"
-                        >
-                            <span className="text-sm text-gray-600 dark:text-gray-400">
-                                First complete day
-                            </span>
-                            {firstCompleteDayFrame !== null &&
-                                currentFrameIdx >= firstCompleteDayFrame && (
-                                    <span className="font-bold text-sm">
-                                        {firstCompleteDayLabel}
-                                    </span>
-                                )}
-                        </li>
-                        <li
-                            className="flex justify-between items-center mt-1"
-                            role="listitem"
-                        >
-                            <span className="text-sm text-gray-600 dark:text-gray-400">
-                                Bingo
-                            </span>
-                            {bingoValue}
-                        </li>
-                    </ul>
+                    <InsightList>
+                        <InsightRow
+                            label="First complete hour"
+                            value={
+                                firstCompleteHourFrame !== null &&
+                                currentFrameIdx >= firstCompleteHourFrame
+                                    ? firstCompleteHourLabel
+                                    : null
+                            }
+                        />
+                        <InsightRow
+                            label="First complete day"
+                            value={
+                                firstCompleteDayFrame !== null &&
+                                currentFrameIdx >= firstCompleteDayFrame
+                                    ? firstCompleteDayLabel
+                                    : null
+                            }
+                        />
+                        <InsightRow label="Bingo" value={bingoValue} />
+                    </InsightList>
                 </div>
                 {tooltip && (
                     <ChartTooltip x={tooltip.x} y={tooltip.y}>

--- a/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
+++ b/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react'
 import { useState } from 'react'
 import type { StreamTimelineQueryResult } from './query'
-import type { Granularity } from '../shared/useGranularity'
+import type { Granularity } from '../shared/types'
 import { formatDuration } from '../../../../utils/formatDuration'
 import {
     ChartCard,

--- a/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
+++ b/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
@@ -8,6 +8,7 @@ import {
     ChartTooltip,
 } from '../../SimpleCharts/shared'
 import { GranularityTabs } from '../shared/GranularityTabs'
+import { InsightList, InsightRow } from '../shared/InsightList'
 
 type TooltipState = {
     x: number
@@ -175,33 +176,16 @@ export const StreamTimeline: FC<Props> = ({
                         </div>
                     </div>
 
-                    <ul
-                        className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700"
-                        role="list"
-                    >
-                        <li
-                            className="flex justify-between items-center"
-                            role="listitem"
-                        >
-                            <span className="text-sm text-gray-600 dark:text-gray-400">
-                                Total duration
-                            </span>
-                            <span className="font-bold">
-                                {formatDuration(totalMs)}
-                            </span>
-                        </li>
-                        <li
-                            className="flex justify-between items-center mt-1"
-                            role="listitem"
-                        >
-                            <span className="text-sm text-gray-600 dark:text-gray-400">
-                                Total streams
-                            </span>
-                            <span className="font-bold">
-                                {totalStreams.toLocaleString()}
-                            </span>
-                        </li>
-                    </ul>
+                    <InsightList>
+                        <InsightRow
+                            label="Total duration"
+                            value={formatDuration(totalMs)}
+                        />
+                        <InsightRow
+                            label="Total streams"
+                            value={totalStreams.toLocaleString()}
+                        />
+                    </InsightList>
                 </>
             )}
             {tooltip && (

--- a/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
+++ b/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
@@ -7,6 +7,7 @@ import {
     ChartCardEmpty,
     ChartTooltip,
 } from '../../SimpleCharts/shared'
+import { GranularityTabs } from '../shared/GranularityTabs'
 
 type TooltipState = {
     x: number
@@ -23,13 +24,6 @@ type Props = {
     availableGranularities: Granularity[]
     onGranularityChange: (g: Granularity) => void
     isLoading?: boolean
-}
-
-const GRAN_LABELS: Record<Granularity, string> = {
-    year: 'Year',
-    month: 'Month',
-    week: 'Week',
-    day: 'Day',
 }
 
 function formatTooltipDate(date: Date, granularity: Granularity): string {
@@ -103,28 +97,11 @@ export const StreamTimeline: FC<Props> = ({
             isLoading={isLoading}
             question="How did my listening evolve over time?"
         >
-            <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30 self-start mb-3">
-                {(['year', 'month', 'week', 'day'] as const).map((g) => {
-                    const available = availableGranularities.includes(g)
-                    const active = granularity === g
-                    return (
-                        <button
-                            key={g}
-                            onClick={() => available && onGranularityChange(g)}
-                            disabled={!available}
-                            className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
-                                active
-                                    ? 'bg-blue-500 text-white shadow-sm'
-                                    : available
-                                      ? 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-                                      : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
-                            }`}
-                        >
-                            {GRAN_LABELS[g]}
-                        </button>
-                    )
-                })}
-            </div>
+            <GranularityTabs
+                value={granularity}
+                available={availableGranularities}
+                onChange={onGranularityChange}
+            />
 
             {!data?.length || totalStreams === 0 ? (
                 <ChartCardEmpty

--- a/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
+++ b/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import type { StreamTimelineQueryResult } from './query'
 import type { Granularity } from '../shared/types'
 import { formatDuration } from '../../../../utils/formatDuration'
+import { formatTooltipDate } from '../shared/formatTooltipDate'
 import {
     ChartCard,
     ChartCardEmpty,
@@ -26,21 +27,6 @@ type Props = {
     availableGranularities: Granularity[]
     onGranularityChange: (g: Granularity) => void
     isLoading?: boolean
-}
-
-function formatTooltipDate(date: Date, granularity: Granularity): string {
-    if (granularity === 'year')
-        return date.toLocaleDateString(undefined, { year: 'numeric' })
-    if (granularity === 'month')
-        return date.toLocaleDateString(undefined, {
-            month: 'long',
-            year: 'numeric',
-        })
-    return date.toLocaleDateString(undefined, {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-    })
 }
 
 function getBarLabel(

--- a/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
+++ b/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 import { useState } from 'react'
-import type { Granularity, StreamTimelineQueryResult } from './query'
+import type { StreamTimelineQueryResult } from './query'
+import type { Granularity } from '../shared/useGranularity'
 import { formatDuration } from '../../../../utils/formatDuration'
 import {
     ChartCard,

--- a/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
+++ b/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
@@ -4,6 +4,7 @@ import type { StreamTimelineQueryResult } from './query'
 import type { Granularity } from '../shared/types'
 import { formatDuration } from '../../../../utils/formatDuration'
 import { formatTooltipDate } from '../shared/formatTooltipDate'
+import { formatBarLabel } from '../shared/formatBarLabel'
 import {
     ChartCard,
     ChartCardEmpty,
@@ -27,38 +28,6 @@ type Props = {
     availableGranularities: Granularity[]
     onGranularityChange: (g: Granularity) => void
     isLoading?: boolean
-}
-
-function getBarLabel(
-    d: StreamTimelineQueryResult,
-    index: number,
-    data: StreamTimelineQueryResult[],
-    year: number | undefined,
-    granularity: Granularity
-): string {
-    const date = new Date(d.ts)
-
-    if (granularity === 'year') return String(date.getUTCFullYear())
-
-    if (granularity === 'month') {
-        if (year !== undefined)
-            return date.toLocaleDateString(undefined, { month: 'short' })
-        return date.getUTCMonth() === 0 ? String(date.getUTCFullYear()) : ''
-    }
-
-    if (granularity === 'week') {
-        if (index === 0)
-            return date.toLocaleDateString(undefined, { month: 'short' })
-        const prev = new Date(data[index - 1].ts)
-        return date.getUTCMonth() !== prev.getUTCMonth()
-            ? date.toLocaleDateString(undefined, { month: 'short' })
-            : ''
-    }
-
-    // day
-    return date.getUTCDate() === 1
-        ? date.toLocaleDateString(undefined, { month: 'short' })
-        : ''
 }
 
 export const StreamTimeline: FC<Props> = ({
@@ -140,7 +109,7 @@ export const StreamTimeline: FC<Props> = ({
                             style={{ minWidth: `${data.length * 4}px` }}
                         >
                             {data.map((d, i) => {
-                                const label = getBarLabel(
+                                const label = formatBarLabel(
                                     d,
                                     i,
                                     data,

--- a/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
+++ b/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
@@ -110,7 +110,7 @@ export const StreamTimeline: FC<Props> = ({
                         >
                             {data.map((d, i) => {
                                 const label = formatBarLabel(
-                                    d,
+                                    d.ts,
                                     i,
                                     data,
                                     year,
@@ -147,7 +147,7 @@ export const StreamTimeline: FC<Props> = ({
             {tooltip && (
                 <ChartTooltip x={tooltip.x} y={tooltip.y}>
                     <div className="font-semibold">
-                        {formatTooltipDate(new Date(tooltip.ts), granularity)}
+                        {formatTooltipDate(tooltip.ts, granularity)}
                     </div>
                     <div className="text-gray-300 dark:text-gray-400">
                         {formatDuration(tooltip.ms_played)}

--- a/app/src/components/Charts/LabCharts/StreamTimeline/index.tsx
+++ b/app/src/components/Charts/LabCharts/StreamTimeline/index.tsx
@@ -1,29 +1,15 @@
-import { useState } from 'react'
 import { useDBQueryMany } from '../../../../hooks/useDBQuery'
-import {
-    queryStreamTimeline,
-    type Granularity,
-    type StreamTimelineQueryResult,
-} from './query'
+import { queryStreamTimeline, type StreamTimelineQueryResult } from './query'
 import { StreamTimeline as StreamTimelineView } from './StreamTimeline'
-
-const ALL_TIME_GRANULARITIES: Granularity[] = ['year', 'month']
-const PER_YEAR_GRANULARITIES: Granularity[] = ['month', 'week', 'day']
+import { useGranularity } from '../shared/useGranularity'
 
 interface StreamTimelineProps {
     year: number | undefined
 }
 
 export function StreamTimeline({ year }: StreamTimelineProps) {
-    const [granularity, setGranularity] = useState<Granularity>('month')
-
-    const availableGranularities =
-        year !== undefined ? PER_YEAR_GRANULARITIES : ALL_TIME_GRANULARITIES
-
-    // Avoids double-fetch: derived fallback instead of useEffect resetting granularity.
-    const effectiveGranularity = availableGranularities.includes(granularity)
-        ? granularity
-        : 'month'
+    const { setGranularity, availableGranularities, effectiveGranularity } =
+        useGranularity(year)
 
     const { data, isLoading } = useDBQueryMany<StreamTimelineQueryResult>({
         query: queryStreamTimeline(year, effectiveGranularity),

--- a/app/src/components/Charts/LabCharts/StreamTimeline/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamTimeline/query.ts
@@ -1,8 +1,9 @@
 import { TABLE } from '../../../../db/queries/constants'
 import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryStreamTimeline from './StreamTimeline.sql?raw'
+import type { Granularity } from '../shared/useGranularity'
 
-export type Granularity = 'year' | 'month' | 'week' | 'day'
+export type { Granularity }
 
 export type StreamTimelineQueryResult = {
     ts: string

--- a/app/src/components/Charts/LabCharts/StreamTimeline/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamTimeline/query.ts
@@ -1,7 +1,7 @@
 import { TABLE } from '../../../../db/queries/constants'
 import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryStreamTimeline from './StreamTimeline.sql?raw'
-import type { Granularity } from '../shared/useGranularity'
+import type { Granularity } from '../shared/types'
 
 export type StreamTimelineQueryResult = {
     ts: string

--- a/app/src/components/Charts/LabCharts/StreamTimeline/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamTimeline/query.ts
@@ -3,8 +3,6 @@ import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryStreamTimeline from './StreamTimeline.sql?raw'
 import type { Granularity } from '../shared/useGranularity'
 
-export type { Granularity }
-
 export type StreamTimelineQueryResult = {
     ts: string
     ms_played: number

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -7,6 +7,7 @@ import type {
 import type { Granularity, EntityType } from '../shared/types'
 import { formatTooltipDate } from '../shared/formatTooltipDate'
 import { formatBarLabel } from '../shared/formatBarLabel'
+import { ChartLegend } from '../shared/ChartLegend'
 import {
     ChartCard,
     ChartCardEmpty,
@@ -169,16 +170,12 @@ export const StreamVariety: FC<Props> = ({
                         </div>
                     </div>
 
-                    <div className="mt-1 mb-3 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
-                        <span className="flex items-center gap-1">
-                            <span className="inline-block w-2 h-2 rounded-sm bg-orange-400" />
-                            Distinct
-                        </span>
-                        <span className="flex items-center gap-1">
-                            <span className="inline-block w-2 h-2 rounded-sm bg-yellow-400" />
-                            Re-listens
-                        </span>
-                    </div>
+                    <ChartLegend
+                        items={[
+                            { color: 'bg-orange-400', label: 'Distinct' },
+                            { color: 'bg-yellow-400', label: 'Re-listens' },
+                        ]}
+                    />
 
                     <InsightList>
                         <InsightRow

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -148,7 +148,7 @@ export const StreamVariety: FC<Props> = ({
                         >
                             {data.map((d, i) => {
                                 const label = formatBarLabel(
-                                    d,
+                                    d.ts,
                                     i,
                                     data,
                                     year,
@@ -206,7 +206,7 @@ export const StreamVariety: FC<Props> = ({
             {tooltip && (
                 <ChartTooltip x={tooltip.x} y={tooltip.y}>
                     <div className="font-semibold">
-                        {formatTooltipDate(new Date(tooltip.ts), granularity)}
+                        {formatTooltipDate(tooltip.ts, granularity)}
                     </div>
                     <div className="text-gray-300 dark:text-gray-400">
                         {tooltip.distinct_count.toLocaleString()} distinct

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -1,11 +1,11 @@
 import type { FC } from 'react'
 import { useState } from 'react'
 import type {
-    EntityType,
-    Granularity,
     StreamVarietyQueryResult,
     StreamVarietyStatsQueryResult,
 } from './query'
+import type { Granularity } from '../shared/useGranularity'
+import type { EntityType } from '../types'
 import {
     ChartCard,
     ChartCardEmpty,

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -12,6 +12,7 @@ import {
     ChartTooltip,
 } from '../../SimpleCharts/shared'
 import { EntityTabs } from '../shared/EntityTabs'
+import { GranularityTabs } from '../shared/GranularityTabs'
 
 type TooltipState = {
     x: number
@@ -32,13 +33,6 @@ type Props = {
     entity: Entity
     onEntityChange: (e: Entity) => void
     isLoading?: boolean
-}
-
-const GRAN_LABELS: Record<Granularity, string> = {
-    year: 'Year',
-    month: 'Month',
-    week: 'Week',
-    day: 'Day',
 }
 
 const ENTITY_SINGULAR: Record<Entity, string> = {
@@ -130,28 +124,11 @@ export const StreamVariety: FC<Props> = ({
                 <EntityTabs value={entity} onChange={onEntityChange} />
             }
         >
-            <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30 self-start mb-3">
-                {(['year', 'month', 'week', 'day'] as const).map((g) => {
-                    const available = availableGranularities.includes(g)
-                    const active = granularity === g
-                    return (
-                        <button
-                            key={g}
-                            onClick={() => available && onGranularityChange(g)}
-                            disabled={!available}
-                            className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
-                                active
-                                    ? 'bg-blue-500 text-white shadow-sm'
-                                    : available
-                                      ? 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-                                      : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
-                            }`}
-                        >
-                            {GRAN_LABELS[g]}
-                        </button>
-                    )
-                })}
-            </div>
+            <GranularityTabs
+                value={granularity}
+                available={availableGranularities}
+                onChange={onGranularityChange}
+            />
 
             {!data?.length || (stats?.total_streams ?? 0) === 0 ? (
                 <ChartCardEmpty

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -6,6 +6,7 @@ import type {
 } from './query'
 import type { Granularity, EntityType } from '../shared/types'
 import { formatTooltipDate } from '../shared/formatTooltipDate'
+import { formatBarLabel } from '../shared/formatBarLabel'
 import {
     ChartCard,
     ChartCardEmpty,
@@ -40,38 +41,6 @@ const ENTITY_SINGULAR: Record<EntityType, string> = {
     tracks: 'track',
     artists: 'artist',
     albums: 'album',
-}
-
-function getBarLabel(
-    d: StreamVarietyQueryResult,
-    index: number,
-    data: StreamVarietyQueryResult[],
-    year: number | undefined,
-    granularity: Granularity
-): string {
-    const date = new Date(d.ts)
-
-    if (granularity === 'year') return String(date.getUTCFullYear())
-
-    if (granularity === 'month') {
-        if (year !== undefined)
-            return date.toLocaleDateString(undefined, { month: 'short' })
-        return date.getUTCMonth() === 0 ? String(date.getUTCFullYear()) : ''
-    }
-
-    if (granularity === 'week') {
-        if (index === 0)
-            return date.toLocaleDateString(undefined, { month: 'short' })
-        const prev = new Date(data[index - 1].ts)
-        return date.getUTCMonth() !== prev.getUTCMonth()
-            ? date.toLocaleDateString(undefined, { month: 'short' })
-            : ''
-    }
-
-    // day
-    return date.getUTCDate() === 1
-        ? date.toLocaleDateString(undefined, { month: 'short' })
-        : ''
 }
 
 export const StreamVariety: FC<Props> = ({
@@ -177,7 +146,7 @@ export const StreamVariety: FC<Props> = ({
                             style={{ minWidth: `${data.length * 4}px` }}
                         >
                             {data.map((d, i) => {
-                                const label = getBarLabel(
+                                const label = formatBarLabel(
                                     d,
                                     i,
                                     data,

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -5,6 +5,7 @@ import type {
     StreamVarietyStatsQueryResult,
 } from './query'
 import type { Granularity, EntityType } from '../shared/types'
+import { formatTooltipDate } from '../shared/formatTooltipDate'
 import {
     ChartCard,
     ChartCardEmpty,
@@ -39,21 +40,6 @@ const ENTITY_SINGULAR: Record<EntityType, string> = {
     tracks: 'track',
     artists: 'artist',
     albums: 'album',
-}
-
-function formatTooltipDate(date: Date, granularity: Granularity): string {
-    if (granularity === 'year')
-        return date.toLocaleDateString(undefined, { year: 'numeric' })
-    if (granularity === 'month')
-        return date.toLocaleDateString(undefined, {
-            month: 'long',
-            year: 'numeric',
-        })
-    return date.toLocaleDateString(undefined, {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-    })
 }
 
 function getBarLabel(

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../SimpleCharts/shared'
 import { EntityTabs } from '../shared/EntityTabs'
 import { GranularityTabs } from '../shared/GranularityTabs'
+import { InsightList, InsightRow } from '../shared/InsightList'
 
 type TooltipState = {
     x: number
@@ -225,34 +226,23 @@ export const StreamVariety: FC<Props> = ({
                         </span>
                     </div>
 
-                    <ul
-                        className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700"
-                        role="list"
-                    >
-                        <li
-                            className="flex justify-between items-center"
-                            role="listitem"
-                        >
-                            <span className="text-sm text-gray-600 dark:text-gray-400">
-                                Unique {ENTITY_SINGULAR[entity]}s listened
-                            </span>
-                            <span className="font-bold">
-                                {totalDistinct.toLocaleString()}
-                            </span>
-                        </li>
-                        <li
-                            className="flex justify-between items-center mt-1"
-                            role="listitem"
-                        >
-                            <span className="text-sm text-gray-600 dark:text-gray-400">
-                                Variety rate
-                                <span className="ml-1 text-xs font-normal text-gray-400 dark:text-gray-500">
-                                    (unique / total streams)
-                                </span>
-                            </span>
-                            <span className="font-bold">{varietyRate}%</span>
-                        </li>
-                    </ul>
+                    <InsightList>
+                        <InsightRow
+                            label={`Unique ${ENTITY_SINGULAR[entity]}s listened`}
+                            value={totalDistinct.toLocaleString()}
+                        />
+                        <InsightRow
+                            label={
+                                <>
+                                    Variety rate
+                                    <span className="ml-1 text-xs font-normal text-gray-400 dark:text-gray-500">
+                                        (unique / total streams)
+                                    </span>
+                                </>
+                            }
+                            value={`${varietyRate}%`}
+                        />
+                    </InsightList>
                     {entity !== 'tracks' && (
                         <p className="mt-2 text-xs italic text-gray-400 dark:text-gray-500">
                             Artist and album counts rely on names, not unique

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react'
 import { useState } from 'react'
 import type {
-    Entity,
+    EntityType,
     Granularity,
     StreamVarietyQueryResult,
     StreamVarietyStatsQueryResult,
@@ -31,12 +31,12 @@ type Props = {
     granularity: Granularity
     availableGranularities: Granularity[]
     onGranularityChange: (g: Granularity) => void
-    entity: Entity
-    onEntityChange: (e: Entity) => void
+    entity: EntityType
+    onEntityChange: (e: EntityType) => void
     isLoading?: boolean
 }
 
-const ENTITY_SINGULAR: Record<Entity, string> = {
+const ENTITY_SINGULAR: Record<EntityType, string> = {
     tracks: 'track',
     artists: 'artist',
     albums: 'album',

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -11,6 +11,7 @@ import {
     ChartCardEmpty,
     ChartTooltip,
 } from '../../SimpleCharts/shared'
+import { EntityTabs } from '../shared/EntityTabs'
 
 type TooltipState = {
     x: number
@@ -38,12 +39,6 @@ const GRAN_LABELS: Record<Granularity, string> = {
     month: 'Month',
     week: 'Week',
     day: 'Day',
-}
-
-const ENTITY_LABELS: Record<Entity, string> = {
-    tracks: 'Tracks',
-    artists: 'Artists',
-    albums: 'Albums',
 }
 
 const ENTITY_SINGULAR: Record<Entity, string> = {
@@ -125,31 +120,15 @@ export const StreamVariety: FC<Props> = ({
         : 0
     const sparseLabelLayout = granularity !== 'month' || year === undefined
 
-    const entityTabs = (
-        <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30">
-            {(['tracks', 'artists', 'albums'] as const).map((e) => (
-                <button
-                    key={e}
-                    onClick={() => onEntityChange(e)}
-                    className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
-                        entity === e
-                            ? 'bg-blue-500 text-white shadow-sm'
-                            : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-                    }`}
-                >
-                    {ENTITY_LABELS[e]}
-                </button>
-            ))}
-        </div>
-    )
-
     return (
         <ChartCard
             title="Stream Variety"
             emoji="🔀"
             isLoading={isLoading}
             question="How varied was my listening?"
-            headerActions={entityTabs}
+            headerActions={
+                <EntityTabs value={entity} onChange={onEntityChange} />
+            }
         >
             <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30 self-start mb-3">
                 {(['year', 'month', 'week', 'day'] as const).map((g) => {

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -4,8 +4,7 @@ import type {
     StreamVarietyQueryResult,
     StreamVarietyStatsQueryResult,
 } from './query'
-import type { Granularity } from '../shared/useGranularity'
-import type { EntityType } from '../types'
+import type { Granularity, EntityType } from '../shared/types'
 import {
     ChartCard,
     ChartCardEmpty,

--- a/app/src/components/Charts/LabCharts/StreamVariety/index.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/index.tsx
@@ -3,7 +3,7 @@ import { useDBQueryMany } from '../../../../hooks/useDBQuery'
 import {
     queryStreamVariety,
     queryStreamVarietyStats,
-    type Entity,
+    type EntityType,
     type StreamVarietyQueryResult,
     type StreamVarietyStatsQueryResult,
 } from './query'
@@ -17,7 +17,7 @@ interface StreamVarietyProps {
 export function StreamVariety({ year }: StreamVarietyProps) {
     const { setGranularity, availableGranularities, effectiveGranularity } =
         useGranularity(year)
-    const [entity, setEntity] = useState<Entity>('tracks')
+    const [entity, setEntity] = useState<EntityType>('tracks')
 
     const { data, isLoading } = useDBQueryMany<StreamVarietyQueryResult>({
         query: queryStreamVariety(year, effectiveGranularity, entity),

--- a/app/src/components/Charts/LabCharts/StreamVariety/index.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/index.tsx
@@ -4,30 +4,20 @@ import {
     queryStreamVariety,
     queryStreamVarietyStats,
     type Entity,
-    type Granularity,
     type StreamVarietyQueryResult,
     type StreamVarietyStatsQueryResult,
 } from './query'
 import { StreamVariety as StreamVarietyView } from './StreamVariety'
-
-const ALL_TIME_GRANULARITIES: Granularity[] = ['year', 'month']
-const PER_YEAR_GRANULARITIES: Granularity[] = ['month', 'week', 'day']
+import { useGranularity } from '../shared/useGranularity'
 
 interface StreamVarietyProps {
     year: number | undefined
 }
 
 export function StreamVariety({ year }: StreamVarietyProps) {
-    const [granularity, setGranularity] = useState<Granularity>('month')
+    const { setGranularity, availableGranularities, effectiveGranularity } =
+        useGranularity(year)
     const [entity, setEntity] = useState<Entity>('tracks')
-
-    const availableGranularities =
-        year !== undefined ? PER_YEAR_GRANULARITIES : ALL_TIME_GRANULARITIES
-
-    // Avoids double-fetch: derived fallback instead of useEffect resetting granularity.
-    const effectiveGranularity = availableGranularities.includes(granularity)
-        ? granularity
-        : availableGranularities[0]
 
     const { data, isLoading } = useDBQueryMany<StreamVarietyQueryResult>({
         query: queryStreamVariety(year, effectiveGranularity, entity),

--- a/app/src/components/Charts/LabCharts/StreamVariety/index.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/index.tsx
@@ -8,7 +8,7 @@ import {
 } from './query'
 import { StreamVariety as StreamVarietyView } from './StreamVariety'
 import { useGranularity } from '../shared/useGranularity'
-import type { EntityType } from '../types'
+import type { EntityType } from '../shared/types'
 
 interface StreamVarietyProps {
     year: number | undefined

--- a/app/src/components/Charts/LabCharts/StreamVariety/index.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/index.tsx
@@ -3,12 +3,12 @@ import { useDBQueryMany } from '../../../../hooks/useDBQuery'
 import {
     queryStreamVariety,
     queryStreamVarietyStats,
-    type EntityType,
     type StreamVarietyQueryResult,
     type StreamVarietyStatsQueryResult,
 } from './query'
 import { StreamVariety as StreamVarietyView } from './StreamVariety'
 import { useGranularity } from '../shared/useGranularity'
+import type { EntityType } from '../types'
 
 interface StreamVarietyProps {
     year: number | undefined

--- a/app/src/components/Charts/LabCharts/StreamVariety/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamVariety/query.ts
@@ -3,10 +3,10 @@ import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryStreamVariety from './StreamVariety.sql?raw'
 import sqlQueryStreamVarietyStats from './StreamVarietyStats.sql?raw'
 import type { Granularity } from '../shared/useGranularity'
+import type { EntityType } from '../types'
 
 export type { Granularity }
-
-export type Entity = 'tracks' | 'artists' | 'albums'
+export type { EntityType }
 
 export type StreamVarietyQueryResult = {
     ts: string
@@ -15,7 +15,7 @@ export type StreamVarietyQueryResult = {
     total_count: number
 }
 
-const ENTITY_COLUMN: Record<Entity, string> = {
+const ENTITY_COLUMN: Record<EntityType, string> = {
     tracks: 'track_uri',
     artists: 'artist_name',
     albums: 'album_name',
@@ -75,7 +75,7 @@ export type StreamVarietyStatsQueryResult = {
 
 export function queryStreamVarietyStats(
     year: number | undefined,
-    entity: Entity
+    entity: EntityType
 ): string {
     const yearCondition = buildYearCondition(year)
     return sqlQueryStreamVarietyStats
@@ -87,7 +87,7 @@ export function queryStreamVarietyStats(
 export function queryStreamVariety(
     year: number | undefined,
     granularity: Granularity,
-    entity: Entity
+    entity: EntityType
 ): string {
     const yearCondition = buildYearCondition(year)
     const perYear = year !== undefined

--- a/app/src/components/Charts/LabCharts/StreamVariety/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamVariety/query.ts
@@ -5,9 +5,6 @@ import sqlQueryStreamVarietyStats from './StreamVarietyStats.sql?raw'
 import type { Granularity } from '../shared/useGranularity'
 import type { EntityType } from '../types'
 
-export type { Granularity }
-export type { EntityType }
-
 export type StreamVarietyQueryResult = {
     ts: string
     distinct_count: number

--- a/app/src/components/Charts/LabCharts/StreamVariety/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamVariety/query.ts
@@ -2,8 +2,7 @@ import { TABLE } from '../../../../db/queries/constants'
 import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryStreamVariety from './StreamVariety.sql?raw'
 import sqlQueryStreamVarietyStats from './StreamVarietyStats.sql?raw'
-import type { Granularity } from '../shared/useGranularity'
-import type { EntityType } from '../types'
+import type { Granularity, EntityType } from '../shared/types'
 
 export type StreamVarietyQueryResult = {
     ts: string

--- a/app/src/components/Charts/LabCharts/StreamVariety/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamVariety/query.ts
@@ -2,8 +2,9 @@ import { TABLE } from '../../../../db/queries/constants'
 import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryStreamVariety from './StreamVariety.sql?raw'
 import sqlQueryStreamVarietyStats from './StreamVarietyStats.sql?raw'
+import type { Granularity } from '../shared/useGranularity'
 
-export type Granularity = 'year' | 'month' | 'week' | 'day'
+export type { Granularity }
 
 export type Entity = 'tracks' | 'artists' | 'albums'
 

--- a/app/src/components/Charts/LabCharts/Top10BillboardRace/Top10BillboardRaceView.tsx
+++ b/app/src/components/Charts/LabCharts/Top10BillboardRace/Top10BillboardRaceView.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
-import type { EntityType, Top10BillboardRaceQueryResult } from './query'
+import type { Top10BillboardRaceQueryResult } from './query'
+import type { EntityType } from '../shared/types'
 import { GhostLeaderboard, type GhostEntry } from './GhostLeaderboard'
 import { InsightCard } from '../../SimpleCharts/shared'
 import { BAR_CHART_COLORS } from '../barChartColors'

--- a/app/src/components/Charts/LabCharts/Top10BillboardRace/index.tsx
+++ b/app/src/components/Charts/LabCharts/Top10BillboardRace/index.tsx
@@ -7,6 +7,7 @@ import {
 } from './query'
 import { Top10BillboardRaceView } from './Top10BillboardRaceView'
 import { ChartCard, ChartCardEmpty } from '../../SimpleCharts/shared'
+import { EntityTabs } from '../shared/EntityTabs'
 
 export function Top10BillboardRace({ year }: { year: number | undefined }) {
     const [data, setData] = useState<Top10BillboardRaceQueryResult[]>([])
@@ -31,28 +32,6 @@ export function Top10BillboardRace({ year }: { year: number | undefined }) {
         fetchData()
     }, [year, entityType])
 
-    const entityTabs = (
-        <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30">
-            {(['artists', 'tracks', 'albums'] as const).map((type) => (
-                <button
-                    key={type}
-                    onClick={() => setEntityType(type)}
-                    className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
-                        entityType === type
-                            ? 'bg-blue-500 text-white shadow-sm'
-                            : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-                    }`}
-                >
-                    {type === 'artists'
-                        ? 'Artists'
-                        : type === 'tracks'
-                          ? 'Tracks'
-                          : 'Albums'}
-                </button>
-            ))}
-        </div>
-    )
-
     const isInitialLoad = isLoading && data.length === 0
 
     return (
@@ -62,7 +41,9 @@ export function Top10BillboardRace({ year }: { year: number | undefined }) {
             className="md:col-span-2 lg:col-span-3"
             isLoading={isInitialLoad}
             question="Who stayed in the charts the longest week after week?"
-            headerActions={entityTabs}
+            headerActions={
+                <EntityTabs value={entityType} onChange={setEntityType} />
+            }
         >
             {data.length === 0 ? (
                 <ChartCardEmpty />

--- a/app/src/components/Charts/LabCharts/Top10BillboardRace/index.tsx
+++ b/app/src/components/Charts/LabCharts/Top10BillboardRace/index.tsx
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react'
 import { queryDBAsJSON } from '../../../../db/queries/queryDB'
 import {
     queryTop10BillboardRace,
-    type EntityType,
     type Top10BillboardRaceQueryResult,
 } from './query'
+import type { EntityType } from '../shared/types'
 import { Top10BillboardRaceView } from './Top10BillboardRaceView'
 import { ChartCard, ChartCardEmpty } from '../../SimpleCharts/shared'
 import { EntityTabs } from '../shared/EntityTabs'

--- a/app/src/components/Charts/LabCharts/Top10BillboardRace/query.ts
+++ b/app/src/components/Charts/LabCharts/Top10BillboardRace/query.ts
@@ -3,8 +3,7 @@ import sqlTop10Artists from './Top10BillboardRaceArtists.sql?raw'
 import sqlTop10Tracks from './Top10BillboardRaceTracks.sql?raw'
 import sqlTop10Albums from './Top10BillboardRaceAlbums.sql?raw'
 
-import type { EntityType } from '../types'
-export type { EntityType }
+import type { EntityType } from '../shared/types'
 
 const sqlByEntity: Record<EntityType, string> = {
     artists: sqlTop10Artists,

--- a/app/src/components/Charts/LabCharts/Top10Race/Top10RaceView.tsx
+++ b/app/src/components/Charts/LabCharts/Top10Race/Top10RaceView.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
-import type { EntityType, Top10RaceQueryResult } from './query'
+import type { Top10RaceQueryResult } from './query'
+import type { EntityType } from '../shared/types'
 import { BAR_CHART_COLORS } from '../barChartColors'
 import { RaceControlBar } from '../Common/RaceControlBar'
 import { useRacePlayback } from '../Common/useRacePlayback'

--- a/app/src/components/Charts/LabCharts/Top10Race/index.tsx
+++ b/app/src/components/Charts/LabCharts/Top10Race/index.tsx
@@ -7,6 +7,7 @@ import {
 } from './query'
 import { Top10RaceView } from './Top10RaceView'
 import { ChartCard, ChartCardEmpty } from '../../SimpleCharts/shared'
+import { EntityTabs } from '../shared/EntityTabs'
 
 export function Top10Race({ year }: { year: number | undefined }) {
     const [data, setData] = useState<Top10RaceQueryResult[]>([])
@@ -30,28 +31,6 @@ export function Top10Race({ year }: { year: number | undefined }) {
         fetchData()
     }, [year, entityType])
 
-    const entityTabs = (
-        <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30">
-            {(['artists', 'tracks', 'albums'] as const).map((type) => (
-                <button
-                    key={type}
-                    onClick={() => setEntityType(type)}
-                    className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
-                        entityType === type
-                            ? 'bg-blue-500 text-white shadow-sm'
-                            : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-                    }`}
-                >
-                    {type === 'artists'
-                        ? 'Artists'
-                        : type === 'tracks'
-                          ? 'Tracks'
-                          : 'Albums'}
-                </button>
-            ))}
-        </div>
-    )
-
     const isInitialLoad = isLoading && data.length === 0
 
     return (
@@ -61,7 +40,9 @@ export function Top10Race({ year }: { year: number | undefined }) {
             className="md:col-span-2 lg:col-span-3"
             isLoading={isInitialLoad}
             question="Who dominated my listening, and when did they rise?"
-            headerActions={entityTabs}
+            headerActions={
+                <EntityTabs value={entityType} onChange={setEntityType} />
+            }
         >
             {data.length === 0 ? (
                 <ChartCardEmpty />

--- a/app/src/components/Charts/LabCharts/Top10Race/index.tsx
+++ b/app/src/components/Charts/LabCharts/Top10Race/index.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useState } from 'react'
 import { queryDBAsJSON } from '../../../../db/queries/queryDB'
-import {
-    queryTop10Race,
-    type EntityType,
-    type Top10RaceQueryResult,
-} from './query'
+import { queryTop10Race, type Top10RaceQueryResult } from './query'
+import type { EntityType } from '../shared/types'
 import { Top10RaceView } from './Top10RaceView'
 import { ChartCard, ChartCardEmpty } from '../../SimpleCharts/shared'
 import { EntityTabs } from '../shared/EntityTabs'

--- a/app/src/components/Charts/LabCharts/Top10Race/query.ts
+++ b/app/src/components/Charts/LabCharts/Top10Race/query.ts
@@ -3,8 +3,7 @@ import sqlTop10Race from './Top10Artists.sql?raw'
 import sqlTop10Tracks from './Top10Tracks.sql?raw'
 import sqlTop10Albums from './Top10Albums.sql?raw'
 
-import type { EntityType } from '../types'
-export type { EntityType }
+import type { EntityType } from '../shared/types'
 
 const sqlByEntity: Record<EntityType, string> = {
     artists: sqlTop10Race,

--- a/app/src/components/Charts/LabCharts/shared/ChartLegend.test.tsx
+++ b/app/src/components/Charts/LabCharts/shared/ChartLegend.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { ChartLegend } from './ChartLegend'
+
+describe('ChartLegend', () => {
+    it('renders all items', () => {
+        const { getByText } = render(
+            <ChartLegend
+                items={[
+                    { color: 'bg-rose-800', label: 'New' },
+                    { color: 'bg-rose-500', label: 'Known' },
+                ]}
+            />
+        )
+        expect(getByText('New')).toBeTruthy()
+        expect(getByText('Known')).toBeTruthy()
+    })
+
+    it('applies color class to swatch', () => {
+        const { container } = render(
+            <ChartLegend
+                items={[{ color: 'bg-orange-400', label: 'Distinct' }]}
+            />
+        )
+        expect(container.querySelector('.bg-orange-400')).toBeTruthy()
+    })
+
+    it('renders empty without items', () => {
+        const { container } = render(<ChartLegend items={[]} />)
+        expect(container.querySelectorAll('span').length).toBe(0)
+    })
+})

--- a/app/src/components/Charts/LabCharts/shared/ChartLegend.tsx
+++ b/app/src/components/Charts/LabCharts/shared/ChartLegend.tsx
@@ -1,0 +1,23 @@
+type LegendItem = {
+    color: string
+    label: string
+}
+
+type Props = {
+    items: LegendItem[]
+}
+
+export function ChartLegend({ items }: Props) {
+    return (
+        <div className="mt-1 mb-3 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+            {items.map(({ color, label }) => (
+                <span key={label} className="flex items-center gap-1">
+                    <span
+                        className={`inline-block w-2 h-2 rounded-sm ${color}`}
+                    />
+                    {label}
+                </span>
+            ))}
+        </div>
+    )
+}

--- a/app/src/components/Charts/LabCharts/shared/EntityTabs.test.tsx
+++ b/app/src/components/Charts/LabCharts/shared/EntityTabs.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { EntityTabs } from './EntityTabs'
+
+describe('EntityTabs', () => {
+    it('renders 3 buttons with correct labels', () => {
+        render(<EntityTabs value="artists" onChange={vi.fn()} />)
+        expect(screen.getByRole('button', { name: 'Artists' })).toBeTruthy()
+        expect(screen.getByRole('button', { name: 'Tracks' })).toBeTruthy()
+        expect(screen.getByRole('button', { name: 'Albums' })).toBeTruthy()
+    })
+
+    it('active button has blue background class', () => {
+        render(<EntityTabs value="tracks" onChange={vi.fn()} />)
+        const tracksBtn = screen.getByRole('button', { name: 'Tracks' })
+        const artistsBtn = screen.getByRole('button', { name: 'Artists' })
+        expect(tracksBtn.className).toContain('bg-blue-500')
+        expect(artistsBtn.className).not.toContain('bg-blue-500')
+    })
+
+    it('clicking inactive button calls onChange with correct EntityType', () => {
+        const onChange = vi.fn()
+        render(<EntityTabs value="artists" onChange={onChange} />)
+        fireEvent.click(screen.getByRole('button', { name: 'Albums' }))
+        expect(onChange).toHaveBeenCalledWith('albums')
+    })
+})

--- a/app/src/components/Charts/LabCharts/shared/EntityTabs.tsx
+++ b/app/src/components/Charts/LabCharts/shared/EntityTabs.tsx
@@ -1,0 +1,32 @@
+import type { EntityType } from '../types'
+
+const LABELS: Record<EntityType, string> = {
+    artists: 'Artists',
+    tracks: 'Tracks',
+    albums: 'Albums',
+}
+
+type Props = {
+    value: EntityType
+    onChange: (type: EntityType) => void
+}
+
+export function EntityTabs({ value, onChange }: Props) {
+    return (
+        <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30">
+            {(['artists', 'tracks', 'albums'] as const).map((type) => (
+                <button
+                    key={type}
+                    onClick={() => onChange(type)}
+                    className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
+                        value === type
+                            ? 'bg-blue-500 text-white shadow-sm'
+                            : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
+                    }`}
+                >
+                    {LABELS[type]}
+                </button>
+            ))}
+        </div>
+    )
+}

--- a/app/src/components/Charts/LabCharts/shared/EntityTabs.tsx
+++ b/app/src/components/Charts/LabCharts/shared/EntityTabs.tsx
@@ -1,4 +1,4 @@
-import type { EntityType } from '../types'
+import type { EntityType } from './types'
 
 const LABELS: Record<EntityType, string> = {
     artists: 'Artists',

--- a/app/src/components/Charts/LabCharts/shared/GranularityTabs.test.tsx
+++ b/app/src/components/Charts/LabCharts/shared/GranularityTabs.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { GranularityTabs } from './GranularityTabs'
+
+describe('GranularityTabs', () => {
+    it('active button has correct active class', () => {
+        render(
+            <GranularityTabs
+                value="month"
+                available={['month', 'week', 'day']}
+                onChange={vi.fn()}
+            />
+        )
+        const monthBtn = screen.getByRole('button', { name: 'Month' })
+        expect(monthBtn.className).toContain('bg-blue-500')
+    })
+
+    it('available buttons call onChange on click', () => {
+        const onChange = vi.fn()
+        render(
+            <GranularityTabs
+                value="month"
+                available={['month', 'week', 'day']}
+                onChange={onChange}
+            />
+        )
+        fireEvent.click(screen.getByRole('button', { name: 'Week' }))
+        expect(onChange).toHaveBeenCalledWith('week')
+    })
+
+    it('disabled buttons do not call onChange', () => {
+        const onChange = vi.fn()
+        render(
+            <GranularityTabs
+                value="month"
+                available={['year', 'month']}
+                onChange={onChange}
+            />
+        )
+        const weekBtn = screen.getByRole('button', { name: 'Week' })
+        expect((weekBtn as HTMLButtonElement).disabled).toBe(true)
+        fireEvent.click(weekBtn)
+        expect(onChange).not.toHaveBeenCalled()
+    })
+})

--- a/app/src/components/Charts/LabCharts/shared/GranularityTabs.tsx
+++ b/app/src/components/Charts/LabCharts/shared/GranularityTabs.tsx
@@ -1,0 +1,41 @@
+import type { Granularity } from './useGranularity'
+
+const GRAN_LABELS: Record<Granularity, string> = {
+    year: 'Year',
+    month: 'Month',
+    week: 'Week',
+    day: 'Day',
+}
+
+type Props = {
+    value: Granularity
+    available: Granularity[]
+    onChange: (g: Granularity) => void
+}
+
+export function GranularityTabs({ value, available, onChange }: Props) {
+    return (
+        <div className="flex items-center bg-gray-100 dark:bg-slate-800/80 rounded-lg p-1 border border-gray-300/30 self-start mb-3">
+            {(['year', 'month', 'week', 'day'] as const).map((g) => {
+                const isAvailable = available.includes(g)
+                const isActive = value === g
+                return (
+                    <button
+                        key={g}
+                        onClick={() => isAvailable && onChange(g)}
+                        disabled={!isAvailable}
+                        className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-all ${
+                            isActive
+                                ? 'bg-blue-500 text-white shadow-sm'
+                                : isAvailable
+                                  ? 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
+                                  : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
+                        }`}
+                    >
+                        {GRAN_LABELS[g]}
+                    </button>
+                )
+            })}
+        </div>
+    )
+}

--- a/app/src/components/Charts/LabCharts/shared/GranularityTabs.tsx
+++ b/app/src/components/Charts/LabCharts/shared/GranularityTabs.tsx
@@ -1,4 +1,4 @@
-import type { Granularity } from './useGranularity'
+import type { Granularity } from './types'
 
 const GRAN_LABELS: Record<Granularity, string> = {
     year: 'Year',

--- a/app/src/components/Charts/LabCharts/shared/InsightList.test.tsx
+++ b/app/src/components/Charts/LabCharts/shared/InsightList.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { InsightList, InsightRow } from './InsightList'
+
+describe('InsightList', () => {
+    it('renders ul with correct classes', () => {
+        const { container } = render(
+            <InsightList>
+                <InsightRow label="Label" value="Value" />
+            </InsightList>
+        )
+        const ul = container.querySelector('ul')
+        expect(ul).toBeTruthy()
+        expect(ul?.className).toContain('border-t')
+    })
+})
+
+describe('InsightRow', () => {
+    it('renders label and value', () => {
+        render(<InsightRow label="Total streams" value="1,234" />)
+        expect(screen.getByText('Total streams')).toBeTruthy()
+        expect(screen.getByText('1,234')).toBeTruthy()
+    })
+
+    it('accepts ReactNode as value', () => {
+        render(
+            <InsightRow
+                label="Best streak"
+                value={<span data-testid="node-value">42 days</span>}
+            />
+        )
+        expect(screen.getByTestId('node-value')).toBeTruthy()
+    })
+
+    it('renders empty value span when value is null', () => {
+        const { container } = render(<InsightRow label="Bingo" value={null} />)
+        const valueSpan = container.querySelector('span.font-bold')
+        expect(valueSpan).toBeTruthy()
+        expect(valueSpan?.textContent).toBe('')
+    })
+})

--- a/app/src/components/Charts/LabCharts/shared/InsightList.tsx
+++ b/app/src/components/Charts/LabCharts/shared/InsightList.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react'
+
+type InsightRowProps = {
+    label: ReactNode
+    value: ReactNode
+}
+
+export function InsightRow({ label, value }: InsightRowProps) {
+    return (
+        <li
+            className="flex justify-between items-center mt-1 first:mt-0"
+            role="listitem"
+        >
+            <span className="text-sm text-gray-600 dark:text-gray-400">
+                {label}
+            </span>
+            <span className="font-bold text-sm">{value}</span>
+        </li>
+    )
+}
+
+type InsightListProps = {
+    children: ReactNode
+}
+
+export function InsightList({ children }: InsightListProps) {
+    return (
+        <ul
+            className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700"
+            role="list"
+        >
+            {children}
+        </ul>
+    )
+}

--- a/app/src/components/Charts/LabCharts/shared/formatBarLabel.test.ts
+++ b/app/src/components/Charts/LabCharts/shared/formatBarLabel.test.ts
@@ -1,13 +1,21 @@
 import { describe, it, expect } from 'vitest'
 import { formatBarLabel } from './formatBarLabel'
 
-const item = (ts: string) => ({ ts })
+const LOCALE = 'en-US'
+const timestamp = (date: string) => date
 
 describe('formatBarLabel', () => {
     describe('year granularity', () => {
         it('returns the year', () => {
             expect(
-                formatBarLabel(item('2024-06-15'), 0, [], undefined, 'year')
+                formatBarLabel(
+                    timestamp('2024-06-15'),
+                    0,
+                    [],
+                    undefined,
+                    'year',
+                    LOCALE
+                )
             ).toBe('2024')
         })
     })
@@ -15,7 +23,7 @@ describe('formatBarLabel', () => {
     describe('month granularity', () => {
         it('returns short month when year is set', () => {
             const result = formatBarLabel(
-                item('2024-06-01'),
+                timestamp('2024-06-01'),
                 0,
                 [],
                 2024,
@@ -27,40 +35,70 @@ describe('formatBarLabel', () => {
 
         it('returns year string for January when no year filter', () => {
             expect(
-                formatBarLabel(item('2024-01-01'), 0, [], undefined, 'month')
+                formatBarLabel(
+                    timestamp('2024-01-01'),
+                    0,
+                    [],
+                    undefined,
+                    'month',
+                    LOCALE
+                )
             ).toBe('2024')
         })
 
         it('returns empty string for non-January when no year filter', () => {
             expect(
-                formatBarLabel(item('2024-06-01'), 5, [], undefined, 'month')
+                formatBarLabel(
+                    timestamp('2024-06-01'),
+                    5,
+                    [],
+                    undefined,
+                    'month',
+                    LOCALE
+                )
             ).toBe('')
         })
     })
 
     describe('week granularity', () => {
         it('returns short month for first item', () => {
-            const data = [item('2024-01-01'), item('2024-01-08')]
-            const result = formatBarLabel(data[0], 0, data, 2024, 'week')
+            const data = [{ ts: '2024-01-01' }, { ts: '2024-01-08' }]
+            const result = formatBarLabel(
+                data[0].ts,
+                0,
+                data,
+                2024,
+                'week',
+                LOCALE
+            )
             expect(result.toLowerCase()).toContain('jan')
         })
 
         it('returns short month when month changes', () => {
-            const data = [item('2024-01-29'), item('2024-02-05')]
-            const result = formatBarLabel(data[1], 1, data, 2024, 'week')
+            const data = [{ ts: '2024-01-29' }, { ts: '2024-02-05' }]
+            const result = formatBarLabel(
+                data[1].ts,
+                1,
+                data,
+                2024,
+                'week',
+                LOCALE
+            )
             expect(result.toLowerCase()).toContain('feb')
         })
 
         it('returns empty string within same month', () => {
-            const data = [item('2024-06-01'), item('2024-06-08')]
-            expect(formatBarLabel(data[1], 1, data, 2024, 'week')).toBe('')
+            const data = [{ ts: '2024-06-01' }, { ts: '2024-06-08' }]
+            expect(
+                formatBarLabel(data[1].ts, 1, data, 2024, 'week', LOCALE)
+            ).toBe('')
         })
     })
 
     describe('day granularity', () => {
         it('returns short month on first day of month', () => {
             const result = formatBarLabel(
-                item('2024-06-01'),
+                timestamp('2024-06-01'),
                 0,
                 [],
                 2024,
@@ -72,7 +110,14 @@ describe('formatBarLabel', () => {
 
         it('returns empty string for other days', () => {
             expect(
-                formatBarLabel(item('2024-06-15'), 14, [], 2024, 'day')
+                formatBarLabel(
+                    timestamp('2024-06-15'),
+                    14,
+                    [],
+                    2024,
+                    'day',
+                    LOCALE
+                )
             ).toBe('')
         })
     })

--- a/app/src/components/Charts/LabCharts/shared/formatBarLabel.test.ts
+++ b/app/src/components/Charts/LabCharts/shared/formatBarLabel.test.ts
@@ -121,4 +121,12 @@ describe('formatBarLabel', () => {
             ).toBe('')
         })
     })
+
+    describe('invalid timestamp', () => {
+        it('does not throw', () => {
+            expect(() =>
+                formatBarLabel('not-a-date', 0, [], undefined, 'month')
+            ).not.toThrow()
+        })
+    })
 })

--- a/app/src/components/Charts/LabCharts/shared/formatBarLabel.test.ts
+++ b/app/src/components/Charts/LabCharts/shared/formatBarLabel.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { formatBarLabel } from './formatBarLabel'
+
+const item = (ts: string) => ({ ts })
+
+describe('formatBarLabel', () => {
+    describe('year granularity', () => {
+        it('returns the year', () => {
+            expect(
+                formatBarLabel(item('2024-06-15'), 0, [], undefined, 'year')
+            ).toBe('2024')
+        })
+    })
+
+    describe('month granularity', () => {
+        it('returns short month when year is set', () => {
+            const result = formatBarLabel(
+                item('2024-06-01'),
+                0,
+                [],
+                2024,
+                'month',
+                LOCALE
+            )
+            expect(result.toLowerCase()).toContain('jun')
+        })
+
+        it('returns year string for January when no year filter', () => {
+            expect(
+                formatBarLabel(item('2024-01-01'), 0, [], undefined, 'month')
+            ).toBe('2024')
+        })
+
+        it('returns empty string for non-January when no year filter', () => {
+            expect(
+                formatBarLabel(item('2024-06-01'), 5, [], undefined, 'month')
+            ).toBe('')
+        })
+    })
+
+    describe('week granularity', () => {
+        it('returns short month for first item', () => {
+            const data = [item('2024-01-01'), item('2024-01-08')]
+            const result = formatBarLabel(data[0], 0, data, 2024, 'week')
+            expect(result.toLowerCase()).toContain('jan')
+        })
+
+        it('returns short month when month changes', () => {
+            const data = [item('2024-01-29'), item('2024-02-05')]
+            const result = formatBarLabel(data[1], 1, data, 2024, 'week')
+            expect(result.toLowerCase()).toContain('feb')
+        })
+
+        it('returns empty string within same month', () => {
+            const data = [item('2024-06-01'), item('2024-06-08')]
+            expect(formatBarLabel(data[1], 1, data, 2024, 'week')).toBe('')
+        })
+    })
+
+    describe('day granularity', () => {
+        it('returns short month on first day of month', () => {
+            const result = formatBarLabel(
+                item('2024-06-01'),
+                0,
+                [],
+                2024,
+                'day',
+                LOCALE
+            )
+            expect(result.toLowerCase()).toContain('jun')
+        })
+
+        it('returns empty string for other days', () => {
+            expect(
+                formatBarLabel(item('2024-06-15'), 14, [], 2024, 'day')
+            ).toBe('')
+        })
+    })
+})

--- a/app/src/components/Charts/LabCharts/shared/formatBarLabel.ts
+++ b/app/src/components/Charts/LabCharts/shared/formatBarLabel.ts
@@ -1,14 +1,14 @@
 import type { Granularity } from './types'
 
 export function formatBarLabel(
-    d: { ts: string },
+    timestamp: string,
     index: number,
     data: { ts: string }[],
     year: number | undefined,
     granularity: Granularity,
     locale: string | undefined = undefined
 ): string {
-    const date = new Date(d.ts)
+    const date = new Date(timestamp)
 
     if (granularity === 'year') return String(date.getUTCFullYear())
 

--- a/app/src/components/Charts/LabCharts/shared/formatBarLabel.ts
+++ b/app/src/components/Charts/LabCharts/shared/formatBarLabel.ts
@@ -1,0 +1,34 @@
+import type { Granularity } from './types'
+
+export function formatBarLabel(
+    d: { ts: string },
+    index: number,
+    data: { ts: string }[],
+    year: number | undefined,
+    granularity: Granularity,
+    locale: string | undefined = undefined
+): string {
+    const date = new Date(d.ts)
+
+    if (granularity === 'year') return String(date.getUTCFullYear())
+
+    if (granularity === 'month') {
+        if (year !== undefined)
+            return date.toLocaleDateString(locale, { month: 'short' })
+        return date.getUTCMonth() === 0 ? String(date.getUTCFullYear()) : ''
+    }
+
+    if (granularity === 'week') {
+        if (index === 0)
+            return date.toLocaleDateString(locale, { month: 'short' })
+        const prev = new Date(data[index - 1].ts)
+        return date.getUTCMonth() !== prev.getUTCMonth()
+            ? date.toLocaleDateString(locale, { month: 'short' })
+            : ''
+    }
+
+    // day
+    return date.getUTCDate() === 1
+        ? date.toLocaleDateString(locale, { month: 'short' })
+        : ''
+}

--- a/app/src/components/Charts/LabCharts/shared/formatTooltipDate.test.ts
+++ b/app/src/components/Charts/LabCharts/shared/formatTooltipDate.test.ts
@@ -4,26 +4,26 @@ import { formatTooltipDate } from './formatTooltipDate'
 const LOCALE = 'en-US'
 
 describe('formatTooltipDate', () => {
-    const date = new Date('2024-06-15T00:00:00Z')
+    const timestamp = '2024-06-15T00:00:00Z'
 
     it('year granularity returns year only', () => {
-        expect(formatTooltipDate(date, 'year')).toBe('2024')
+        expect(formatTooltipDate(timestamp, 'year', LOCALE)).toBe('2024')
     })
 
     it('month granularity returns month and year', () => {
-        const result = formatTooltipDate(date, 'month')
+        const result = formatTooltipDate(timestamp, 'month', LOCALE)
         expect(result).toContain('2024')
         expect(result.toLowerCase()).toContain('june')
     })
 
     it('week granularity returns month, day, and year', () => {
-        const result = formatTooltipDate(date, 'week')
+        const result = formatTooltipDate(timestamp, 'week', LOCALE)
         expect(result).toContain('2024')
         expect(result).toContain('15')
     })
 
     it('day granularity returns month, day, and year', () => {
-        const result = formatTooltipDate(date, 'day')
+        const result = formatTooltipDate(timestamp, 'day', LOCALE)
         expect(result).toContain('2024')
         expect(result).toContain('15')
     })

--- a/app/src/components/Charts/LabCharts/shared/formatTooltipDate.test.ts
+++ b/app/src/components/Charts/LabCharts/shared/formatTooltipDate.test.ts
@@ -27,4 +27,8 @@ describe('formatTooltipDate', () => {
         expect(result).toContain('2024')
         expect(result).toContain('15')
     })
+
+    it('does not throw on invalid timestamp', () => {
+        expect(() => formatTooltipDate('not-a-date', 'month')).not.toThrow()
+    })
 })

--- a/app/src/components/Charts/LabCharts/shared/formatTooltipDate.test.ts
+++ b/app/src/components/Charts/LabCharts/shared/formatTooltipDate.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { formatTooltipDate } from './formatTooltipDate'
+
+const LOCALE = 'en-US'
+
+describe('formatTooltipDate', () => {
+    const date = new Date('2024-06-15T00:00:00Z')
+
+    it('year granularity returns year only', () => {
+        expect(formatTooltipDate(date, 'year')).toBe('2024')
+    })
+
+    it('month granularity returns month and year', () => {
+        const result = formatTooltipDate(date, 'month')
+        expect(result).toContain('2024')
+        expect(result.toLowerCase()).toContain('june')
+    })
+
+    it('week granularity returns month, day, and year', () => {
+        const result = formatTooltipDate(date, 'week')
+        expect(result).toContain('2024')
+        expect(result).toContain('15')
+    })
+
+    it('day granularity returns month, day, and year', () => {
+        const result = formatTooltipDate(date, 'day')
+        expect(result).toContain('2024')
+        expect(result).toContain('15')
+    })
+})

--- a/app/src/components/Charts/LabCharts/shared/formatTooltipDate.ts
+++ b/app/src/components/Charts/LabCharts/shared/formatTooltipDate.ts
@@ -1,9 +1,11 @@
 import type { Granularity } from './types'
 
 export function formatTooltipDate(
-    date: Date,
-    granularity: Granularity
+    timestamp: string,
+    granularity: Granularity,
+    locale: string | undefined = undefined
 ): string {
+    const date = new Date(timestamp)
     if (granularity === 'year')
         return date.toLocaleDateString(locale, { year: 'numeric' })
     if (granularity === 'month')

--- a/app/src/components/Charts/LabCharts/shared/formatTooltipDate.ts
+++ b/app/src/components/Charts/LabCharts/shared/formatTooltipDate.ts
@@ -1,0 +1,19 @@
+import type { Granularity } from './types'
+
+export function formatTooltipDate(
+    date: Date,
+    granularity: Granularity
+): string {
+    if (granularity === 'year')
+        return date.toLocaleDateString(locale, { year: 'numeric' })
+    if (granularity === 'month')
+        return date.toLocaleDateString(locale, {
+            month: 'long',
+            year: 'numeric',
+        })
+    return date.toLocaleDateString(locale, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+    })
+}

--- a/app/src/components/Charts/LabCharts/shared/types.ts
+++ b/app/src/components/Charts/LabCharts/shared/types.ts
@@ -1,0 +1,3 @@
+export type EntityType = 'artists' | 'tracks' | 'albums'
+
+export type Granularity = 'year' | 'month' | 'week' | 'day'

--- a/app/src/components/Charts/LabCharts/shared/useGranularity.test.ts
+++ b/app/src/components/Charts/LabCharts/shared/useGranularity.test.ts
@@ -1,0 +1,37 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useGranularity } from './useGranularity'
+
+describe('useGranularity', () => {
+    it('year=undefined yields availableGranularities=[year, month]', () => {
+        const { result } = renderHook(() => useGranularity(undefined))
+        expect(result.current.availableGranularities).toEqual(['year', 'month'])
+    })
+
+    it('year=2023 yields availableGranularities=[month, week, day]', () => {
+        const { result } = renderHook(() => useGranularity(2023))
+        expect(result.current.availableGranularities).toEqual([
+            'month',
+            'week',
+            'day',
+        ])
+    })
+
+    it('effectiveGranularity falls back to availableGranularities[0] when current unavailable', () => {
+        const { result, rerender } = renderHook(
+            ({ year }: { year: number | undefined }) => useGranularity(year),
+            { initialProps: { year: 2023 as number | undefined } }
+        )
+        act(() => result.current.setGranularity('day'))
+        expect(result.current.effectiveGranularity).toBe('day')
+
+        rerender({ year: undefined })
+        expect(result.current.effectiveGranularity).toBe('year')
+    })
+
+    it('effectiveGranularity preserves granularity when available', () => {
+        const { result } = renderHook(() => useGranularity(2023))
+        act(() => result.current.setGranularity('week'))
+        expect(result.current.effectiveGranularity).toBe('week')
+    })
+})

--- a/app/src/components/Charts/LabCharts/shared/useGranularity.ts
+++ b/app/src/components/Charts/LabCharts/shared/useGranularity.ts
@@ -1,6 +1,5 @@
 import { useState } from 'react'
-
-export type Granularity = 'year' | 'month' | 'week' | 'day'
+import type { Granularity } from './types'
 
 const ALL_TIME_GRANULARITIES: Granularity[] = ['year', 'month']
 const PER_YEAR_GRANULARITIES: Granularity[] = ['month', 'week', 'day']

--- a/app/src/components/Charts/LabCharts/shared/useGranularity.ts
+++ b/app/src/components/Charts/LabCharts/shared/useGranularity.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+
+export type Granularity = 'year' | 'month' | 'week' | 'day'
+
+const ALL_TIME_GRANULARITIES: Granularity[] = ['year', 'month']
+const PER_YEAR_GRANULARITIES: Granularity[] = ['month', 'week', 'day']
+
+type UseGranularityResult = {
+    granularity: Granularity
+    setGranularity: (g: Granularity) => void
+    availableGranularities: Granularity[]
+    effectiveGranularity: Granularity
+}
+
+export function useGranularity(year: number | undefined): UseGranularityResult {
+    const [granularity, setGranularity] = useState<Granularity>('month')
+
+    const availableGranularities =
+        year !== undefined ? PER_YEAR_GRANULARITIES : ALL_TIME_GRANULARITIES
+
+    const effectiveGranularity = availableGranularities.includes(granularity)
+        ? granularity
+        : availableGranularities[0]
+
+    return {
+        granularity,
+        setGranularity,
+        availableGranularities,
+        effectiveGranularity,
+    }
+}

--- a/app/src/components/Charts/LabCharts/types.ts
+++ b/app/src/components/Charts/LabCharts/types.ts
@@ -1,1 +1,0 @@
-export type EntityType = 'artists' | 'tracks' | 'albums'


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Several UI patterns were copy-pasted verbatim across multiple chart components: the entity toggle (Artists / Tracks / Albums), the granularity strip (Year / Month / Week / Day), and the insight summary rows at the bottom of cards. Any styling change or bug fix required touching 3 to 5 files simultaneously.

## 🎹 Proposal

Seven reusable components are extracted into a new `LabCharts/shared/` directory:

- `EntityTabs` renders the Artists / Tracks / Albums toggle. Used in Top10Race, Top10BillboardRace, StreamVariety, and StreamDiscovery.
- `useGranularity` centralises the available granularities logic and the fallback when the current granularity is unavailable for the selected year range. The `Granularity` type is now shared from this hook.
- `GranularityTabs` renders the Year / Month / Week / Day strip with disabled states. Used in StreamTimeline, StreamVariety, and StreamDiscovery.
- `InsightList` and `InsightRow` replace the repeated `<ul>/<li>` insight pattern. Used in StreamTimeline, StreamVariety, StreamDiscovery, Streaks, and StreamPerDayOfWeek.
- EntityType and Granularity are consolidated into `shared/types.ts`. Query files import types directly; no re-exports.
- Duplicated formatting functions extracted to `shared/formatTooltipDate.ts` and `shared/formatBarLabel.ts`, each with their own test file. Both formatters accept a timestamp: string for a consistent interface. Legend markup extracted to a shared `ChartLegend` component.

No behavior changes. No visual changes. No new dependencies.

## 🎶 Comments

`Common/` is left untouched. It will be evaluated when the Observable Plot components are reworked separately.

The `shared/` directory intentionally has no barrel (`index.ts`). Imports are direct.

## 🎤 Test

Load a Spotify or Deezer file. Verify:
- Entity tabs (Artists / Tracks / Albums) still work in Top10Race, Top10BillboardRace, Stream Variety, Stream Discovery.
- Granularity strip (Year / Month / Week / Day) still works in Stream Timeline, Stream Variety, Stream Discovery. Unavailable options are disabled.
- Insight rows at the bottom of Stream Timeline, Stream Variety, Stream Discovery, Streaks, Listening Bingo display correctly.