### PR TITLE
refactor(charts): simplify formatBarLabel and extract entity constants

### DIFF
--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -14,6 +14,7 @@ import { ChartTooltip } from '../../SimpleCharts/shared/ChartTooltip'
 import { EntityTabs } from '../shared/EntityTabs'
 import { GranularityTabs } from '../shared/GranularityTabs'
 import { InsightList, InsightRow } from '../shared/InsightList'
+import { ENTITY_SINGULAR } from '../shared/entityLabels'
 
 type TooltipState = {
     x: number
@@ -34,12 +35,6 @@ type Props = {
     entity: EntityType
     onEntityChange: (e: EntityType) => void
     isLoading?: boolean
-}
-
-const ENTITY_SINGULAR: Record<EntityType, string> = {
-    tracks: 'track',
-    artists: 'artist',
-    albums: 'album',
 }
 
 export const StreamDiscovery: FC<Props> = ({

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -141,8 +141,7 @@ export const StreamDiscovery: FC<Props> = ({
                             {data.map((d, i) => {
                                 const label = formatBarLabel(
                                     d.ts,
-                                    i,
-                                    data,
+                                    data[i - 1]?.ts,
                                     year,
                                     granularity
                                 )

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/query.ts
@@ -3,6 +3,7 @@ import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryStreamDiscovery from './StreamDiscovery.sql?raw'
 import sqlQueryStreamDiscoveryStats from './StreamDiscoveryStats.sql?raw'
 import type { Granularity, EntityType } from '../shared/types'
+import { ENTITY_COLUMN } from '../shared/entityColumns'
 
 export type StreamDiscoveryQueryResult = {
     ts: string
@@ -15,12 +16,6 @@ export type StreamDiscoveryStatsQueryResult = {
     total_new: number
     total_known: number
     total_distinct: number
-}
-
-const ENTITY_COLUMN: Record<EntityType, string> = {
-    tracks: 'track_uri',
-    artists: 'artist_name',
-    albums: 'album_name',
 }
 
 type GranConfig = {

--- a/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
+++ b/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
@@ -109,8 +109,7 @@ export const StreamTimeline: FC<Props> = ({
                             {data.map((d, i) => {
                                 const label = formatBarLabel(
                                     d.ts,
-                                    i,
-                                    data,
+                                    data[i - 1]?.ts,
                                     year,
                                     granularity
                                 )

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -14,6 +14,7 @@ import { ChartTooltip } from '../../SimpleCharts/shared/ChartTooltip'
 import { EntityTabs } from '../shared/EntityTabs'
 import { GranularityTabs } from '../shared/GranularityTabs'
 import { InsightList, InsightRow } from '../shared/InsightList'
+import { ENTITY_SINGULAR } from '../shared/entityLabels'
 
 type TooltipState = {
     x: number
@@ -34,12 +35,6 @@ type Props = {
     entity: EntityType
     onEntityChange: (e: EntityType) => void
     isLoading?: boolean
-}
-
-const ENTITY_SINGULAR: Record<EntityType, string> = {
-    tracks: 'track',
-    artists: 'artist',
-    albums: 'album',
 }
 
 export const StreamVariety: FC<Props> = ({

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -147,8 +147,7 @@ export const StreamVariety: FC<Props> = ({
                             {data.map((d, i) => {
                                 const label = formatBarLabel(
                                     d.ts,
-                                    i,
-                                    data,
+                                    data[i - 1]?.ts,
                                     year,
                                     granularity
                                 )

--- a/app/src/components/Charts/LabCharts/StreamVariety/query.ts
+++ b/app/src/components/Charts/LabCharts/StreamVariety/query.ts
@@ -3,18 +3,13 @@ import { buildYearCondition } from '../../../../db/queries/buildYearCondition'
 import sqlQueryStreamVariety from './StreamVariety.sql?raw'
 import sqlQueryStreamVarietyStats from './StreamVarietyStats.sql?raw'
 import type { Granularity, EntityType } from '../shared/types'
+import { ENTITY_COLUMN } from '../shared/entityColumns'
 
 export type StreamVarietyQueryResult = {
     ts: string
     distinct_count: number
     repeat_count: number
     total_count: number
-}
-
-const ENTITY_COLUMN: Record<EntityType, string> = {
-    tracks: 'track_uri',
-    artists: 'artist_name',
-    albums: 'album_name',
 }
 
 type GranConfig = {

--- a/app/src/components/Charts/LabCharts/shared/entityColumns.ts
+++ b/app/src/components/Charts/LabCharts/shared/entityColumns.ts
@@ -1,0 +1,7 @@
+import type { EntityType } from './types'
+
+export const ENTITY_COLUMN: Record<EntityType, string> = {
+    tracks: 'track_uri',
+    artists: 'artist_name',
+    albums: 'album_name',
+}

--- a/app/src/components/Charts/LabCharts/shared/entityLabels.ts
+++ b/app/src/components/Charts/LabCharts/shared/entityLabels.ts
@@ -1,0 +1,7 @@
+import type { EntityType } from './types'
+
+export const ENTITY_SINGULAR: Record<EntityType, string> = {
+    tracks: 'track',
+    artists: 'artist',
+    albums: 'album',
+}

--- a/app/src/components/Charts/LabCharts/shared/formatBarLabel.test.ts
+++ b/app/src/components/Charts/LabCharts/shared/formatBarLabel.test.ts
@@ -2,16 +2,14 @@ import { describe, it, expect } from 'vitest'
 import { formatBarLabel } from './formatBarLabel'
 
 const LOCALE = 'en-US'
-const timestamp = (date: string) => date
 
 describe('formatBarLabel', () => {
     describe('year granularity', () => {
         it('returns the year', () => {
             expect(
                 formatBarLabel(
-                    timestamp('2024-06-15'),
-                    0,
-                    [],
+                    '2024-06-15',
+                    undefined,
                     undefined,
                     'year',
                     LOCALE
@@ -23,9 +21,8 @@ describe('formatBarLabel', () => {
     describe('month granularity', () => {
         it('returns short month when year is set', () => {
             const result = formatBarLabel(
-                timestamp('2024-06-01'),
-                0,
-                [],
+                '2024-06-01',
+                undefined,
                 2024,
                 'month',
                 LOCALE
@@ -36,9 +33,8 @@ describe('formatBarLabel', () => {
         it('returns year string for January when no year filter', () => {
             expect(
                 formatBarLabel(
-                    timestamp('2024-01-01'),
-                    0,
-                    [],
+                    '2024-01-01',
+                    undefined,
                     undefined,
                     'month',
                     LOCALE
@@ -49,9 +45,8 @@ describe('formatBarLabel', () => {
         it('returns empty string for non-January when no year filter', () => {
             expect(
                 formatBarLabel(
-                    timestamp('2024-06-01'),
-                    5,
-                    [],
+                    '2024-06-01',
+                    undefined,
                     undefined,
                     'month',
                     LOCALE
@@ -61,12 +56,10 @@ describe('formatBarLabel', () => {
     })
 
     describe('week granularity', () => {
-        it('returns short month for first item', () => {
-            const data = [{ ts: '2024-01-01' }, { ts: '2024-01-08' }]
+        it('returns short month when prevTimestamp is undefined (first item)', () => {
             const result = formatBarLabel(
-                data[0].ts,
-                0,
-                data,
+                '2024-01-01',
+                undefined,
                 2024,
                 'week',
                 LOCALE
@@ -75,11 +68,9 @@ describe('formatBarLabel', () => {
         })
 
         it('returns short month when month changes', () => {
-            const data = [{ ts: '2024-01-29' }, { ts: '2024-02-05' }]
             const result = formatBarLabel(
-                data[1].ts,
-                1,
-                data,
+                '2024-02-05',
+                '2024-01-29',
                 2024,
                 'week',
                 LOCALE
@@ -88,9 +79,8 @@ describe('formatBarLabel', () => {
         })
 
         it('returns empty string within same month', () => {
-            const data = [{ ts: '2024-06-01' }, { ts: '2024-06-08' }]
             expect(
-                formatBarLabel(data[1].ts, 1, data, 2024, 'week', LOCALE)
+                formatBarLabel('2024-06-08', '2024-06-01', 2024, 'week', LOCALE)
             ).toBe('')
         })
     })
@@ -98,9 +88,8 @@ describe('formatBarLabel', () => {
     describe('day granularity', () => {
         it('returns short month on first day of month', () => {
             const result = formatBarLabel(
-                timestamp('2024-06-01'),
-                0,
-                [],
+                '2024-06-01',
+                undefined,
                 2024,
                 'day',
                 LOCALE
@@ -110,14 +99,7 @@ describe('formatBarLabel', () => {
 
         it('returns empty string for other days', () => {
             expect(
-                formatBarLabel(
-                    timestamp('2024-06-15'),
-                    14,
-                    [],
-                    2024,
-                    'day',
-                    LOCALE
-                )
+                formatBarLabel('2024-06-15', undefined, 2024, 'day', LOCALE)
             ).toBe('')
         })
     })
@@ -125,7 +107,7 @@ describe('formatBarLabel', () => {
     describe('invalid timestamp', () => {
         it('does not throw', () => {
             expect(() =>
-                formatBarLabel('not-a-date', 0, [], undefined, 'month')
+                formatBarLabel('not-a-date', undefined, undefined, 'month')
             ).not.toThrow()
         })
     })

--- a/app/src/components/Charts/LabCharts/shared/formatBarLabel.ts
+++ b/app/src/components/Charts/LabCharts/shared/formatBarLabel.ts
@@ -2,11 +2,10 @@ import type { Granularity } from './types'
 
 export function formatBarLabel(
     timestamp: string,
-    index: number,
-    data: { ts: string }[],
+    prevTimestamp: string | undefined,
     year: number | undefined,
     granularity: Granularity,
-    locale: string | undefined = undefined
+    locale?: string
 ): string {
     const date = new Date(timestamp)
 
@@ -19,9 +18,8 @@ export function formatBarLabel(
     }
 
     if (granularity === 'week') {
-        if (index === 0)
-            return date.toLocaleDateString(locale, { month: 'short' })
-        const prev = new Date(data[index - 1].ts)
+        const prev = prevTimestamp ? new Date(prevTimestamp) : null
+        if (!prev) return date.toLocaleDateString(locale, { month: 'short' })
         return date.getUTCMonth() !== prev.getUTCMonth()
             ? date.toLocaleDateString(locale, { month: 'short' })
             : ''

--- a/app/src/components/Charts/LabCharts/shared/formatTooltipDate.ts
+++ b/app/src/components/Charts/LabCharts/shared/formatTooltipDate.ts
@@ -3,7 +3,7 @@ import type { Granularity } from './types'
 export function formatTooltipDate(
     timestamp: string,
     granularity: Granularity,
-    locale: string | undefined = undefined
+    locale?: string
 ): string {
     const date = new Date(timestamp)
     if (granularity === 'year')


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The `formatBarLabel` function required callers to pass the full dataset array and an index just to look up the previous bar's timestamp. Two separate components and their query files each declared identical constants for entity display labels and SQL column names.

## 🎹 Proposal

`formatBarLabel` now accepts a single optional `prevTimestamp` string instead of `index` and `data[]`. Callers pass `data[i - 1]?.ts` directly, which removes the coupling to the full array.

`ENTITY_SINGULAR` (track/artist/album display labels) and `ENTITY_COLUMN` (SQL column names) are now declared once in `shared/entityLabels.ts` and `shared/entityColumns.ts` and imported where needed.

## 🎶 Comments

No behavior changes. TypeScript enforces completeness of both constants via `Record<EntityType, string>`.

## 🎤 Test

No visible changes. Run `moon run app:typecheck app:test` to verify.