### PR TITLE
refactor(synthetic-datasets): clean up unused code

### DIFF
--- a/synthetic-datasets/synthetic_datasets/factories/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/factories/spotify.py
@@ -195,8 +195,3 @@ class SpotifyFactory:
             all_streamings.extend(year_records)
 
         return all_streamings
-
-
-def rotate(elements, step):
-    step = step % len(elements)
-    return elements[step:] + elements[:step]

--- a/synthetic-datasets/tests/factories/test_spotify.py
+++ b/synthetic-datasets/tests/factories/test_spotify.py
@@ -1,6 +1,6 @@
 import pytest
 
-from synthetic_datasets.factories.spotify import SpotifyFactory, rotate
+from synthetic_datasets.factories.spotify import SpotifyFactory
 from synthetic_datasets.models.spotify import Streaming
 
 
@@ -14,24 +14,3 @@ def test_create_streaming_history(num_records, default_generation_config):
     assert len(streamings) == num_records
     for streaming in streamings:
         assert isinstance(streaming, Streaming)
-
-
-@pytest.mark.parametrize(
-    "input, step, expected",
-    [
-        ([1, 2, 3], -2, [2, 3, 1]),
-        ([1, 2, 3], -1, [3, 1, 2]),
-        ([1, 2, 3], 0, [1, 2, 3]),
-        ([1, 2, 3], 1, [2, 3, 1]),
-        ([1, 2, 3], 2, [3, 1, 2]),
-        ([1, 2, 3], 3, [1, 2, 3]),
-        ([1, 2, 3], 4, [2, 3, 1]),
-        ([1, 2, 3], 5, [3, 1, 2]),
-        ([1, 2, 3, 4, 5], 6, [2, 3, 4, 5, 1]),
-    ],
-)
-def test_rotate(input, step, expected):
-    # when
-    result = rotate(input, step)
-    # then
-    assert result == expected


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The Spotify synthetic dataset generator had a dead utility function with associated tests.

## 🎹 Proposal

Remove the unused `rotate()` function and its tests from the Spotify factory module.

## 🎶 Comments

<!-- Additional information, tips or problems encountered. -->

## 🎤 Test

1. Run `moon run synthetic-datasets:test` — all tests pass.