### PR TITLE
refactor(charts): replace ChartTooltip children API with title + rows

### DIFF
--- a/app/src/components/Charts/LabCharts/Streaks/StreaksView.tsx
+++ b/app/src/components/Charts/LabCharts/Streaks/StreaksView.tsx
@@ -359,16 +359,16 @@ export function StreaksView({ data, year, isLatestYear, isLoading }: Props) {
                 </>
             )}
             {tooltip && (
-                <ChartTooltip x={tooltip.x} y={tooltip.y}>
-                    <div className="font-semibold">
-                        {formatDisplayDate(tooltip.cell.day)}
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {tooltip.cell.streak > 0
+                <ChartTooltip
+                    x={tooltip.x}
+                    y={tooltip.y}
+                    title={formatDisplayDate(tooltip.cell.day)}
+                    rows={[
+                        tooltip.cell.streak > 0
                             ? `Day ${tooltip.cell.streak} of streak`
-                            : 'Streak broken'}
-                    </div>
-                </ChartTooltip>
+                            : 'Streak broken',
+                    ]}
+                />
             )}
         </ChartCard>
     )

--- a/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
+++ b/app/src/components/Charts/LabCharts/StreamDiscovery/StreamDiscovery.tsx
@@ -190,26 +190,16 @@ export const StreamDiscovery: FC<Props> = ({
                 </>
             )}
             {tooltip && (
-                <ChartTooltip x={tooltip.x} y={tooltip.y}>
-                    <div className="font-semibold">
-                        {formatTooltipDate(tooltip.ts, granularity)}
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {tooltip.new_count.toLocaleString()} new
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {tooltip.known_count.toLocaleString()} known
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {tooltip.total_count > 0
-                            ? Math.round(
-                                  (tooltip.new_count / tooltip.total_count) *
-                                      100
-                              )
-                            : 0}
-                        % discovery
-                    </div>
-                </ChartTooltip>
+                <ChartTooltip
+                    x={tooltip.x}
+                    y={tooltip.y}
+                    title={formatTooltipDate(tooltip.ts, granularity)}
+                    rows={[
+                        `${tooltip.new_count.toLocaleString()} new`,
+                        `${tooltip.known_count.toLocaleString()} known`,
+                        `${tooltip.total_count > 0 ? Math.round((tooltip.new_count / tooltip.total_count) * 100) : 0}% discovery`,
+                    ]}
+                />
             )}
         </ChartCard>
     )

--- a/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
+++ b/app/src/components/Charts/LabCharts/StreamPerDayOfWeek/StreamPerDayOfWeekView.tsx
@@ -474,22 +474,17 @@ export function StreamPerDayOfWeekView({ data, year, isLoading }: Props) {
                     </InsightList>
                 </div>
                 {tooltip && (
-                    <ChartTooltip x={tooltip.x} y={tooltip.y}>
-                        <div className="font-semibold">
-                            {DAY_NAMES[tooltip.day]} {tooltip.hour}h
-                        </div>
-                        <div className="text-gray-300 dark:text-gray-400">
-                            {tooltip.count.toLocaleString()} streams
-                        </div>
-                        {tooltip.firstPlayedTs !== null && (
-                            <div className="text-gray-300 dark:text-gray-400">
-                                first played{' '}
-                                {new Date(
-                                    tooltip.firstPlayedTs
-                                ).toLocaleDateString()}
-                            </div>
-                        )}
-                    </ChartTooltip>
+                    <ChartTooltip
+                        x={tooltip.x}
+                        y={tooltip.y}
+                        title={`${DAY_NAMES[tooltip.day]} ${tooltip.hour}h`}
+                        rows={[
+                            `${tooltip.count.toLocaleString()} streams`,
+                            tooltip.firstPlayedTs !== null
+                                ? `first played ${new Date(tooltip.firstPlayedTs).toLocaleDateString()}`
+                                : null,
+                        ]}
+                    />
                 )}
             </ChartCard>
         </div>

--- a/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
+++ b/app/src/components/Charts/LabCharts/StreamTimeline/StreamTimeline.tsx
@@ -142,17 +142,15 @@ export const StreamTimeline: FC<Props> = ({
                 </>
             )}
             {tooltip && (
-                <ChartTooltip x={tooltip.x} y={tooltip.y}>
-                    <div className="font-semibold">
-                        {formatTooltipDate(tooltip.ts, granularity)}
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {formatDuration(tooltip.ms_played)}
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {tooltip.count_streams.toLocaleString()} streams
-                    </div>
-                </ChartTooltip>
+                <ChartTooltip
+                    x={tooltip.x}
+                    y={tooltip.y}
+                    title={formatTooltipDate(tooltip.ts, granularity)}
+                    rows={[
+                        formatDuration(tooltip.ms_played),
+                        `${tooltip.count_streams.toLocaleString()} streams`,
+                    ]}
+                />
             )}
         </ChartCard>
     )

