### PR TITLE
refactor(charts): redefine FunFact data contract and migrate SQL to new schema

### DIFF
--- a/app/src/components/Charts/SimpleCharts/FunFacts/AbsoluteLoyalty.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/AbsoluteLoyalty.sql
@@ -29,10 +29,8 @@ artist_loyalty as (
 )
 
 select
-    artist_name as main_text,
-    (loyalty_ratio * 100)::integer as fact_value,
-    '%' as unit,
-    'of your plays went all the way' as context
+    artist_name as entity,
+    (loyalty_ratio * 100)::integer as metric
 from artist_loyalty
-order by fact_value desc
+order by metric desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/AfternoonFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/AfternoonFavorite.sql
@@ -1,12 +1,10 @@
 select
-    artist_name as main_text,
-    count(*) as fact_value,
-    'streams' as unit,
-    'between 12pm and 6pm' as context
+    artist_name as entity,
+    count(*)::integer as metric
 from ${table}
 where
     (hour(ts::datetime) >= 12 and hour(ts::datetime) < 18)
     and artist_name is not null
 group by artist_name
-order by fact_value desc
+order by metric desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/CozyAlbum.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/CozyAlbum.sql
@@ -22,7 +22,6 @@ sunday_album_listening as (
 )
 
 select
-    album_name as main_text,
-    artist_name as second_text,
-    'the album that wraps your Sundays in musical coziness' as context
+    album_name as entity,
+    artist_name as parent_entity
 from sunday_album_listening

--- a/app/src/components/Charts/SimpleCharts/FunFacts/CurrentObsession.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/CurrentObsession.sql
@@ -5,14 +5,12 @@ recent_date as (
 )
 
 select
-    t.track_name as main_text,
-    count(*)::integer as fact_value,
-    'streams' as unit,
-    'in the last 30 days' as context
+    t.track_name as entity,
+    count(*)::integer as metric
 from ${table} as t, recent_date
 where
     t.ts::date >= recent_date.max_date - interval 30 day
     and t.track_name is not null
 group by t.track_name
-order by fact_value desc
+order by metric desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/EveningFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/EveningFavorite.sql
@@ -1,12 +1,10 @@
 select
-    artist_name as main_text,
-    count(*) as fact_value,
-    'streams' as unit,
-    'between 6pm and 0am' as context
+    artist_name as entity,
+    count(*)::integer as metric
 from ${table}
 where
     (hour(ts::datetime) >= 18 and hour(ts::datetime) < 24)
     and artist_name is not null
 group by artist_name
-order by fact_value desc
+order by metric desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FirstArtist.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FirstArtist.sql
@@ -1,9 +1,8 @@
 select
-    artist_name as main_text,
-    min(year(ts::date)) as fact_value,
-    'still in your rotation today?' as context
+    artist_name as entity,
+    min(year(ts::date))::integer as metric
 from ${table}
 where artist_name is not null
 group by artist_name
-order by fact_value asc
+order by metric asc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/ForgottenArtist.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/ForgottenArtist.sql
@@ -49,11 +49,9 @@ artist_stats as (
 )
 
 select
-    artist as main_text,
+    artist as entity,
     date_diff(
         'day', last_listen, (select max_date from recent_date)
-    )::integer as fact_value,
-    'days' as unit,
-    'off your radar' as context
+    )::integer as metric
 from artist_stats
 USING SAMPLE 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
@@ -5,7 +5,7 @@ import { FunFacts } from '.'
 import * as query from '../../../../db/queries/queryDB'
 import * as db from '../../../../db/getDB'
 import { DATA_LOADED_EVENT } from '../../../../db/dataSignal'
-import { FunFactResult, facts } from './queries'
+import { FunFactData, facts } from './queries'
 
 const EMPTY_MESSAGE = 'Not enough data for this fun fact — keep listening!'
 const ERROR_MESSAGE = 'Something went wrong while loading fun facts'
