### PR TITLE
refactor(synthetic-datasets): extract shared logic into BaseFactory

### DIFF
--- a/synthetic-datasets/synthetic_datasets/factories/apple_music.py
+++ b/synthetic-datasets/synthetic_datasets/factories/apple_music.py
@@ -1,14 +1,10 @@
-import calendar
 import random
 from dataclasses import dataclass
-from datetime import datetime, timedelta
-
-import numpy as np
-from faker import Faker
-from tqdm import tqdm
+from datetime import datetime
 
 from ..config import GenerationConfig
 from ..models.apple_music import AppleMusicRecord
+from .base import BaseFactory
 
 
 @dataclass
@@ -20,98 +16,21 @@ class AppleMusicTrack:
 CLIENT_PLATFORMS = ["FUSE", "TILT"]
 
 
-class AppleMusicFactory:
-    month_weights = [0.08, 0.07, 0.07, 0.06, 0.07, 0.08, 0.08, 0.08, 0.1, 0.10, 0.11, 0.1]
-    hour_weights = [
-        0.01, 0.01, 0.01, 0.01, 0.02, 0.04, 0.07, 0.09, 0.08, 0.06, 0.04, 0.04,
-        0.05, 0.03, 0.04, 0.05, 0.05, 0.06, 0.07, 0.06, 0.05, 0.03, 0.02, 0.01,
-    ]  # fmt: skip
+class AppleMusicFactory(BaseFactory[AppleMusicRecord]):
+    def __init__(self, num_records: int, config: GenerationConfig) -> None:
+        super().__init__(num_records, config)
 
-    def __init__(self, num_records: int, config: GenerationConfig):
-        self.config = config
-
-        random.seed(self.config.seed)
-        np.random.seed(self.config.seed)
-        Faker.seed(self.config.seed)
-
-        self.faker = Faker()
-        self.now = self.config.reference_date
-        self.start_year = 2020
-        self.skip_chance_trend = np.linspace(0.15, 0.30, self.now.year - self.start_year + 1)
-
+    def _generate_catalog(self, num_records: int) -> list[AppleMusicTrack]:
         num_tracks = max(int(num_records * 0.5), 1)
-
-        print("🎵 Generating music catalog...")
         print(f" - records: {num_records}")
         print(f" - tracks : {num_tracks}")
-        self.tracks = self._generate_catalog(num_tracks)
-
-        print("📈 Generating evolving listening tastes...")
-        self.weighted_tracks = self._generate_weighted_tracks_by_year()
-        for year, weighted_records in self.weighted_tracks.items():
-            print(f" - {year}: {len(weighted_records)} records")
-
-        print("📅 Generating distribution over year...")
-        self.records_per_year = self._generate_distribution_over_year(num_records)
-        for year, num_records_for_year in self.records_per_year.items():
-            print(f" - {year}: {num_records_for_year} records")
-
-    def _generate_catalog(self, num_tracks: int) -> list[AppleMusicTrack]:
         return [
             AppleMusicTrack(
                 song_name=" ".join(self.faker.words(4)).title(),
-                duration_ms=random.randint(120_000, 360_000),
+                duration_ms=random.randint(self.TRACK_DURATION_MIN_MS, self.TRACK_DURATION_MAX_MS),
             )
             for _ in range(num_tracks)
         ]