--- a/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
+++ b/app/src/components/Charts/LabCharts/StreamVariety/StreamVariety.tsx
@@ -196,35 +196,17 @@ export const StreamVariety: FC<Props> = ({
                 </>
             )}
             {tooltip && (
-                <ChartTooltip x={tooltip.x} y={tooltip.y}>
-                    <div className="font-semibold">
-                        {formatTooltipDate(tooltip.ts, granularity)}
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {tooltip.distinct_count.toLocaleString()} distinct
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {tooltip.repeat_count.toLocaleString()} re-listens
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {tooltip.total_count > 0
-                            ? Math.round(
-                                  (tooltip.distinct_count /
-                                      tooltip.total_count) *
-                                      100
-                              )
-                            : 0}
-                        % variety
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {tooltip.distinct_count > 0
-                            ? Math.round(
-                                  tooltip.total_count / tooltip.distinct_count
-                              )
-                            : 0}{' '}
-                        avg listens/{ENTITY_SINGULAR[entity]}
-                    </div>
-                </ChartTooltip>
+                <ChartTooltip
+                    x={tooltip.x}
+                    y={tooltip.y}
+                    title={formatTooltipDate(tooltip.ts, granularity)}
+                    rows={[
+                        `${tooltip.distinct_count.toLocaleString()} distinct`,
+                        `${tooltip.repeat_count.toLocaleString()} re-listens`,
+                        `${tooltip.total_count > 0 ? Math.round((tooltip.distinct_count / tooltip.total_count) * 100) : 0}% variety`,
+                        `${tooltip.distinct_count > 0 ? Math.round(tooltip.total_count / tooltip.distinct_count) : 0} avg listens/${ENTITY_SINGULAR[entity]}`,
+                    ]}
+                />
             )}
         </ChartCard>
     )

--- a/app/src/components/Charts/SimpleCharts/CalendarHeatmap/CalendarHeatmap.tsx
+++ b/app/src/components/Charts/SimpleCharts/CalendarHeatmap/CalendarHeatmap.tsx
@@ -149,14 +149,12 @@ export const CalendarHeatmap: FC<Props> = ({ data, year, isLoading }) => {
                 </div>
             )}
             {tooltip && (
-                <ChartTooltip x={tooltip.x} y={tooltip.y}>
-                    <div className="font-semibold">
-                        {formatDate(tooltip.cell.date)}
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {tooltip.cell.stream_count} streams
-                    </div>
-                </ChartTooltip>
+                <ChartTooltip
+                    x={tooltip.x}
+                    y={tooltip.y}
+                    title={formatDate(tooltip.cell.date)}
+                    rows={[`${tooltip.cell.stream_count} streams`]}
+                />
             )}
         </ChartCard>
     )

--- a/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.tsx
+++ b/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.tsx
@@ -128,6 +128,8 @@ export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
                     rows={[
                         `${tooltip.count.toLocaleString()} streams`,
                         formatDuration(tooltip.ms_played),
+                    ]}
+                    secondaryRows={[
                         `${totalStreams.toLocaleString()} total streams`,
                         `${formatDuration(totalMsPlayed)} total listening`,
                     ]}