@@ -22,12 +22,11 @@ describe('FunFacts Component', () => {
             i++
             return [
                 {
-                    fact_type: fact.fact_type,
-                    main_text: `main_text_for_${fact.fact_type}`,
-                    fact_value: i % 2 === 0 ? 1 : 'one',
-                    context: i % 2 === 0 ? undefined : 'dummy_context',
+                    entity: `entity_for_${fact.fact_type}`,
+                    metric: i % 2 === 0 ? 1 : undefined,
+                    context_suffix: i % 2 === 0 ? undefined : 'dummy_context',
                 },
-            ] as FunFactResult[]
+            ] as FunFactData[]
         })
 
         vi.spyOn(db, 'getDB').mockResolvedValue({
@@ -63,11 +62,10 @@ describe('FunFacts Component', () => {
                 callIndex++
                 return [
                     {
-                        main_text: `Test fact #${callIndex}`,
-                        fact_value: callIndex,
-                        unit: 'streams',
+                        entity: `Test fact #${callIndex}`,
+                        metric: callIndex,
                     },
-                ] as FunFactResult[]
+                ] as FunFactData[]
             })
         const { container } = render(<FunFacts />)
 
@@ -199,12 +197,10 @@ describe('FunFacts Component', () => {
 
         spy.mockResolvedValue([
             {
-                fact_type: 'morning_favorite',
-                main_text: 'Test morning_favorite',
-                fact_value: 1,
-                unit: 'streams',
+                entity: 'Test morning_favorite',
+                metric: 1,
             },
-        ] as FunFactResult[])
+        ] as FunFactData[])
 
         fireEvent.click(screen.getByTitle('New fact'))
 
@@ -218,10 +214,9 @@ describe('FunFacts Component', () => {
     it('should show empty state when query returns null main_text and no other content', async () => {
         vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue([
             {
-                fact_type: 'dummy_fact_type',
-                main_text: null,
+                entity: null as unknown as string,
             },
-        ] as FunFactResult[])
+        ] as FunFactData[])
         render(<FunFacts />)
 
         await waitFor(() => {
@@ -234,15 +229,11 @@ describe('FunFacts Component', () => {
     it('should render content when query returns main_text and value', async () => {
         vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue([
             {
-                fact_type: 'cozy_album',
-                main_text: 'Cozy Album',
-                second_text: 'Cozy Artist',
-                fact_value: 10,
-                unit: 'streams',
-                context:
-                    'the album that wraps your Sundays in musical coziness',
+                entity: 'Cozy Album',
+                parent_entity: 'Cozy Artist',
+                metric: 10,
             },
-        ] as FunFactResult[])
+        ] as FunFactData[])
         render(<FunFacts />)
 
         await waitFor(() => {
@@ -266,12 +257,10 @@ describe('FunFacts Component', () => {
     it('displays numeric value when query returns fact_value', async () => {
         vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue([
             {
-                fact_type: 'morning_favorite',
-                main_text: 'Some Artist',
-                fact_value: 42,
-                unit: 'streams',
+                entity: 'Some Artist',
+                metric: 42,
             },
-        ] as FunFactResult[])
+        ] as FunFactData[])
         render(<FunFacts />)
 
         await waitFor(() => {

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.test.tsx
@@ -211,7 +211,7 @@ describe('FunFacts Component', () => {
         })
     })
 
-    it('should show empty state when query returns null main_text and no other content', async () => {
+    it('should show empty state when query returns null entity', async () => {
         vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue([
             {
                 entity: null as unknown as string,
@@ -226,7 +226,7 @@ describe('FunFacts Component', () => {
         expect(hasAnyTitle).toBe(true)
     })
 
-    it('should render content when query returns main_text and value', async () => {
+    it('should render entity and metric when query returns data', async () => {
         vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue([
             {
                 entity: 'Cozy Album',
@@ -239,6 +239,7 @@ describe('FunFacts Component', () => {
         await waitFor(() => {
             expect(screen.getByText('Cozy Album')).toBeDefined()
         })
+        expect(screen.getByText('Cozy Artist')).toBeDefined()
         expect(
             screen.getByText((content) => content.includes('10'))
         ).toBeDefined()
@@ -254,7 +255,7 @@ describe('FunFacts Component', () => {
         })
     })
 
-    it('displays numeric value when query returns fact_value', async () => {
+    it('displays numeric metric when query returns metric', async () => {
         vi.spyOn(query, 'queryDBAsJSON').mockResolvedValue([
             {
                 entity: 'Some Artist',

--- a/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/FunFacts.tsx
@@ -4,9 +4,9 @@ export type FunFactProps = {
     fact_type: string
     title: string
     emoji: string
-    main_text: string | undefined
-    second_text?: string
-    value?: number | string
+    entity: string | undefined
+    parent_entity?: string
+    metric?: number
     unit?: string
     context?: string
 }
@@ -31,7 +31,7 @@ const EmptyFunFact: FC = () => (
 )
 
 const FunFactContent: FC<ContentProps> = ({ fact, error, isLoading }) => {
-    if (isLoading && !fact) {
+    if (isLoading && !fact?.entity) {
         return (
             <div className="space-y-2 animate-pulse">
                 <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-3/4" />
@@ -49,33 +49,29 @@ const FunFactContent: FC<ContentProps> = ({ fact, error, isLoading }) => {
         )
     }
 
-    // type guard — unreachable in practice: skeleton renders while fact is null
-    if (!fact) return <EmptyFunFact />
+    if (!fact?.entity) return <EmptyFunFact />
 
-    if (!(fact.main_text || fact.value !== undefined || fact.second_text)) {
-        return <EmptyFunFact />
-    }
-
-    const { main_text, second_text, value, unit, context } = fact
-    const valueDisplayed =
-        typeof value === 'number' ? value.toLocaleString() : value
+    const { entity, parent_entity, metric, unit, context } = fact
 
     return (
         <>
-            {main_text && (
-                <div className="text-2xl md:text-4xl font-bold text-gray-900 dark:text-white mb-2 break-words text-balance">
-                    {main_text}
+            <div className="text-2xl md:text-4xl font-bold text-gray-900 dark:text-white mb-1 break-words text-balance">
+                {entity}
+            </div>
+            {parent_entity && (
+                <div className="text-base text-gray-500 dark:text-gray-400 mb-1">
+                    {parent_entity}
                 </div>
             )}
-            <div className="text-lg text-gray-600 dark:text-gray-300">
-                {second_text} {second_text && valueDisplayed ? '(' : undefined}
-                <span className="font-bold text-blue-600 dark:text-blue-400">
-                    {valueDisplayed}
-                    {unit === '%' ? unit : undefined}
-                </span>{' '}
-                {unit !== '%' ? unit : undefined}
-                {second_text && valueDisplayed ? ')' : undefined}
-            </div>
+            {metric !== undefined && (
+                <div className="text-lg text-gray-600 dark:text-gray-300">
+                    <span className="font-bold text-blue-600 dark:text-blue-400">
+                        {metric.toLocaleString()}
+                        {unit === '%' ? unit : ''}
+                    </span>
+                    {unit && unit !== '%' && ` ${unit}`}
+                </div>
+            )}
             {context && (
                 <div className="text-sm text-gray-600 dark:text-gray-400 mt-1 italic">
                     {context}

--- a/app/src/components/Charts/SimpleCharts/FunFacts/Marathon.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/Marathon.sql
@@ -28,10 +28,9 @@ group_sizes as (
 )
 
 select
-    artist_name as main_text,
-    stream_count::double as fact_value,
-    'streams in a row' as unit,
-    'one uninterrupted run on ' || listen_date::varchar as context
+    artist_name as entity,
+    stream_count::integer as metric,
+    listen_date::text as context_suffix
 from group_sizes
 order by stream_count desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/MorningFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/MorningFavorite.sql
@@ -1,12 +1,10 @@
 select
-    artist_name as main_text,
-    count(*) as fact_value,
-    'streams' as unit,
-    'between 6am and 12pm' as context
+    artist_name as entity,
+    count(*)::integer as metric
 from ${table}
 where
     (hour(ts::datetime) >= 6 and hour(ts::datetime) < 12)
     and artist_name is not null
 group by artist_name
-order by fact_value desc
+order by metric desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/MusicalAnniversary.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/MusicalAnniversary.sql
@@ -35,9 +35,7 @@ artist_years as (
 )
 
 select
-    artist_years.artist_name as main_text,
-    year(recent_date.max_date) - artist_years.first_year as fact_value,
-    'years' as unit,
-    'strong' as context
+    artist_years.artist_name as entity,
+    year(recent_date.max_date) - artist_years.first_year as metric
 from artist_years, recent_date
 USING SAMPLE 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/NightFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/NightFavorite.sql
@@ -1,12 +1,10 @@
 select
-    artist_name as main_text,
-    count(*) as fact_value,
-    'streams' as unit,
-    'between 0am and 6am' as context
+    artist_name as entity,
+    count(*)::integer as metric
 from ${table}
 where
     hour(ts::datetime) < 6
     and artist_name is not null
 group by artist_name
-order by fact_value desc
+order by metric desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/NostalgicReturn.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/NostalgicReturn.sql
@@ -50,9 +50,7 @@ artist_gaps as (
 )
 
 select
-    artist as main_text,
-    gap::integer as fact_value,
-    'days' as unit,
-    'later, it''s back' as context
+    artist as entity,
+    gap::integer as metric
 from artist_gaps
 USING SAMPLE 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/OneHitWonder.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/OneHitWonder.sql
@@ -29,9 +29,8 @@ track_stats as (
 )
 
 select
-    track_name as main_text,
-    percentage as fact_value,
-    '%' as unit,
-    'of your streams of ' || artist_name as context
+    track_name as entity,
+    percentage as metric,
+    artist_name as context_suffix
 from track_stats
 USING SAMPLE 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/RecentDiscovery.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/RecentDiscovery.sql
@@ -14,10 +14,8 @@ artist_first_listen as (
 )
 
 select
-    artist_name as main_text,
-    count(*)::integer as fact_value,
-    'streams' as unit,
-    'discovered in the last 3 months' as context
+    artist_name as entity,
+    count(*)::integer as metric
 from ${table}
 inner join artist_first_listen using (artist_name)
 where
@@ -25,5 +23,5 @@ where
     >= (select max_date - interval 90 day from recent_date)
     and artist_name is not null
 group by artist_name
-order by fact_value desc
+order by metric desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/SubscribedArtist.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/SubscribedArtist.sql
@@ -1,10 +1,8 @@
 select
-    artist_name as main_text,
-    count(distinct strftime(ts::date, '%Y-%m'))::integer as fact_value,
-    'months' as unit,
-    'in your rotation' as context
+    artist_name as entity,
+    count(distinct strftime(ts::date, '%Y-%m'))::integer as metric
 from ${table}
 where artist_name is not null
 group by artist_name
-order by fact_value desc
+order by metric desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/TrackProposition.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/TrackProposition.sql
@@ -1,7 +1,6 @@
 select
-    track_name as main_text,
-    artist_name as second_text,
-    'your next listen is already waiting' as context
+    track_name as entity,
+    artist_name as parent_entity
 from ${table}
 where track_name is not null
 USING SAMPLE 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/WeekendFavorite.sql
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/WeekendFavorite.sql
@@ -1,8 +1,6 @@
 select
-    artist_name as main_text,
-    count(*) as fact_value,
-    'streams' as unit,
-    'on weekends' as context
+    artist_name as entity,
+    count(*)::integer as metric
 from ${table}
 where
     (
@@ -11,5 +9,5 @@ where
     )
     and artist_name is not null
 group by artist_name
-order by fact_value desc
+order by metric desc
 limit 1

--- a/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
@@ -40,10 +40,10 @@ export function FunFacts() {
                 title: factDefinition.title,
                 emoji: factDefinition.emoji,
                 fact_type: factDefinition.fact_type,
-                main_text: result?.entity ?? undefined,
-                second_text: result?.parent_entity,
-                value: result?.metric,
-                unit: result?.unit,
+                entity: result?.entity ?? undefined,
+                parent_entity: result?.parent_entity,
+                metric: result?.metric,
+                unit: factDefinition.unit,
                 context: [factDefinition.context, result?.context_suffix]
                     .filter(Boolean)
                     .join(' '),

--- a/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { type FunFactResult, facts } from './queries'
+import { type FunFactData, facts } from './queries'
 import { queryDBAsJSON } from '../../../../db/queries/queryDB'
 import { DATA_LOADED_EVENT } from '../../../../db/dataSignal'
 import { FunFacts as FunFactsView, type FunFactProps } from './FunFacts'
@@ -33,18 +33,20 @@ export function FunFacts() {
 
             seenFactsRef.current.add(factDefinition.fact_type)
 
-            const [result] = await queryDBAsJSON<FunFactResult>(
+            const [result] = await queryDBAsJSON<FunFactData>(
                 factDefinition.sql
             )
             setFact({
                 title: factDefinition.title,
                 emoji: factDefinition.emoji,
                 fact_type: factDefinition.fact_type,
-                main_text: result?.main_text ?? undefined,
-                second_text: result?.second_text,
-                value: result?.fact_value,
+                main_text: result?.entity ?? undefined,
+                second_text: result?.parent_entity,
+                value: result?.metric,
                 unit: result?.unit,
-                context: result?.context,
+                context: [factDefinition.context, result?.context_suffix]
+                    .filter(Boolean)
+                    .join(' '),
             })
         } catch (error) {
             console.error('Error loading fun fact:', error)

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
@@ -28,6 +28,8 @@ describe('FunFacts queries', () => {
             expect(fact.fact_type).toBeTruthy()
             expect(fact.title).toBeTruthy()
             expect(fact.emoji).toBeTruthy()
+            expect(fact).toHaveProperty('unit')
+            expect(fact.context).toBeTruthy()
             expect(fact.sql).toBeTruthy()
             expect(fact.sql).not.toContain('$')
             expect(fact.sql).not.toContain('{')
@@ -59,10 +61,9 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('morning_favorite').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBe('top_morning_artist')
-            expect(row.fact_value).toBe('2')
-            expect(row.unit).toBe('streams')
-            expect(row.context).toBe('between 6am and 12pm')
+            expect(row.entity).toBe('top_morning_artist')
+            expect(row.metric).toBe(2)
+            expect(row.context_suffix).toBeUndefined()
         })
 
         it('queryAfternoonFavorite returns artist with most afternoon streams', async () => {
@@ -72,10 +73,9 @@ describe('FunFacts queries', () => {
             )
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBe('top_afternoon_artist')
-            expect(row.fact_value).toBe('2')
-            expect(row.unit).toBe('streams')
-            expect(row.context).toBe('between 12pm and 6pm')
+            expect(row.entity).toBe('top_afternoon_artist')
+            expect(row.metric).toBe(2)
+            expect(row.context_suffix).toBeUndefined()
         })
 
         it('queryEveningFavorite returns artist with most evening streams', async () => {
@@ -85,10 +85,9 @@ describe('FunFacts queries', () => {
             const rows = result.getRowObjectsJson()
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBe('top_evening_artist')
-            expect(row.fact_value).toBe('2')
-            expect(row.unit).toBe('streams')
-            expect(row.context).toBe('between 6pm and 0am')
+            expect(row.entity).toBe('top_evening_artist')
+            expect(row.metric).toBe(2)
+            expect(row.context_suffix).toBeUndefined()
         })
 
         it('queryNightFavorite returns artist with most night streams', async () => {
@@ -98,10 +97,9 @@ describe('FunFacts queries', () => {
             const rows = result.getRowObjectsJson()
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBe('top_night_artist')
-            expect(row.fact_value).toBe('2')
-            expect(row.unit).toBe('streams')
-            expect(row.context).toBe('between 0am and 6am')
+            expect(row.entity).toBe('top_night_artist')
+            expect(row.metric).toBe(2)
+            expect(row.context_suffix).toBeUndefined()
         })
     })
 
@@ -122,10 +120,9 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('marathon').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBe('consecutive_stream_artist')
-            expect(row.fact_value).toBe(3)
-            expect(row.unit).toBe('streams in a row')
-            expect(row.context).toBe('one uninterrupted run on 2024-01-01')
+            expect(row.entity).toBe('consecutive_stream_artist')
+            expect(row.metric).toBe(3)
+            expect(row.context_suffix).toBe('2024-01-01')
         })
     })
 
@@ -142,10 +139,9 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('one_hit_wonder').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBe('hit_track')
-            expect(row.fact_value).toBe(100)
-            expect(row.unit).toBe('%')
-            expect(row.context).toBe('of your streams of one_hit_wonder_artist')
+            expect(row.entity).toBe('hit_track')
+            expect(row.metric).toBe(100)
+            expect(row.context_suffix).toBe('one_hit_wonder_artist')
         })
     })
 
@@ -169,10 +165,9 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('weekend_favorite').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBe('weekend_artist')
-            expect(row.fact_value).toBe('2')
-            expect(row.unit).toBe('streams')
-            expect(row.context).toBe('on weekends')
+            expect(row.entity).toBe('weekend_artist')
+            expect(row.metric).toBe(2)
+            expect(row.context_suffix).toBeUndefined()
         })
     })
 
@@ -196,10 +191,9 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('absolute_loyalty').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBe('loyal_artist')
-            expect(row.fact_value).toBe(75)
-            expect(row.unit).toBe('%')
-            expect(row.context).toBe('of your plays went all the way')
+            expect(row.entity).toBe('loyal_artist')
+            expect(row.metric).toBe(75)
+            expect(row.context_suffix).toBeUndefined()
         })
     })
 
@@ -220,10 +214,9 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('nostalgic_return').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBe('nostalgic_artist')
-            expect(row.fact_value).toBe(366)
-            expect(row.unit).toBe('days')
-            expect(row.context).toBe("later, it's back")
+            expect(row.entity).toBe('nostalgic_artist')
+            expect(row.metric).toBe(366)
+            expect(row.context_suffix).toBeUndefined()
         })
     })
 
@@ -248,10 +241,9 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('current_obsession').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBe('current_hit')
-            expect(row.fact_value).toBe(2)
-            expect(row.unit).toBe('streams')
-            expect(row.context).toBe('in the last 30 days')
+            expect(row.entity).toBe('current_hit')
+            expect(row.metric).toBe(2)
+            expect(row.context_suffix).toBeUndefined()
         })
     })
 
@@ -273,10 +265,9 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('recent_discovery').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBe('recent_discovery_artist')
-            expect(row.fact_value).toBe(1)
-            expect(row.unit).toBe('streams')
-            expect(row.context).toBe('discovered in the last 3 months')
+            expect(row.entity).toBe('recent_discovery_artist')
+            expect(row.metric).toBe(1)
+            expect(row.context_suffix).toBeUndefined()
         })
     })
 
@@ -299,10 +290,9 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('subscribed_artist').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBe('subscribed_artist')
-            expect(row.fact_value).toBe(3)
-            expect(row.unit).toBe('months')
-            expect(row.context).toBe('in your rotation')
+            expect(row.entity).toBe('subscribed_artist')
+            expect(row.metric).toBe(3)
+            expect(row.context_suffix).toBeUndefined()
         })
     })
 
@@ -322,10 +312,9 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('first_artist').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBe('first_artist')
-            expect(row.fact_value).toBe('2006')
-            expect(row.unit).toBeUndefined()
-            expect(row.context).toBe('still in your rotation today?')
+            expect(row.entity).toBe('first_artist')
+            expect(row.metric).toBe(2006)
+            expect(row.context_suffix).toBeUndefined()
         })
 
         it('queryMusicalAnniversary returns artist listened to for longest time', async () => {
@@ -335,10 +324,9 @@ describe('FunFacts queries', () => {
             )
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBeDefined()
-            expect(row.fact_value).toBeDefined()
-            expect(row.unit).toBe('years')
-            expect(row.context).toBe('strong')
+            expect(row.entity).toBeDefined()
+            expect(row.metric).toBeDefined()
+            expect(row.context_suffix).toBeUndefined()
         })
     })
 
@@ -361,10 +349,9 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('forgotten_artist').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBe('forgotten_artist')
-            expect(row.fact_value).toBe(366)
-            expect(row.unit).toBe('days')
-            expect(row.context).toBe('off your radar')
+            expect(row.entity).toBe('forgotten_artist')
+            expect(row.metric).toBe(366)
+            expect(row.context_suffix).toBeUndefined()
         })
     })
 
@@ -382,11 +369,10 @@ describe('FunFacts queries', () => {
             const rows = await testQuery(conn, getFact('track_proposition').sql)
             expect(rows.length).toBe(1)
             const row = rows[0]
-            expect(row.main_text).toBeOneOf(['track1', 'track2'])
-            expect(row.fact_value).toBeUndefined()
-            expect(row.second_text).toBeOneOf(['artist1', 'artist2'])
-            expect(row.unit).toBeUndefined()
-            expect(row.context).toBe('your next listen is already waiting')
+            expect(row.entity).toBeOneOf(['track1', 'track2'])
+            expect(row.metric).toBeUndefined()
+            expect(row.parent_entity).toBeOneOf(['artist1', 'artist2'])
+            expect(row.context_suffix).toBeUndefined()
         })
     })
 
@@ -416,13 +402,11 @@ describe('FunFacts queries', () => {
 
                 const rows = await testQuery(conn, getFact('cozy_album').sql)
                 expect(rows.length).toBe(1)
-                expect(rows[0].main_text).toBe('album1')
-                expect(rows[0].second_text).toBe('artist1')
-                expect(rows[0].fact_value).toBeUndefined()
+                expect(rows[0].entity).toBe('album1')
+                expect(rows[0].parent_entity).toBe('artist1')
+                expect(rows[0].metric).toBeUndefined()
                 expect(rows[0].unit).toBeUndefined()
-                expect(rows[0].context).toBe(
-                    'the album that wraps your Sundays in musical coziness'
-                )
+                expect(rows[0].context_suffix).toBeUndefined()
             })
         })
 
@@ -452,7 +436,7 @@ describe('FunFacts queries', () => {
                 await createTestTable(conn, testData)
                 const rows = await testQuery(conn, getFact('cozy_album').sql)
                 expect(rows.length).toBe(1)
-                expect(rows[0].main_text).toBe('album1')
+                expect(rows[0].entity).toBe('album1')
             })
         })
 
@@ -482,7 +466,7 @@ describe('FunFacts queries', () => {
                 await createTestTable(conn, testData)
                 const rows = await testQuery(conn, getFact('cozy_album').sql)
                 expect(rows.length).toBe(1)
-                expect(rows[0].main_text).toBe('album2')
+                expect(rows[0].entity).toBe('album2')
             })
         })
 