-
-    def _generate_weighted_tracks_by_year(self) -> dict[int, list[AppleMusicTrack]]:
-        weighted_tracks_by_year = {}
-        for year in range(self.start_year, self.now.year + 1):
-            popularity = np.random.zipf(a=1.8, size=len(self.tracks))
-            np.random.shuffle(popularity)
-
-            weighted = []
-            for track, weight in zip(self.tracks, popularity):
-                repeats = min(int(weight / 10), 100)
-                if repeats > 0:
-                    weighted.extend([track] * repeats)
-                else:
-                    weighted.extend([track])
-
-            weighted_tracks_by_year[year] = weighted
-
-        return weighted_tracks_by_year
-
-    def _get_random_datetime_for_year(self, year: int) -> datetime:
-        if year < self.now.year:
-            months = np.arange(1, 13)
-            month_weights = np.array(self.month_weights)
-        else:
-            months = np.arange(1, self.now.month + 1)
-            month_weights = np.array(self.month_weights[: self.now.month])
-
-        month_weights = month_weights / month_weights.sum()
-        month = np.random.choice(months, p=month_weights)
-
-        max_day = calendar.monthrange(year, month)[1]
-        day = random.randint(1, max_day)
-
-        hour_weights = np.array(self.hour_weights)
-        hour_weights = hour_weights / hour_weights.sum()
-        hour = np.random.choice(range(24), p=hour_weights)
-
-        minute = random.randint(0, 59)
-        second = random.randint(0, 59)
-
-        candidate = datetime(year, month, day, hour, minute, second)
-
-        if candidate > self.now:
-            start = datetime(year, 1, 1)
-            delta_seconds = int((self.now - start).total_seconds())
-            return start + timedelta(seconds=random.randint(0, delta_seconds))
-
-        return candidate
 
     def _create_one_record(self, ts: datetime) -> AppleMusicRecord:
         year_index = ts.year - self.start_year
@@ -129,30 +48,3 @@ class AppleMusicFactory:
             play_duration_ms=play_duration_ms,
             client_platform=client_platform,
         )