--- a/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.tsx
+++ b/app/src/components/Charts/SimpleCharts/EvolutionOverTime/EvolutionOverTime.tsx
@@ -121,22 +121,17 @@ export const EvolutionOverTime: FC<Props> = ({ data, year, isLoading }) => {
                 </>
             )}
             {tooltip && (
-                <ChartTooltip x={tooltip.x} y={tooltip.y}>
-                    <div className="font-semibold">{tooltip.year}</div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {tooltip.count.toLocaleString()} streams
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {formatDuration(tooltip.ms_played)}
-                    </div>
-                    <div className="border-t border-gray-700 my-1.5" />
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {totalStreams.toLocaleString()} total streams
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {formatDuration(totalMsPlayed)} total listening
-                    </div>
-                </ChartTooltip>
+                <ChartTooltip
+                    x={tooltip.x}
+                    y={tooltip.y}
+                    title={String(tooltip.year)}
+                    rows={[
+                        `${tooltip.count.toLocaleString()} streams`,
+                        formatDuration(tooltip.ms_played),
+                        `${totalStreams.toLocaleString()} total streams`,
+                        `${formatDuration(totalMsPlayed)} total listening`,
+                    ]}
+                />
             )}
         </ChartCard>
     )

--- a/app/src/components/Charts/SimpleCharts/FavoriteWeekday/FavoriteWeekday.tsx
+++ b/app/src/components/Charts/SimpleCharts/FavoriteWeekday/FavoriteWeekday.tsx
@@ -105,15 +105,15 @@ export const FavoriteWeekday: FC<Props> = ({ data, isLoading }) => {
                 </>
             )}
             {tooltip && (
-                <ChartTooltip x={tooltip.x} y={tooltip.y}>
-                    <div className="font-semibold">{tooltip.day_name}</div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {tooltip.stream_count.toLocaleString()} streams
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {formatDuration(tooltip.ms_played)}
-                    </div>
-                </ChartTooltip>
+                <ChartTooltip
+                    x={tooltip.x}
+                    y={tooltip.y}
+                    title={tooltip.day_name}
+                    rows={[
+                        `${tooltip.stream_count.toLocaleString()} streams`,
+                        formatDuration(tooltip.ms_played),
+                    ]}
+                />
             )}
         </ChartCard>
     )

--- a/app/src/components/Charts/SimpleCharts/HourlyStreams/HourlyStreams.tsx
+++ b/app/src/components/Charts/SimpleCharts/HourlyStreams/HourlyStreams.tsx
@@ -199,17 +199,15 @@ export const HourlyStreams: FC<Props> = ({
                 <ChartCardEmpty />
             )}
             {tooltip && (
-                <ChartTooltip x={tooltip.x} y={tooltip.y}>
-                    <div className="font-semibold">
-                        {String(tooltip.hour).padStart(2, '0')}h
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {tooltip.count} streams
-                    </div>
-                    <div className="text-gray-300 dark:text-gray-400">
-                        {formatDuration(tooltip.ms)}
-                    </div>
-                </ChartTooltip>
+                <ChartTooltip
+                    x={tooltip.x}
+                    y={tooltip.y}
+                    title={`${String(tooltip.hour).padStart(2, '0')}h`}
+                    rows={[
+                        `${tooltip.count} streams`,
+                        formatDuration(tooltip.ms),
+                    ]}
+                />
             )}
         </ChartCard>
     )

--- a/app/src/components/Charts/SimpleCharts/shared/ChartTooltip.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/shared/ChartTooltip.test.tsx
@@ -42,6 +42,28 @@ describe('ChartTooltip', () => {
         expect(rows).toHaveLength(0)
     })
 