@@ -511,7 +495,7 @@ describe('FunFacts queries', () => {
                 await createTestTable(conn, testData)
                 const rows = await testQuery(conn, getFact('cozy_album').sql)
                 expect(rows.length).toBe(1)
-                expect(rows[0].main_text).toBe('album2')
+                expect(rows[0].entity).toBe('album2')
             })
         })
 

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.ts
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.ts
@@ -17,12 +17,11 @@ import sqlQueryMarathon from './Marathon.sql?raw'
 import sqlQueryTrackProposition from './TrackProposition.sql?raw'
 import sqlQueryCozyAlbum from './CozyAlbum.sql?raw'
 
-export type FunFactResult = {
-    main_text: string | undefined
-    second_text?: string
-    fact_value?: number | string
-    unit?: string
-    context?: string
+export type FunFactData = {
+    entity: string
+    parent_entity?: string
+    metric?: number
+    context_suffix?: string
 }
 
 const build = (sql: string) => sql.replaceAll('${table}', TABLE)
@@ -32,102 +31,136 @@ export const facts = [
         fact_type: 'morning_favorite',
         title: '🌅 Musical Breakfast',
         emoji: '🥐',
+        unit: 'streams',
+        context: 'between 6am and 12pm',
         sql: build(sqlQueryMorningFavorite),
     },
     {
         fact_type: 'afternoon_favorite',
         title: '🏞️ Afternoon Boost',
         emoji: '⚡️',
+        unit: 'streams',
+        context: 'between 12pm and 6pm',
         sql: build(sqlQueryAfternoonFavorite),
     },
     {
         fact_type: 'evening_favorite',
         title: '🌆 Calm Return',
         emoji: '🛋️',
+        unit: 'streams',
+        context: 'between 6pm and 0am',
         sql: build(sqlQueryEveningFavorite),
     },
     {
         fact_type: 'night_favorite',
         title: '🌌 Musical Insomnia',
         emoji: '💤',
+        unit: 'streams',
+        context: 'between 0am and 6am',
         sql: build(sqlQueryNightFavorite),
     },
     {
         fact_type: 'weekend_favorite',
         title: '🧉 Weekend Vibes',
         emoji: '🕺',
+        unit: 'streams',
+        context: 'on weekends',
         sql: build(sqlQueryWeekendFavorite),
     },
     {
         fact_type: 'nostalgic_return',
         title: '📻 Signal Found',
         emoji: '🛰️',
+        unit: 'days',
+        context: "later, it's back",
         sql: build(sqlQueryNostalgicReturn),
     },
     {
         fact_type: 'forgotten_artist',
         title: '🥀 Fading Away',
         emoji: '🌫️',
+        unit: 'days',
+        context: 'off your radar',
         sql: build(sqlQueryForgottenArtist),
     },
     {
         fact_type: 'absolute_loyalty',
         title: '💎 Absolute Loyalty',
         emoji: '💍',
+        unit: '%',
+        context: 'of your plays went all the way',
         sql: build(sqlQueryAbsoluteLoyalty),
     },
     {
         fact_type: 'subscribed_artist',
         title: '🎟️ Monthly Subscription',
         emoji: '📬',
+        unit: 'months',
+        context: 'in your rotation',
         sql: build(sqlQuerySubscribedArtist),
     },
     {
         fact_type: 'musical_anniversary',
         title: '🎉 Musical Anniversary',
         emoji: '🎂',
+        unit: 'years',
+        context: 'strong',
         sql: build(sqlQueryMusicalAnniversary),
     },
     {
         fact_type: 'first_artist',
         title: '1️⃣ The Very First',
         emoji: '🦖',
+        unit: undefined,
+        context: 'still in your rotation today?',
         sql: build(sqlQueryFirstArtist),
     },
     {
         fact_type: 'one_hit_wonder',
         title: '⭐ One Hit Wonder',
         emoji: '📼',
+        unit: '%',
+        context: 'of your streams of',
         sql: build(sqlQueryOneHitWonder),
     },
     {
         fact_type: 'current_obsession',
         title: '🔁 Current Obsession',
         emoji: '🎯',
+        unit: 'streams',
+        context: 'in the last 30 days',
         sql: build(sqlQueryCurrentObsession),
     },
     {
         fact_type: 'recent_discovery',
         title: '🔍 Recent Discovery',
         emoji: '✨',
+        unit: 'streams',
+        context: 'discovered in the last 3 months',
         sql: build(sqlQueryRecentDiscovery),
     },
     {
         fact_type: 'marathon',
         title: '🏃 Marathon',
         emoji: '☄️',
+        unit: 'streams in a row',
+        context: 'one uninterrupted run on',
         sql: build(sqlQueryMarathon),
     },
     {
         fact_type: 'track_proposition',
         title: '▶️ Up Next',
         emoji: '🔮',
+        unit: undefined,
+        context: 'your next listen is already waiting',
         sql: build(sqlQueryTrackProposition),
     },
     {
         fact_type: 'cozy_album',
         title: '💿 Cozy Album',
         emoji: '☁️',
+        unit: undefined,
+        context: 'the album that wraps your Sundays in musical coziness',
         sql: build(sqlQueryCozyAlbum),
     },
 ] as const


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The FunFact data contract did not reflect how facts actually work: static context strings were embedded in SQL queries as literal values, the numeric field accepted strings unnecessarily, and field names (main_text, second_text, fact_value) did not describe the data they held.

## 🎹 Proposal

The FunFact type is redefined around what a fact actually contains: a musical entity (artist, track, or album), an optional parent entity, an optional numeric metric. Static display strings (`context` and `unit`) move from SQL into the fact definitions in code. For facts with a computed context (Marathon and OneHitWonder), SQL returns only the dynamic fragment as `context_suffix`, and the full string is assembled in the controller. 

## 🎶 Comments

`value` was the natural name for the numeric field but is a reserved SQL keyword, sqruff rejects it as an unquoted identifier. Renamed to `metric` to stay clean at the SQL layer without quoting workarounds.

## 🎤 Test

1. Load the demo data
2. Navigate to the dashboard and observe the Fun Fact card
3. Click the refresh button several times and verify each fact displays correctly: entity name, optional parent, optional metric with unit, and context line
4. Verify Marathon shows a date in the context line ("one uninterrupted run on YYYY-MM-DD")
5. Verify One Hit Wonder shows an artist name in the context line ("of your streams of Artist")