### PR TITLE
test(charts): make testQuery generic and type all SimpleCharts query test call sites

### DIFF
--- a/app/src/components/Charts/SimpleCharts/ArtistLoyalty/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/ArtistLoyalty/query.test.ts
@@ -51,10 +51,10 @@ describe('ArtistLoyalty Query', () => {
     })
 
     it('should return artist bins for 2025', async () => {
-        const rows = (await testQuery(
+        const rows = await testQuery<ArtistLoyaltyResult>(
             conn,
             queryArtistLoyalty(2025)
-        )) as unknown as ArtistLoyaltyResult[]
+        )
 
         expect(rows.length).toBe(5)
 
@@ -74,10 +74,10 @@ describe('ArtistLoyalty Query', () => {
     })
 
     it('should calculate correct stream counts per bin', async () => {
-        const rows = (await testQuery(
+        const rows = await testQuery<ArtistLoyaltyResult>(
             conn,
             queryArtistLoyalty(2025)
-        )) as unknown as ArtistLoyaltyResult[]
+        )
 
         const bins = rows.reduce(
             (acc, row) => {
@@ -95,10 +95,10 @@ describe('ArtistLoyalty Query', () => {
     })
 
     it('should return correct share of total streams', async () => {
-        const rows = (await testQuery(
+        const rows = await testQuery<ArtistLoyaltyResult>(
             conn,
             queryArtistLoyalty(2025)
-        )) as unknown as ArtistLoyaltyResult[]
+        )
 
         const totalStreams = rows.reduce(
             (sum, row) => sum + (row.streams_in_bin ?? 0),
@@ -115,14 +115,14 @@ describe('ArtistLoyalty Query', () => {
     })
 
     it('should filter by year correctly', async () => {
-        const rows2025 = (await testQuery(
+        const rows2025 = await testQuery<ArtistLoyaltyResult>(
             conn,
             queryArtistLoyalty(2025)
-        )) as unknown as ArtistLoyaltyResult[]
-        const rows2024 = (await testQuery(
+        )
+        const rows2024 = await testQuery<ArtistLoyaltyResult>(
             conn,
             queryArtistLoyalty(2024)
-        )) as unknown as ArtistLoyaltyResult[]
+        )
 
         expect(rows2025.length).toBe(5)
         expect(rows2024.length).toBe(1)
@@ -131,10 +131,10 @@ describe('ArtistLoyalty Query', () => {
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = (await testQuery(
+        const rows = await testQuery<ArtistLoyaltyResult>(
             conn,
             queryArtistLoyalty(undefined)
-        )) as unknown as ArtistLoyaltyResult[]
+        )
 
         expect(rows.length).toBe(5)
         expect(rows[0].artist_count).toBe(2)

--- a/app/src/components/Charts/SimpleCharts/BingeListener/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/BingeListener/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { buildBingeListenerQuery } from './query'
+import { type BingeListenerResult, buildBingeListenerQuery } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -36,14 +36,20 @@ describe('BingeListener Query', () => {
     })
 
     it('should return the heaviest listening day for a given year', async () => {
-        const rows = await testQuery(conn, buildBingeListenerQuery(testYear))
+        const rows = await testQuery<BingeListenerResult>(
+            conn,
+            buildBingeListenerQuery(testYear)
+        )
         expect(rows.length).toBe(1)
         expect(rows[0].stream_date).toBe(`${testYear}-01-01`)
         expect(rows[0].hours_played).toBeCloseTo(2.0)
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = await testQuery(conn, buildBingeListenerQuery(undefined))
+        const rows = await testQuery<BingeListenerResult>(
+            conn,
+            buildBingeListenerQuery(undefined)
+        )
         expect(rows.length).toBe(1)
         expect(rows[0].stream_date).toBe(`${anotherYear}-06-01`)
         expect(rows[0].hours_played).toBeCloseTo(4.0)
@@ -51,7 +57,10 @@ describe('BingeListener Query', () => {
 
     it('should return empty when no data', async () => {
         await createTestTable(conn, [])
-        const rows = await testQuery(conn, buildBingeListenerQuery(testYear))
+        const rows = await testQuery<BingeListenerResult>(
+            conn,
+            buildBingeListenerQuery(testYear)
+        )
         expect(rows.length).toBe(0)
     })
 })

--- a/app/src/components/Charts/SimpleCharts/ConcentrationScore/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/ConcentrationScore/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { queryConcentrationScore } from './query'
+import { type ConcentrationResult, queryConcentrationScore } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -78,7 +78,10 @@ describe('ConcentrationScore Query', () => {
     })
 
     it('should return concentration metrics', async () => {
-        const rows = await testQuery(conn, queryConcentrationScore(2025))
+        const rows = await testQuery<ConcentrationResult>(
+            conn,
+            queryConcentrationScore(2025)
+        )
 
         expect(rows.length).toBe(1)
         const row = rows[0]
@@ -89,7 +92,10 @@ describe('ConcentrationScore Query', () => {
     })
 
     it('should return empty metrics', async () => {
-        const rows = await testQuery(conn, queryConcentrationScore(2023))
+        const rows = await testQuery<ConcentrationResult>(
+            conn,
+            queryConcentrationScore(2023)
+        )
 
         expect(rows.length).toBe(1)
         const row = rows[0]
@@ -100,7 +106,10 @@ describe('ConcentrationScore Query', () => {
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = await testQuery(conn, queryConcentrationScore(undefined))
+        const rows = await testQuery<ConcentrationResult>(
+            conn,
+            queryConcentrationScore(undefined)
+        )
         // artist24 now has 2 streams (testDate + anotherYear), total streams increase
         expect(rows.length).toBe(1)
         const row = rows[0]

--- a/app/src/components/Charts/SimpleCharts/EvolutionOverTime/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/EvolutionOverTime/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { queryEvolutionOverTime } from './query'
+import { type EvolutionResult, queryEvolutionOverTime } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -33,7 +33,10 @@ describe('EvolutionOverTime Query', () => {
     })
 
     it('should return evolution metrics', async () => {
-        const rows = await testQuery(conn, queryEvolutionOverTime())
+        const rows = await testQuery<EvolutionResult>(
+            conn,
+            queryEvolutionOverTime()
+        )
 
         expect(rows).toEqual([
             { stream_year: 2006, stream_count: 1, ms_played: 1 },

--- a/app/src/components/Charts/SimpleCharts/FavoriteWeekday/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/FavoriteWeekday/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { queryFavoriteWeekday } from './query'
+import { type FavoriteWeekdayResult, queryFavoriteWeekday } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -38,7 +38,10 @@ describe('FavoriteWeekday Query', () => {
     })
 
     it('should return weekday statistics', async () => {
-        const rows = await testQuery(conn, queryFavoriteWeekday(2025))
+        const rows = await testQuery<FavoriteWeekdayResult>(
+            conn,
+            queryFavoriteWeekday(2025)
+        )
 
         expect(rows).toEqual([
             { day_name: 'Monday', stream_count: 2, ms_played: 90000, pct: 25 },
@@ -85,7 +88,10 @@ describe('FavoriteWeekday Query', () => {
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = await testQuery(conn, queryFavoriteWeekday(undefined))
+        const rows = await testQuery<FavoriteWeekdayResult>(
+            conn,
+            queryFavoriteWeekday(undefined)
+        )
         // 2024-12-01 is a Sunday, so total streams increases from 8 to 9
         const total = rows.reduce(
             (sum, row) => sum + (row.stream_count as number),

--- a/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
+++ b/app/src/components/Charts/SimpleCharts/FunFacts/queries.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { facts } from './queries'
+import { type FunFactData, facts } from './queries'
 import {
     createTestConnection,
     closeTestConnection,
@@ -58,7 +58,10 @@ describe('FunFacts queries', () => {
         })
 
         it('queryMorningFavorite returns artist with most morning streams', async () => {
-            const rows = await testQuery(conn, getFact('morning_favorite').sql)
+            const rows = await testQuery<FunFactData>(
+                conn,
+                getFact('morning_favorite').sql
+            )
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.entity).toBe('top_morning_artist')
@@ -67,7 +70,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryAfternoonFavorite returns artist with most afternoon streams', async () => {
-            const rows = await testQuery(
+            const rows = await testQuery<FunFactData>(
                 conn,
                 getFact('afternoon_favorite').sql
             )
@@ -117,7 +120,10 @@ describe('FunFacts queries', () => {
         })
 
         it('queryMarathon returns longest consecutive artist stream', async () => {
-            const rows = await testQuery(conn, getFact('marathon').sql)
+            const rows = await testQuery<FunFactData>(
+                conn,
+                getFact('marathon').sql
+            )
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.entity).toBe('consecutive_stream_artist')
@@ -136,7 +142,10 @@ describe('FunFacts queries', () => {
         })
 
         it('queryOneHitWonder returns track with highest percentage of artist streams', async () => {
-            const rows = await testQuery(conn, getFact('one_hit_wonder').sql)
+            const rows = await testQuery<FunFactData>(
+                conn,
+                getFact('one_hit_wonder').sql
+            )
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.entity).toBe('hit_track')
@@ -162,7 +171,10 @@ describe('FunFacts queries', () => {
         })
 
         it('queryWeekendFavorite returns artist with most weekend streams', async () => {
-            const rows = await testQuery(conn, getFact('weekend_favorite').sql)
+            const rows = await testQuery<FunFactData>(
+                conn,
+                getFact('weekend_favorite').sql
+            )
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.entity).toBe('weekend_artist')
@@ -188,7 +200,10 @@ describe('FunFacts queries', () => {
         })
 
         it('queryAbsoluteLoyalty returns artist with highest listening time percentage', async () => {
-            const rows = await testQuery(conn, getFact('absolute_loyalty').sql)
+            const rows = await testQuery<FunFactData>(
+                conn,
+                getFact('absolute_loyalty').sql
+            )
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.entity).toBe('loyal_artist')
@@ -211,7 +226,10 @@ describe('FunFacts queries', () => {
         })
 
         it('queryNostalgicReturn returns recently played artist with longest gap', async () => {
-            const rows = await testQuery(conn, getFact('nostalgic_return').sql)
+            const rows = await testQuery<FunFactData>(
+                conn,
+                getFact('nostalgic_return').sql
+            )
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.entity).toBe('nostalgic_artist')
@@ -238,7 +256,10 @@ describe('FunFacts queries', () => {
         })
 
         it('queryCurrentObsession returns most played track in last 30 days', async () => {
-            const rows = await testQuery(conn, getFact('current_obsession').sql)
+            const rows = await testQuery<FunFactData>(
+                conn,
+                getFact('current_obsession').sql
+            )
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.entity).toBe('current_hit')
@@ -262,7 +283,10 @@ describe('FunFacts queries', () => {
         })
 
         it('queryRecentDiscovery returns recently discovered artist with most streams', async () => {
-            const rows = await testQuery(conn, getFact('recent_discovery').sql)
+            const rows = await testQuery<FunFactData>(
+                conn,
+                getFact('recent_discovery').sql
+            )
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.entity).toBe('recent_discovery_artist')
@@ -287,7 +311,10 @@ describe('FunFacts queries', () => {
         })
 
         it('querySubscribedArtist returns artist present in most months', async () => {
-            const rows = await testQuery(conn, getFact('subscribed_artist').sql)
+            const rows = await testQuery<FunFactData>(
+                conn,
+                getFact('subscribed_artist').sql
+            )
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.entity).toBe('subscribed_artist')
@@ -309,7 +336,10 @@ describe('FunFacts queries', () => {
         })
 
         it('queryFirstArtist returns first artist listened to', async () => {
-            const rows = await testQuery(conn, getFact('first_artist').sql)
+            const rows = await testQuery<FunFactData>(
+                conn,
+                getFact('first_artist').sql
+            )
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.entity).toBe('first_artist')
@@ -318,7 +348,7 @@ describe('FunFacts queries', () => {
         })
 
         it('queryMusicalAnniversary returns artist listened to for longest time', async () => {
-            const rows = await testQuery(
+            const rows = await testQuery<FunFactData>(
                 conn,
                 getFact('musical_anniversary').sql
             )
@@ -346,7 +376,10 @@ describe('FunFacts queries', () => {
         })
 
         it('queryForgottenArtist returns top artist not listened to recently', async () => {
-            const rows = await testQuery(conn, getFact('forgotten_artist').sql)
+            const rows = await testQuery<FunFactData>(
+                conn,
+                getFact('forgotten_artist').sql
+            )
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.entity).toBe('forgotten_artist')
@@ -366,7 +399,10 @@ describe('FunFacts queries', () => {
         })
 
         it('queryTrackProposition returns a random track', async () => {
-            const rows = await testQuery(conn, getFact('track_proposition').sql)
+            const rows = await testQuery<FunFactData>(
+                conn,
+                getFact('track_proposition').sql
+            )
             expect(rows.length).toBe(1)
             const row = rows[0]
             expect(row.entity).toBeOneOf(['track1', 'track2'])
@@ -400,7 +436,10 @@ describe('FunFacts queries', () => {
             it('contains album and artist names', async () => {
                 await createTestTable(conn, testData)
 
-                const rows = await testQuery(conn, getFact('cozy_album').sql)
+                const rows = await testQuery<FunFactData>(
+                    conn,
+                    getFact('cozy_album').sql
+                )
                 expect(rows.length).toBe(1)
                 expect(rows[0].entity).toBe('album1')
                 expect(rows[0].parent_entity).toBe('artist1')
@@ -434,7 +473,10 @@ describe('FunFacts queries', () => {
 
             it('includes Sunday and Monday before 4am only', async () => {
                 await createTestTable(conn, testData)
-                const rows = await testQuery(conn, getFact('cozy_album').sql)
+                const rows = await testQuery<FunFactData>(
+                    conn,
+                    getFact('cozy_album').sql
+                )
                 expect(rows.length).toBe(1)
                 expect(rows[0].entity).toBe('album1')
             })
@@ -464,7 +506,10 @@ describe('FunFacts queries', () => {
 
             it('ignores listens older than one year', async () => {
                 await createTestTable(conn, testData)
-                const rows = await testQuery(conn, getFact('cozy_album').sql)
+                const rows = await testQuery<FunFactData>(
+                    conn,
+                    getFact('cozy_album').sql
+                )
                 expect(rows.length).toBe(1)
                 expect(rows[0].entity).toBe('album2')
             })
@@ -493,7 +538,10 @@ describe('FunFacts queries', () => {
 
             it('requires at least 7 distinct tracks', async () => {
                 await createTestTable(conn, testData)
-                const rows = await testQuery(conn, getFact('cozy_album').sql)
+                const rows = await testQuery<FunFactData>(
+                    conn,
+                    getFact('cozy_album').sql
+                )
                 expect(rows.length).toBe(1)
                 expect(rows[0].entity).toBe('album2')
             })
@@ -509,7 +557,10 @@ describe('FunFacts queries', () => {
 
             it('returns empty result if no album satisfies the rules', async () => {
                 await createTestTable(conn, testData)
-                const rows = await testQuery(conn, getFact('cozy_album').sql)
+                const rows = await testQuery<FunFactData>(
+                    conn,
+                    getFact('cozy_album').sql
+                )
                 expect(rows.length).toBe(0)
             })
         })

--- a/app/src/components/Charts/SimpleCharts/HourlyStreams/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/HourlyStreams/query.test.ts
@@ -32,19 +32,19 @@ describe('HourlyStreams Query', () => {
     })
 
     it('always returns exactly 24 rows', async () => {
-        const rows = (await testQuery(
+        const rows = await testQuery<HourlyStreamsQueryResult>(
             conn,
             buildHourlyStreamsQuery(2025)
-        )) as unknown as HourlyStreamsQueryResult[]
+        )
 
         expect(rows.length).toBe(24)
     })
 
     it('returns correct stream count for active hours', async () => {
-        const rows = (await testQuery(
+        const rows = await testQuery<HourlyStreamsQueryResult>(
             conn,
             buildHourlyStreamsQuery(2025)
-        )) as unknown as HourlyStreamsQueryResult[]
+        )
 
         const hour8 = rows.find((r) => r.play_hour === 8)
         const hour14 = rows.find((r) => r.play_hour === 14)
@@ -54,10 +54,10 @@ describe('HourlyStreams Query', () => {
     })
 
     it('returns zero count_streams for hours with no activity', async () => {
-        const rows = (await testQuery(
+        const rows = await testQuery<HourlyStreamsQueryResult>(
             conn,
             buildHourlyStreamsQuery(2025)
-        )) as unknown as HourlyStreamsQueryResult[]
+        )
 
         const hour0 = rows.find((r) => r.play_hour === 0)
         expect(hour0?.count_streams).toBe(0)
@@ -65,14 +65,14 @@ describe('HourlyStreams Query', () => {
     })
 
     it('filters by year correctly', async () => {
-        const rows2025 = (await testQuery(
+        const rows2025 = await testQuery<HourlyStreamsQueryResult>(
             conn,
             buildHourlyStreamsQuery(2025)
-        )) as unknown as HourlyStreamsQueryResult[]
-        const rows2024 = (await testQuery(
+        )
+        const rows2024 = await testQuery<HourlyStreamsQueryResult>(
             conn,
             buildHourlyStreamsQuery(2024)
-        )) as unknown as HourlyStreamsQueryResult[]
+        )
 
         const total2025 = rows2025.reduce((s, r) => s + r.count_streams, 0)
         const total2024 = rows2024.reduce((s, r) => s + r.count_streams, 0)
@@ -82,10 +82,10 @@ describe('HourlyStreams Query', () => {
     })
 
     it('includes all years when year is undefined', async () => {
-        const rows = (await testQuery(
+        const rows = await testQuery<HourlyStreamsQueryResult>(
             conn,
             buildHourlyStreamsQuery(undefined)
-        )) as unknown as HourlyStreamsQueryResult[]
+        )
 
         const total = rows.reduce((s, r) => s + r.count_streams, 0)
         expect(total).toBe(4)

--- a/app/src/components/Charts/SimpleCharts/ListeningRhythm/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/ListeningRhythm/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { queryListeningRhythm } from './query'
+import { type ListeningRhythmResult, queryListeningRhythm } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -36,7 +36,10 @@ describe('ListeningRhythm Query', () => {
     })
 
     it('should return rhythm metrics', async () => {
-        const rows = await testQuery(conn, queryListeningRhythm(2024))
+        const rows = await testQuery<ListeningRhythmResult>(
+            conn,
+            queryListeningRhythm(2024)
+        )
 
         expect(rows.length).toBe(1)
         const row = rows[0]
@@ -49,7 +52,10 @@ describe('ListeningRhythm Query', () => {
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = await testQuery(conn, queryListeningRhythm(undefined))
+        const rows = await testQuery<ListeningRhythmResult>(
+            conn,
+            queryListeningRhythm(undefined)
+        )
         // 2025-01-01 23:00:00 adds 1 to night, total becomes 8
         expect(rows.length).toBe(1)
         expect(rows[0].total).toBe(8)

--- a/app/src/components/Charts/SimpleCharts/NewVsOld/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { queryNewVsOld } from './query'
+import { type NewVsOldResult, queryNewVsOld } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -34,7 +34,7 @@ describe('NewVsOld Query', () => {
     })
 
     it('should return new vs old metrics', async () => {
-        const rows = await testQuery(conn, queryNewVsOld(2025))
+        const rows = await testQuery<NewVsOldResult>(conn, queryNewVsOld(2025))
 
         expect(rows.length).toBe(1)
         const row = rows[0]
@@ -46,7 +46,10 @@ describe('NewVsOld Query', () => {
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = await testQuery(conn, queryNewVsOld(undefined))
+        const rows = await testQuery<NewVsOldResult>(
+            conn,
+            queryNewVsOld(undefined)
+        )
         // All years included; "new" = discovered in the latest year (2026)
         expect(rows.length).toBe(1)
         expect(rows[0].total).toBe(5)

--- a/app/src/components/Charts/SimpleCharts/PrincipalPlatform/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/PrincipalPlatform/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { queryPrincipalPlatform } from './query'
+import { type PlatformResult, queryPrincipalPlatform } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -37,7 +37,10 @@ describe('PrincipalPlatform Query', () => {
     })
 
     it('should return platform metrics', async () => {
-        const rows = await testQuery(conn, queryPrincipalPlatform(testYear))
+        const rows = await testQuery<PlatformResult>(
+            conn,
+            queryPrincipalPlatform(testYear)
+        )
 
         expect(rows).toEqual([
             { pct: 20, platform: 'iOS', stream_count: 1 },
@@ -50,7 +53,10 @@ describe('PrincipalPlatform Query', () => {
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = await testQuery(conn, queryPrincipalPlatform(undefined))
+        const rows = await testQuery<PlatformResult>(
+            conn,
+            queryPrincipalPlatform(undefined)
+        )
         // anotherYear android stream is now included (total = 6)
         const android = rows.find((r) => r.platform === 'Android OS')
         expect(android?.stream_count).toBe(2)

--- a/app/src/components/Charts/SimpleCharts/Regularity/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/Regularity/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, it, expect } from 'vitest'
-import { queryRegularity } from './query'
+import { type RegularityResult, queryRegularity } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -28,7 +28,10 @@ describe('Regularity Query', () => {
         ]
         await createTestTable(conn, testData)
 
-        const rows = await testQuery(conn, queryRegularity(2024))
+        const rows = await testQuery<RegularityResult>(
+            conn,
+            queryRegularity(2024)
+        )
 
         expect(rows.length).toBe(1)
         const row = rows[0]
@@ -46,7 +49,10 @@ describe('Regularity Query', () => {
         ]
         await createTestTable(conn, testData)
 
-        const rows = await testQuery(conn, queryRegularity(2024))
+        const rows = await testQuery<RegularityResult>(
+            conn,
+            queryRegularity(2024)
+        )
 
         expect(rows.length).toBe(1)
         const row = rows[0]
@@ -65,7 +71,10 @@ describe('Regularity Query', () => {
         ]
         await createTestTable(conn, testData)
 
-        const rows = await testQuery(conn, queryRegularity(2024))
+        const rows = await testQuery<RegularityResult>(
+            conn,
+            queryRegularity(2024)
+        )
 
         expect(rows.length).toBe(1)
         const row = rows[0]
@@ -83,7 +92,10 @@ describe('Regularity Query', () => {
         ]
         await createTestTable(conn, testData)
 
-        const rows = await testQuery(conn, queryRegularity(2024))
+        const rows = await testQuery<RegularityResult>(
+            conn,
+            queryRegularity(2024)
+        )
 
         expect(rows.length).toBe(1)
         const row = rows[0]
@@ -102,7 +114,10 @@ describe('Regularity Query', () => {
         ]
         await createTestTable(conn, testData)
 
-        const rows = await testQuery(conn, queryRegularity(2024))
+        const rows = await testQuery<RegularityResult>(
+            conn,
+            queryRegularity(2024)
+        )
 
         expect(rows.length).toBe(1)
         const row = rows[0]
@@ -120,7 +135,10 @@ describe('Regularity Query', () => {
         ]
         await createTestTable(conn, testData)
 
-        const rows = await testQuery(conn, queryRegularity(undefined))
+        const rows = await testQuery<RegularityResult>(
+            conn,
+            queryRegularity(undefined)
+        )
 
         expect(rows.length).toBe(1)
         const row = rows[0]

--- a/app/src/components/Charts/SimpleCharts/RepeatBehavior/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/RepeatBehavior/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { queryRepeatBehavior } from './query'
+import { type RepeatResult, queryRepeatBehavior } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -103,7 +103,10 @@ describe('RepeatBehavior Query', () => {
     })
 
     it('should return repeat behavior metrics', async () => {
-        const rows = await testQuery(conn, queryRepeatBehavior(2024))
+        const rows = await testQuery<RepeatResult>(
+            conn,
+            queryRepeatBehavior(2024)
+        )
 
         expect(rows.length).toBe(1)
         const row = rows[0]
@@ -117,7 +120,10 @@ describe('RepeatBehavior Query', () => {
     })
 
     it('should return empty metrics', async () => {
-        const rows = await testQuery(conn, queryRepeatBehavior(2025))
+        const rows = await testQuery<RepeatResult>(
+            conn,
+            queryRepeatBehavior(2025)
+        )
 
         expect(rows.length).toBe(1)
         const row = rows[0]
@@ -129,7 +135,10 @@ describe('RepeatBehavior Query', () => {
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = await testQuery(conn, queryRepeatBehavior(undefined))
+        const rows = await testQuery<RepeatResult>(
+            conn,
+            queryRepeatBehavior(undefined)
+        )
         // 2018 unselected_year_track (2 consecutive) is now included
         expect(rows.length).toBe(1)
         expect(rows[0].total_repeat_sequences).toBeGreaterThan(0)

--- a/app/src/components/Charts/SimpleCharts/SeasonalPatterns/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/SeasonalPatterns/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { querySeasonalPatterns } from './query'
+import { type SeasonalResult, querySeasonalPatterns } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -35,7 +35,10 @@ describe('SeasonalPatterns Query', () => {
     })
 
     it('should return seasonal metrics', async () => {
-        const rows = await testQuery(conn, querySeasonalPatterns(2022))
+        const rows = await testQuery<SeasonalResult>(
+            conn,
+            querySeasonalPatterns(2022)
+        )
 
         expect(rows.length).toBe(1)
         const row = rows[0]
@@ -48,7 +51,10 @@ describe('SeasonalPatterns Query', () => {
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = await testQuery(conn, querySeasonalPatterns(undefined))
+        const rows = await testQuery<SeasonalResult>(
+            conn,
+            querySeasonalPatterns(undefined)
+        )
         // 2023-08-01 (summer) is also included, total becomes 7
         expect(rows.length).toBe(1)
         expect(rows[0].total).toBe(7)

--- a/app/src/components/Charts/SimpleCharts/SkipRate/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/SkipRate/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { querySkipRate } from './query'
+import { type SkipRateResult, querySkipRate } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -36,7 +36,10 @@ describe('SkipRate Query', () => {
     })
 
     it('should return skip rate metrics', async () => {
-        const rows = await testQuery(conn, querySkipRate(testYear))
+        const rows = await testQuery<SkipRateResult>(
+            conn,
+            querySkipRate(testYear)
+        )
 
         expect(rows.length).toBe(1)
         const row = rows[0]
@@ -46,7 +49,10 @@ describe('SkipRate Query', () => {
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = await testQuery(conn, querySkipRate(undefined))
+        const rows = await testQuery<SkipRateResult>(
+            conn,
+            querySkipRate(undefined)
+        )
         // anotherYear trackdone stream is now included
         expect(rows.length).toBe(1)
         expect(rows[0].complete_listens).toBe(4)

--- a/app/src/components/Charts/SimpleCharts/TopAlbums/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/TopAlbums/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { queryTopAlbums } from './query'
+import { type TopAlbumsResult, queryTopAlbums } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -78,14 +78,20 @@ describe('TopAlbums Query', () => {
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = await testQuery(conn, queryTopAlbums(undefined))
+        const rows = await testQuery<TopAlbumsResult>(
+            conn,
+            queryTopAlbums(undefined)
+        )
         // album7 has 5 streams in anotherDate, making it visible across all years
         const albumNames = rows.map((r) => r.album_name)
         expect(albumNames).toContain('album7')
     })
 
     it('should return top albums ordered by stream count desc', async () => {
-        const rows = await testQuery(conn, queryTopAlbums(testYear))
+        const rows = await testQuery<TopAlbumsResult>(
+            conn,
+            queryTopAlbums(testYear)
+        )
         expect(rows).toHaveLength(5)
         expect(rows).toEqual([
             {

--- a/app/src/components/Charts/SimpleCharts/TopArtists/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/TopArtists/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { queryTopArtists } from './query'
+import { type TopArtistsResult, queryTopArtists } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -75,7 +75,10 @@ describe('TopArtists Query', () => {
     })
 
     it('should return top artists ordered by stream count desc', async () => {
-        const rows = await testQuery(conn, queryTopArtists(testYear))
+        const rows = await testQuery<TopArtistsResult>(
+            conn,
+            queryTopArtists(testYear)
+        )
         expect(rows).toHaveLength(5)
         expect(rows).toEqual([
             { artist_name: 'artist1', count_streams: 12, ms_played: 12 },
@@ -87,7 +90,10 @@ describe('TopArtists Query', () => {
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = await testQuery(conn, queryTopArtists(undefined))
+        const rows = await testQuery<TopArtistsResult>(
+            conn,
+            queryTopArtists(undefined)
+        )
         // artist7 has 5 streams in anotherDate, making it visible across all years
         expect(rows).toHaveLength(5)
         const artistNames = rows.map((r) => r.artist_name)

--- a/app/src/components/Charts/SimpleCharts/TopTracks/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/TopTracks/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { queryTopTracks } from './query'
+import { type TopTracksResult, queryTopTracks } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -56,7 +56,10 @@ describe('TopTracks Query', () => {
     })
 
     it('should return top tracks ordered by stream count desc', async () => {
-        const rows = await testQuery(conn, queryTopTracks(testYear))
+        const rows = await testQuery<TopTracksResult>(
+            conn,
+            queryTopTracks(testYear)
+        )
         expect(rows).toHaveLength(5)
         expect(rows).toEqual([
             {
@@ -93,7 +96,10 @@ describe('TopTracks Query', () => {
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = await testQuery(conn, queryTopTracks(undefined))
+        const rows = await testQuery<TopTracksResult>(
+            conn,
+            queryTopTracks(undefined)
+        )
         // track4 has 6 in testYear + 10 in anotherDate = 16 total, ranking it first
         expect(rows).toHaveLength(5)
         expect(rows[0]).toMatchObject({

--- a/app/src/components/Charts/SimpleCharts/UnbeatableStreak/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/UnbeatableStreak/query.test.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { buildUnbeatableStreakQuery } from './query'
+import {
+    type UnbeatableStreakResult,
+    buildUnbeatableStreakQuery,
+} from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -40,7 +43,10 @@ describe('UnbeatableStreak Query', () => {
     })
 
     it('should return the longest streak for a given year', async () => {
-        const rows = await testQuery(conn, buildUnbeatableStreakQuery(testYear))
+        const rows = await testQuery<UnbeatableStreakResult>(
+            conn,
+            buildUnbeatableStreakQuery(testYear)
+        )
         expect(rows.length).toBe(1)
         expect(rows[0].streak_days).toBe(3)
         expect(rows[0].start_date).toBe(`${testYear}-01-01`)
@@ -48,7 +54,7 @@ describe('UnbeatableStreak Query', () => {
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = await testQuery(
+        const rows = await testQuery<UnbeatableStreakResult>(
             conn,
             buildUnbeatableStreakQuery(undefined)
         )
@@ -58,7 +64,10 @@ describe('UnbeatableStreak Query', () => {
 
     it('should return empty when no data', async () => {
         await createTestTable(conn, [])
-        const rows = await testQuery(conn, buildUnbeatableStreakQuery(testYear))
+        const rows = await testQuery<UnbeatableStreakResult>(
+            conn,
+            buildUnbeatableStreakQuery(testYear)
+        )
         expect(rows.length).toBe(0)
     })
 })

--- a/app/src/components/Charts/SimpleCharts/VarietyDay/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/VarietyDay/query.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
-import { buildVarietyDayQuery } from './query'
+import { type VarietyDayResult, buildVarietyDayQuery } from './query'
 import {
     createTestConnection,
     closeTestConnection,
@@ -40,14 +40,20 @@ describe('VarietyDay Query', () => {
     })
 
     it('should return the most diverse day for a given year', async () => {
-        const rows = await testQuery(conn, buildVarietyDayQuery(testYear))
+        const rows = await testQuery<VarietyDayResult>(
+            conn,
+            buildVarietyDayQuery(testYear)
+        )
         expect(rows.length).toBe(1)
         expect(rows[0].stream_date).toBe(`${testYear}-01-01`)
         expect(rows[0].artist_count).toBe(3)
     })
 
     it('should include all years when year is undefined', async () => {
-        const rows = await testQuery(conn, buildVarietyDayQuery(undefined))
+        const rows = await testQuery<VarietyDayResult>(
+            conn,
+            buildVarietyDayQuery(undefined)
+        )
         expect(rows.length).toBe(1)
         expect(rows[0].stream_date).toBe(`${anotherYear}-06-01`)
         expect(rows[0].artist_count).toBe(5)
@@ -55,7 +61,10 @@ describe('VarietyDay Query', () => {
 
     it('should return empty when no data', async () => {
         await createTestTable(conn, [])
-        const rows = await testQuery(conn, buildVarietyDayQuery(testYear))
+        const rows = await testQuery<VarietyDayResult>(
+            conn,
+            buildVarietyDayQuery(testYear)
+        )
         expect(rows.length).toBe(0)
     })
 })

--- a/app/src/components/Charts/SimpleCharts/__tests__/test-utils.ts
+++ b/app/src/components/Charts/SimpleCharts/__tests__/test-utils.ts
@@ -66,12 +66,12 @@ export async function createTestTable(
     appender.closeSync()
 }
 
-export async function testQuery(
+export async function testQuery<T = Record<string, Json>>(
     conn: DuckDBConnection,
     sql: string
-): Promise<Record<string, Json>[]> {
+): Promise<T[]> {
     const result = await conn.runAndReadAll(sql)
-    return result.getRowObjectsJson()
+    return result.getRowObjectsJson() as unknown as T[]
 }
 
 export function closeTestConnection(conn: DuckDBConnection): void {

--- a/app/src/components/Charts/SimpleCharts/__tests__/test-utils.ts
+++ b/app/src/components/Charts/SimpleCharts/__tests__/test-utils.ts
@@ -1,4 +1,4 @@
-import { DuckDBConnection, type Json } from '@duckdb/node-api'
+import { DuckDBConnection } from '@duckdb/node-api'
 import { TABLE } from '../../../../db/queries/constants'
 
 export type TestStreamEntry = {
@@ -66,7 +66,7 @@ export async function createTestTable(
     appender.closeSync()
 }
 
-export async function testQuery<T = Record<string, Json>>(
+export async function testQuery<T>(
     conn: DuckDBConnection,
     sql: string
 ): Promise<T[]> {


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Query test helpers were untyped, making it easy to write call sites that passed wrong shapes or missed required fields without any compile-time feedback.

## 🎹 Proposal

Make `testQuery` generic so callers declare the expected row type. No default type param for testQuery to enforce typed call sites, so type errors at call sites are caught by the compiler rather than at runtime.

## 🎶 Comments

Depends on #467.

## 🎤 Test

Run all SimpleCharts query tests and confirm they pass with no type errors:

```bash
moon run app:typecheck
moon run app:test -- src/components/Charts/SimpleCharts
```