-
-    def _generate_distribution_over_year(self, n_records: int) -> dict[int, int]:
-        years = range(self.start_year, self.now.year + 1)
-
-        year_weights = [random.uniform(0.5, 1.5) for _ in years]
-        base_records_per_year = n_records / sum(year_weights)
-        records_per_year = {
-            year: int(base_records_per_year * year_weight) for year, year_weight in zip(years, year_weights)
-        }
-        records_per_year[self.now.year] += n_records - sum(records_per_year.values())
-        return records_per_year
-
-    def create_streaming_history(self) -> list[AppleMusicRecord]:
-        all_records = []
-
-        for year, num_records_for_year in self.records_per_year.items():
-            year_records = [
-                self._create_one_record(self._get_random_datetime_for_year(year))
-                for _ in tqdm(
-                    range(num_records_for_year),
-                    desc=f"💿 Generating streamings for {year}",
-                    leave=True,
-                )
-            ]
-            all_records.extend(year_records)
-
-        return all_records

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -1,0 +1,129 @@
+import calendar
+import random
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta
+from typing import Generic, TypeVar
+
+import numpy as np
+from faker import Faker
+from tqdm import tqdm
+
+from ..config import GenerationConfig
+
+RecordT = TypeVar("RecordT")
+
+
+class BaseFactory(ABC, Generic[RecordT]):
+    month_weights = [0.08, 0.07, 0.07, 0.06, 0.07, 0.08, 0.08, 0.08, 0.1, 0.10, 0.11, 0.1]
+    hour_weights = [
+        0.01, 0.01, 0.01, 0.01, 0.02, 0.04, 0.07, 0.09, 0.08, 0.06, 0.04, 0.04,
+        0.05, 0.03, 0.04, 0.05, 0.05, 0.06, 0.07, 0.06, 0.05, 0.03, 0.02, 0.01,
+    ]  # fmt: skip
+
+    ZIPF_A: float = 1.8
+    SKIP_CHANCE_MIN: float = 0.15
+    SKIP_CHANCE_MAX: float = 0.30
+    START_YEAR: int = 2020
+    TRACK_DURATION_MIN_MS: int = 120_000
+    TRACK_DURATION_MAX_MS: int = 360_000
+
+    def __init__(self, num_records: int, config: GenerationConfig) -> None:
+        self.config = config
+        random.seed(config.seed)
+        np.random.seed(config.seed)
+        Faker.seed(config.seed)
+        self.faker = Faker()
+        self.now = config.reference_date
+        self.start_year = self.START_YEAR
+        self.skip_chance_trend = np.linspace(
+            self.SKIP_CHANCE_MIN,
+            self.SKIP_CHANCE_MAX,
+            self.now.year - self.start_year + 1,
+        )
+        print("🎵 Generating music catalog...")
+        self.tracks = self._generate_catalog(num_records)
+        print("📈 Generating evolving listening tastes...")
+        self.weighted_tracks = self._generate_weighted_tracks_by_year()
+        for year, weighted_records in self.weighted_tracks.items():
+            print(f" - {year}: {len(weighted_records)} records")
+        print("📅 Generating distribution over year...")
+        self.records_per_year = self._generate_distribution_over_year(num_records)
+        for year, n in self.records_per_year.items():
+            print(f" - {year}: {n} records")
+
+    @abstractmethod
+    def _generate_catalog(self, num_records: int) -> list: ...
+
+    @abstractmethod
+    def _create_one_record(self, ts: datetime) -> RecordT: ...
+
+    def _get_random_datetime_for_year(self, year: int) -> datetime:
+        if year < self.now.year:
+            months = np.arange(1, 13)
+            month_weights = np.array(self.month_weights)
+        else:
+            months = np.arange(1, self.now.month + 1)
+            month_weights = np.array(self.month_weights[: self.now.month])
+
+        month_weights = month_weights / month_weights.sum()
+        month = np.random.choice(months, p=month_weights)
+
+        max_day = calendar.monthrange(year, month)[1]
+        day = random.randint(1, max_day)
+
+        hour_weights = np.array(self.hour_weights)
+        hour_weights = hour_weights / hour_weights.sum()
+        hour = np.random.choice(range(24), p=hour_weights)
+
+        minute = random.randint(0, 59)
+        second = random.randint(0, 59)
+
+        candidate = datetime(year, month, day, hour, minute, second)
+
+        if candidate > self.now:
+            start = datetime(year, 1, 1)
+            delta_seconds = int((self.now - start).total_seconds())
+            return start + timedelta(seconds=random.randint(0, delta_seconds))
+
+        return candidate
+
+    def _generate_distribution_over_year(self, n_records: int) -> dict[int, int]:
+        years = range(self.start_year, self.now.year + 1)
+
+        year_weights = [random.uniform(0.5, 1.5) for _ in years]
+        base_records_per_year = n_records / sum(year_weights)
+        records_per_year = {
+            year: int(base_records_per_year * year_weight) for year, year_weight in zip(years, year_weights)
+        }
+        records_per_year[self.now.year] += n_records - sum(records_per_year.values())
+        return records_per_year
+
+    def _generate_weighted_tracks_by_year(self) -> dict[int, list]:
+        weighted_tracks_by_year = {}
+        for year in range(self.start_year, self.now.year + 1):
+            popularity = np.random.zipf(a=self.ZIPF_A, size=len(self.tracks))
+            np.random.shuffle(popularity)
+
+            weighted = []
+            for track, weight in zip(self.tracks, popularity):
+                repeats = min(int(weight / 10), 100)
+                if repeats > 0:
+                    weighted.extend([track] * repeats)
+                else:
+                    weighted.extend([track])
+
+            weighted_tracks_by_year[year] = weighted
+
+        return weighted_tracks_by_year
+
+    def create_streaming_history(self) -> list[RecordT]:
+        all_records: list[RecordT] = []
+
+        for year, num_records_for_year in self.records_per_year.items():
+            year_records = [
+                self._create_one_record(self._get_random_datetime_for_year(year))
+                for _ in tqdm(range(num_records_for_year), desc=f"💿 Generating streamings for {year}", leave=True)
+            ]
+            all_records.extend(year_records)
+
+        return all_records

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -2,7 +2,7 @@ import calendar
 import random
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from typing import Generic, TypeVar
+from typing import ClassVar, Generic, TypeVar
 
 import numpy as np
 from faker import Faker
@@ -14,18 +14,18 @@ RecordT = TypeVar("RecordT")
 
 
 class BaseFactory(ABC, Generic[RecordT]):