+    it('renders secondaryRows separated from rows', () => {
+        const { baseElement } = render(
+            <ChartTooltip
+                x={100}
+                y={200}
+                title="2024"
+                rows={['10 streams', '30m']}
+                secondaryRows={['100 total streams', '5h total']}
+            />
+        )
+        expect(baseElement.querySelector('hr')).not.toBeNull()
+        const rows = baseElement.querySelectorAll('.text-gray-300')
+        expect(rows).toHaveLength(4)
+    })
+
+    it('renders no separator when secondaryRows is absent', () => {
+        const { baseElement } = render(
+            <ChartTooltip x={100} y={200} title="2024" rows={['10 streams']} />
+        )
+        expect(baseElement.querySelector('hr')).toBeNull()
+    })
+
     it('applies correct position styles', () => {
         const { baseElement } = render(
             <ChartTooltip x={150} y={300} title="Test" rows={[]} />

--- a/app/src/components/Charts/SimpleCharts/shared/ChartTooltip.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/shared/ChartTooltip.test.tsx
@@ -3,34 +3,55 @@ import { describe, it, expect } from 'vitest'
 import { ChartTooltip } from './ChartTooltip'
 
 describe('ChartTooltip', () => {
-    it('renders children at specified position', () => {
-        render(
-            <ChartTooltip x={100} y={200}>
-                Tooltip content
-            </ChartTooltip>
-        )
+    it('renders title', () => {
+        render(<ChartTooltip x={100} y={200} title="June 2024" rows={[]} />)
+        expect(screen.getByText('June 2024')).toBeDefined()
+    })
 
-        expect(screen.getByText('Tooltip content')).toBeDefined()
+    it('renders each non-null row', () => {
+        render(
+            <ChartTooltip
+                x={100}
+                y={200}
+                title="June 2024"
+                rows={['42 streams', '1h 30m']}
+            />
+        )
+        expect(screen.getByText('42 streams')).toBeDefined()
+        expect(screen.getByText('1h 30m')).toBeDefined()
+    })
+
+    it('skips null rows', () => {
+        const { baseElement } = render(
+            <ChartTooltip
+                x={100}
+                y={200}
+                title="June 2024"
+                rows={['42 streams', null, '1h 30m']}
+            />
+        )
+        const rows = baseElement.querySelectorAll('.text-gray-300')
+        expect(rows).toHaveLength(2)
+    })
+
+    it('renders no rows when array is empty', () => {
+        const { baseElement } = render(
+            <ChartTooltip x={100} y={200} title="June 2024" rows={[]} />
+        )
+        const rows = baseElement.querySelectorAll('.text-gray-300')
+        expect(rows).toHaveLength(0)
     })
 
     it('applies correct position styles', () => {
         const { baseElement } = render(
-            <ChartTooltip x={150} y={300}>
-                Test
-            </ChartTooltip>
+            <ChartTooltip x={150} y={300} title="Test" rows={[]} />
         )
-
         const tooltip = baseElement.querySelector('[style*="left: 150px"]')
         expect(tooltip).not.toBeNull()
     })
 
     it('renders via portal — content is accessible in the document', () => {
-        render(
-            <ChartTooltip x={0} y={0}>
-                Portal content
-            </ChartTooltip>
-        )
-
+        render(<ChartTooltip x={0} y={0} title="Portal content" rows={[]} />)
         expect(document.body.textContent).toContain('Portal content')
     })
 })

--- a/app/src/components/Charts/SimpleCharts/shared/ChartTooltip.tsx
+++ b/app/src/components/Charts/SimpleCharts/shared/ChartTooltip.tsx
@@ -1,20 +1,25 @@
-import type { FC, ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 
 type Props = {
     x: number
     y: number
-    children: ReactNode
+    title: string
+    rows: (string | null)[]
 }
 
-export const ChartTooltip: FC<Props> = ({ x, y, children }) => {
+export function ChartTooltip({ x, y, title, rows }: Props) {
     return createPortal(
         <div
             className="fixed z-50 pointer-events-none"
             style={{ left: x, top: y, transform: 'translate(-50%, -100%)' }}
         >
             <div className="bg-gray-900 dark:bg-slate-700 text-white rounded-lg shadow-lg px-2.5 py-1.5 text-[11px] whitespace-nowrap mb-2">
-                {children}
+                <div className="font-semibold">{title}</div>
+                {rows.filter(Boolean).map((text, i) => (
+                    <div key={i} className="text-gray-300 dark:text-gray-400">
+                        {text}
+                    </div>
+                ))}
             </div>
             <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900 dark:border-t-slate-700" />
         </div>,

--- a/app/src/components/Charts/SimpleCharts/shared/ChartTooltip.tsx
+++ b/app/src/components/Charts/SimpleCharts/shared/ChartTooltip.tsx
@@ -5,9 +5,10 @@ type Props = {
     y: number
     title: string
     rows: (string | null)[]
+    secondaryRows?: (string | null)[]
 }
 
-export function ChartTooltip({ x, y, title, rows }: Props) {
+export function ChartTooltip({ x, y, title, rows, secondaryRows }: Props) {
     return createPortal(
         <div
             className="fixed z-50 pointer-events-none"
@@ -15,11 +16,31 @@ export function ChartTooltip({ x, y, title, rows }: Props) {
         >
             <div className="bg-gray-900 dark:bg-slate-700 text-white rounded-lg shadow-lg px-2.5 py-1.5 text-[11px] whitespace-nowrap mb-2">
                 <div className="font-semibold">{title}</div>
-                {rows.filter((r): r is string => r !== null).map((text, i) => (
-                    <div key={i} className="text-gray-300 dark:text-gray-400">
-                        {text}
-                    </div>
-                ))}
+                {rows
+                    .filter((r): r is string => r !== null)
+                    .map((text, i) => (
+                        <div
+                            key={i}
+                            className="text-gray-300 dark:text-gray-400"
+                        >
+                            {text}
+                        </div>
+                    ))}
+                {secondaryRows && (
+                    <>
+                        <hr className="border-gray-700 my-1.5" />
+                        {secondaryRows
+                            .filter((r): r is string => r !== null)
+                            .map((text, i) => (
+                                <div
+                                    key={i}
+                                    className="text-gray-300 dark:text-gray-400"
+                                >
+                                    {text}
+                                </div>
+                            ))}
+                    </>
+                )}
             </div>
             <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900 dark:border-t-slate-700" />
         </div>,

--- a/app/src/components/Charts/SimpleCharts/shared/ChartTooltip.tsx
+++ b/app/src/components/Charts/SimpleCharts/shared/ChartTooltip.tsx
@@ -15,7 +15,7 @@ export function ChartTooltip({ x, y, title, rows }: Props) {
         >
             <div className="bg-gray-900 dark:bg-slate-700 text-white rounded-lg shadow-lg px-2.5 py-1.5 text-[11px] whitespace-nowrap mb-2">
                 <div className="font-semibold">{title}</div>
-                {rows.filter(Boolean).map((text, i) => (
+                {rows.filter((r): r is string => r !== null).map((text, i) => (
                     <div key={i} className="text-gray-300 dark:text-gray-400">
                         {text}
                     </div>


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

`ChartTooltip` accepted arbitrary `children`, so each call site assembled its own JSX structure with repeated `font-semibold` and `text-gray-300` divs. The layout was implicit and diverged across components.

## 🎹 Proposal

`ChartTooltip` now takes a `title` string and a `rows: (string | null)[]` array. Callers pre-format each row as a string and pass `null` for conditional rows that should not render. The component handles filtering and consistent styling internally.

An optional `secondaryRows` prop renders a second group of rows separated by a horizontal rule. `EvolutionOverTime` uses it to separate per-year stats from all-time totals.

The null filter uses a type guard (`r !== null`) instead of `Boolean` to avoid silently dropping empty strings.

## 🎶 Comments

Stacked on #460.

## 🎤 Test

No visible changes. Run `moon run app:typecheck app:test` to verify.