-    month_weights = [0.08, 0.07, 0.07, 0.06, 0.07, 0.08, 0.08, 0.08, 0.1, 0.10, 0.11, 0.1]
-    hour_weights = [
+    month_weights: ClassVar[list[float]] = [0.08, 0.07, 0.07, 0.06, 0.07, 0.08, 0.08, 0.08, 0.1, 0.10, 0.11, 0.1]
+    hour_weights: ClassVar[list[float]] = [
         0.01, 0.01, 0.01, 0.01, 0.02, 0.04, 0.07, 0.09, 0.08, 0.06, 0.04, 0.04,
         0.05, 0.03, 0.04, 0.05, 0.05, 0.06, 0.07, 0.06, 0.05, 0.03, 0.02, 0.01,
     ]  # fmt: skip
 
-    ZIPF_A: float = 1.8
-    SKIP_CHANCE_MIN: float = 0.15
-    SKIP_CHANCE_MAX: float = 0.30
-    START_YEAR: int = 2020
-    TRACK_DURATION_MIN_MS: int = 120_000
-    TRACK_DURATION_MAX_MS: int = 360_000
+    ZIPF_A: ClassVar[float] = 1.8
+    SKIP_CHANCE_MIN: ClassVar[float] = 0.15
+    SKIP_CHANCE_MAX: ClassVar[float] = 0.30
+    START_YEAR: ClassVar[int] = 2020
+    TRACK_DURATION_MIN_MS: ClassVar[int] = 120_000
+    TRACK_DURATION_MAX_MS: ClassVar[int] = 360_000
 
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         self.config = config

--- a/synthetic-datasets/synthetic_datasets/factories/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/factories/deezer.py
@@ -1,16 +1,12 @@
-import calendar
 import random
 import string
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
 from ipaddress import ip_address
-
-import numpy as np
-from faker import Faker
-from tqdm import tqdm
 
 from ..config import GenerationConfig
 from ..models.deezer import DeezerStreaming
+from .base import BaseFactory
 
 
 @dataclass
@@ -22,46 +18,11 @@ class DeezerTrack:
     duration_sec: int
 
 
-class DeezerFactory:
-    month_weights = [0.08, 0.07, 0.07, 0.06, 0.07, 0.08, 0.08, 0.08, 0.1, 0.10, 0.11, 0.1]
-    hour_weights = [
-        0.01, 0.01, 0.01, 0.01, 0.02, 0.04, 0.07, 0.09, 0.08, 0.06, 0.04, 0.04,
-        0.05, 0.03, 0.04, 0.05, 0.05, 0.06, 0.07, 0.06, 0.05, 0.03, 0.02, 0.01,
-    ]  # fmt: skip
+class DeezerFactory(BaseFactory[DeezerStreaming]):
+    def __init__(self, num_records: int, config: GenerationConfig) -> None:
+        super().__init__(num_records, config)
 
-    def __init__(self, num_records: int, config: GenerationConfig):
-        self.config = config
-
-        random.seed(self.config.seed)
-        np.random.seed(self.config.seed)
-        Faker.seed(self.config.seed)
-
-        self.faker = Faker()
-        self.now = self.config.reference_date
-        self.start_year = 2020
-        self.skip_chance_trend = np.linspace(0.15, 0.30, self.now.year - self.start_year + 1)
-
-        num_artists = max(int(num_records * 0.2), 1)
-        num_albums = max(int(num_records * 0.3), 1)
-        num_tracks = max(int(num_records * 0.5), 1)
         num_ip_addresses = 20
-
-        print("🎵 Generating music catalog...")
-        print(f" - records: {num_records}")
-        print(f" - artists: {num_artists}")
-        print(f" - albums : {num_albums}")
-        print(f" - tracks : {num_tracks}")
-        self.tracks = self._generate_catalog(num_artists, num_albums, num_tracks)
-
-        print("📈 Generating evolving listening tastes...")
-        self.weighted_tracks = self._generate_weighted_tracks_by_year()
-        for year, weighted_records in self.weighted_tracks.items():
-            print(f" - {year}: {len(weighted_records)} records")
-
-        print("📅 Generating distribution over year...")
-        self.records_per_year = self._generate_distribution_over_year(num_records)
-        for year, num_records_for_year in self.records_per_year.items():
-            print(f" - {year}: {num_records_for_year} records")
 
         print("💻 Generating platforms...")
         self.platforms = ["web", "ios", "android", "desktop", "tv"]
@@ -77,7 +38,15 @@ class DeezerFactory:
         designation = str(random.randint(0, 99999)).zfill(5)
         return f"{country}{registrant}{year}{designation}"
 
-    def _generate_catalog(self, num_artists: int, num_albums: int, num_tracks: int) -> list[DeezerTrack]:
+    def _generate_catalog(self, num_records: int) -> list[DeezerTrack]:
+        num_artists = max(int(num_records * 0.2), 1)
+        num_albums = max(int(num_records * 0.3), 1)
+        num_tracks = max(int(num_records * 0.5), 1)
+        print(f" - records: {num_records}")
+        print(f" - artists: {num_artists}")
+        print(f" - albums : {num_albums}")
+        print(f" - tracks : {num_tracks}")
+
         artists = [self.faker.name() for _ in range(num_artists)]
         album_names = [" ".join(self.faker.words(3)).title() for _ in range(num_albums)]
         albums = [(name, random.choice(artists)) for name in album_names]
@@ -87,61 +56,13 @@ class DeezerFactory:
                 song_title=" ".join(self.faker.words(4)).title(),
                 artist=random.choice(albums)[1],
                 album_title=random.choice(albums)[0],
-                duration_sec=random.randint(120, 360),
+                duration_sec=random.randint(self.TRACK_DURATION_MIN_MS // 1000, self.TRACK_DURATION_MAX_MS // 1000),
             )
             for _ in range(num_tracks)
         ]
         return tracks
 
-    def _generate_weighted_tracks_by_year(self) -> dict[int, list[DeezerTrack]]:
-        weighted_tracks_by_year = {}
-        for year in range(self.start_year, self.now.year + 1):
-            popularity = np.random.zipf(a=1.8, size=len(self.tracks))
-            np.random.shuffle(popularity)
-
-            weighted = []
-            for track, weight in zip(self.tracks, popularity):
-                repeats = min(int(weight / 10), 100)
-                if repeats > 0:
-                    weighted.extend([track] * repeats)
-                else:
-                    weighted.extend([track])
-
-            weighted_tracks_by_year[year] = weighted
-
-        return weighted_tracks_by_year
-
-    def _get_random_datetime_for_year(self, year: int) -> datetime:
-        if year < self.now.year:
-            months = np.arange(1, 13)
-            month_weights = np.array(self.month_weights)
-        else:
-            months = np.arange(1, self.now.month + 1)
-            month_weights = np.array(self.month_weights[: self.now.month])
-
-        month_weights = month_weights / month_weights.sum()
-        month = np.random.choice(months, p=month_weights)
-
-        max_day = calendar.monthrange(year, month)[1]
-        day = random.randint(1, max_day)
-
-        hour_weights = np.array(self.hour_weights)
-        hour_weights = hour_weights / hour_weights.sum()
-        hour = np.random.choice(range(24), p=hour_weights)
-
-        minute = random.randint(0, 59)
-        second = random.randint(0, 59)
-
-        candidate = datetime(year, month, day, hour, minute, second)
-
-        if candidate > self.now:
-            start = datetime(year, 1, 1)
-            delta_seconds = int((self.now - start).total_seconds())
-            return start + timedelta(seconds=random.randint(0, delta_seconds))
-
-        return candidate
-
-    def _create_one_streaming_record(self, ts: datetime) -> DeezerStreaming:
+    def _create_one_record(self, ts: datetime) -> DeezerStreaming:
         year_index = ts.year - self.start_year
 
         is_skipped = random.random() < self.skip_chance_trend[year_index]
@@ -163,26 +84,3 @@ class DeezerFactory:
             platform_model=platform_model,
             date=ts,
         )
-
-    def _generate_distribution_over_year(self, n_records: int) -> dict[int, int]:
-        years = range(self.start_year, self.now.year + 1)
-
-        year_weights = [random.uniform(0.5, 1.5) for _ in years]
-        base_records_per_year = n_records / sum(year_weights)
-        records_per_year = {
-            year: int(base_records_per_year * year_weight) for year, year_weight in zip(years, year_weights)
-        }
-        records_per_year[self.now.year] += n_records - sum(records_per_year.values())
-        return records_per_year
-
-    def create_streaming_history(self) -> list[DeezerStreaming]:
-        all_streamings = []
-
-        for year, num_records_for_year in self.records_per_year.items():
-            year_records = [
-                self._create_one_streaming_record(self._get_random_datetime_for_year(year))
-                for _ in tqdm(range(num_records_for_year), desc=f"💿 Generating streamings for {year}", leave=True)
-            ]
-            all_streamings.extend(year_records)
-
-        return all_streamings

--- a/synthetic-datasets/synthetic_datasets/factories/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/factories/spotify.py
@@ -1,23 +1,14 @@
-import calendar
 import random
 import string
 from datetime import datetime, timedelta
 from ipaddress import ip_address
 
-import numpy as np
-from faker import Faker
-from tqdm import tqdm
-
 from ..config import GenerationConfig
 from ..models.spotify import Album, Artist, ReasonEndEnum, ReasonStartEnum, Streaming, Track
+from .base import BaseFactory
 
 
-class SpotifyFactory:
-    month_weights = [0.08, 0.07, 0.07, 0.06, 0.07, 0.08, 0.08, 0.08, 0.1, 0.10, 0.11, 0.1]
-    hour_weights = [
-        0.01, 0.01, 0.01, 0.01, 0.02, 0.04, 0.07, 0.09, 0.08, 0.06, 0.04, 0.04,
-        0.05, 0.03, 0.04, 0.05, 0.05, 0.06, 0.07, 0.06, 0.05, 0.03, 0.02, 0.01,
-    ]  # fmt: skip
+class SpotifyFactory(BaseFactory[Streaming]):
     reason_start = [
         ReasonStartEnum.TRACK_DONE,
         ReasonStartEnum.FORWARD_BUTTON,
@@ -25,41 +16,12 @@ class SpotifyFactory:
         ReasonStartEnum.CLICK_ROW,
     ]
 
-    def __init__(self, num_records: int, config: GenerationConfig):
-        self.config = config
+    def __init__(self, num_records: int, config: GenerationConfig) -> None:
+        super().__init__(num_records, config)
 
-        random.seed(self.config.seed)
-        np.random.seed(self.config.seed)
-        Faker.seed(self.config.seed)
-
-        self.faker = Faker()
-        self.now = self.config.reference_date
-        self.start_year = 2020
-        self.skip_chance_trend = np.linspace(0.15, 0.30, self.now.year - self.start_year + 1)
-
-        num_artists = max(int(num_records * 0.2), 1)
-        num_albums = max(int(num_records * 0.3), 1)
-        num_tracks = max(int(num_records * 0.5), 1)
         num_platforms = 5
         num_countries = 5
         num_ip_addresses = 20
-
-        print("🎵 Generating music catalog...")
-        print(f" - records: {num_records}")
-        print(f" - artists: {num_artists}")
-        print(f" - albums : {num_albums}")
-        print(f" - tracks : {num_tracks}")
-        self.tracks = self._generate_catalog(num_artists, num_albums, num_tracks)
-
-        print("📈 Generating evolving listening tastes...")
-        self.weighted_tracks = self._generate_weighted_tracks_by_year()
-        for year, weighted_records in self.weighted_tracks.items():
-            print(f" - {year}: {len(weighted_records)} records")
-
-        print("📅 Generating distribution over year...")
-        self.records_per_year = self._generate_distribution_over_year(num_records)
-        for year, num_records in self.records_per_year.items():
-            print(f" - {year}: {num_records} records")
 
         print("💻 Generating platforms...")
         self.platforms = [
@@ -80,7 +42,15 @@ class SpotifyFactory:
         print("🛜 Generatin IPs...")
         self.ip_addr = [ip_address(self.faker.ipv4()) for _ in range(0, num_ip_addresses)]
 
-    def _generate_catalog(self, num_artists: int, num_albums: int, num_tracks: int) -> list[Track]:
+    def _generate_catalog(self, num_records: int) -> list[Track]:
+        num_artists = max(int(num_records * 0.2), 1)
+        num_albums = max(int(num_records * 0.3), 1)
+        num_tracks = max(int(num_records * 0.5), 1)
+        print(f" - records: {num_records}")
+        print(f" - artists: {num_artists}")
+        print(f" - albums : {num_albums}")
+        print(f" - tracks : {num_tracks}")
+
         track_uri_chars = string.ascii_letters + string.digits
         artists = [Artist(name=self.faker.name()) for _ in range(num_artists)]
         albums = [
@@ -91,61 +61,13 @@ class SpotifyFactory:
                 uri=f"spotify:track:{''.join(random.choices(track_uri_chars, k=22))}",
                 name=" ".join(self.faker.words(4)).title(),
                 album=random.choice(albums),
-                duration_ms=random.randint(120_000, 360_000),
+                duration_ms=random.randint(self.TRACK_DURATION_MIN_MS, self.TRACK_DURATION_MAX_MS),
             )
             for _ in range(num_tracks)
         ]
         return tracks
 
-    def _generate_weighted_tracks_by_year(self) -> dict[int, list]:
-        weighted_tracks_by_year = {}
-        for year in range(self.start_year, self.now.year + 1):
-            popularity = np.random.zipf(a=1.8, size=len(self.tracks))
-            np.random.shuffle(popularity)
-
-            weighted = []
-            for track, weight in zip(self.tracks, popularity):
-                repeats = min(int(weight / 10), 100)
-                if repeats > 0:
-                    weighted.extend([track] * repeats)
-                else:
-                    weighted.extend([track])
-
-            weighted_tracks_by_year[year] = weighted
-
-        return weighted_tracks_by_year
-
-    def _get_random_datetime_for_year(self, year: int) -> datetime:
-        if year < self.now.year:
-            months = np.arange(1, 13)
-            month_weights = np.array(self.month_weights)
-        else:
-            months = np.arange(1, self.now.month + 1)
-            month_weights = np.array(self.month_weights[: self.now.month])
-
-        month_weights = month_weights / month_weights.sum()
-        month = np.random.choice(months, p=month_weights)
-
-        max_day = calendar.monthrange(year, month)[1]
-        day = random.randint(1, max_day)
-
-        hour_weights = np.array(self.hour_weights)
-        hour_weights = hour_weights / hour_weights.sum()
-        hour = np.random.choice(range(24), p=hour_weights)
-
-        minute = random.randint(0, 59)
-        second = random.randint(0, 59)
-
-        candidate = datetime(year, month, day, hour, minute, second)
-
-        if candidate > self.now:
-            start = datetime(year, 1, 1)
-            delta_seconds = int((self.now - start).total_seconds())
-            return start + timedelta(seconds=random.randint(0, delta_seconds))
-
-        return candidate
-
-    def _create_one_streaming_record(self, ts: datetime) -> Streaming:
+    def _create_one_record(self, ts: datetime) -> Streaming:
         year_index = ts.year - self.start_year
 
         is_skipped = random.random() < self.skip_chance_trend[year_index]
@@ -172,26 +94,3 @@ class SpotifyFactory:
             offline_timestamp=int((ts - timedelta(minutes=random.randint(1, 60))).timestamp()) if is_offline else None,
             incognito_mode=bool(random.getrandbits(1)),
         )
-
-    def _generate_distribution_over_year(self, n_records):
-        years = range(self.start_year, self.now.year + 1)
-
-        year_weights = [random.uniform(0.5, 1.5) for _ in years]
-        base_records_per_year = n_records / sum(year_weights)
-        records_per_year = {
-            year: int(base_records_per_year * year_weight) for year, year_weight in zip(years, year_weights)
-        }
-        records_per_year[self.now.year] += n_records - sum(records_per_year.values())
-        return records_per_year
-
-    def create_streaming_history(self) -> list[Streaming]:
-        all_streamings = []
-
-        for year, num_records_for_year in self.records_per_year.items():
-            year_records = [
-                self._create_one_streaming_record(self._get_random_datetime_for_year(year))
-                for _ in tqdm(range(num_records_for_year), desc=f"💿 Generating streamings for {year}", leave=True)
-            ]
-            all_streamings.extend(year_records)
-
-        return all_streamings

--- a/synthetic-datasets/synthetic_datasets/factories/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/factories/spotify.py
@@ -2,6 +2,7 @@ import random
 import string
 from datetime import datetime, timedelta
 from ipaddress import ip_address
+from typing import ClassVar
 
 from ..config import GenerationConfig
 from ..models.spotify import Album, Artist, ReasonEndEnum, ReasonStartEnum, Streaming, Track
@@ -9,7 +10,7 @@ from .base import BaseFactory
 
 
 class SpotifyFactory(BaseFactory[Streaming]):
-    reason_start = [
+    reason_start: ClassVar[list[ReasonStartEnum]] = [
         ReasonStartEnum.TRACK_DONE,
         ReasonStartEnum.FORWARD_BUTTON,
         ReasonStartEnum.BACK_BUTTON,

--- a/synthetic-datasets/tests/factories/test_base_factory.py
+++ b/synthetic-datasets/tests/factories/test_base_factory.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+
+import pytest
+
+from synthetic_datasets.config import GenerationConfig
+from synthetic_datasets.factories.base import BaseFactory
+
+
+class ConcreteFactory(BaseFactory[str]):
+    def _generate_catalog(self, num_records: int) -> list:
+        return []
+
+    def _create_one_record(self, ts: datetime) -> str:
+        return "record"
+
+
+@pytest.fixture
+def config():
+    return GenerationConfig(seed=42, reference_date=datetime(2026, 2, 8))
+
+
+@pytest.fixture
+def factory(config):
+    return ConcreteFactory(num_records=10, config=config)
+
+
+def test_get_random_datetime_for_year_returns_correct_year(factory):
+    for year in range(2020, 2026):
+        dt = factory._get_random_datetime_for_year(year)
+        assert dt.year == year
+
+
+def test_get_random_datetime_for_current_year_never_future(factory):
+    current_year = factory.now.year
+    for _ in range(100):
+        dt = factory._get_random_datetime_for_year(current_year)
+        assert dt <= factory.now
+
+
+def test_generate_distribution_over_year_sums_to_n(factory):
+    for n in [0, 1, 50, 100, 999]:
+        result = factory._generate_distribution_over_year(n)
+        assert sum(result.values()) == n
+
+
+def test_rng_seeding_is_deterministic(config):
+    f1 = ConcreteFactory(num_records=50, config=config)
+    f2 = ConcreteFactory(num_records=50, config=config)
+    assert f1.records_per_year == f2.records_per_year


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The three factory classes (Spotify, Apple Music, Deezer) duplicated the same generation logic: seeding, catalog weighting, time distribution, and the main generation loop. Adding a fourth provider meant copying that code again.

## 🎹 Proposal

A new abstract `BaseFactory[RecordT]` class holds all shared logic: RNG seeding, constants (ZIPF_A, skip chance bounds, duration bounds, start year), and the methods for generating weighted track distributions, time distributions, and the streaming history loop. Each provider subclass only implements its catalog generation and record construction. Magic numbers are replaced by named class constants on `BaseFactory`.

## 🎶 Comments

`_create_one_streaming_record` was renamed to `_create_one_record` in Spotify and Deezer to match the abstract method name and Apple Music's existing convention.

## 🎤 Test

```bash
moon run synthetic-datasets:test
moon run synthetic-datasets:lint
moon run synthetic-datasets:typecheck
```