### PR TITLE
ci(synthetic-datasets): verify generate-e2e output hash

### DIFF
--- a/.github/workflows/datasets-test-synthetic.yml
+++ b/.github/workflows/datasets-test-synthetic.yml
@@ -53,3 +53,41 @@ jobs:
 
       - name: Run tests
         run: moon run synthetic-datasets:test
+
+      - name: Generate e2e dataset
+        run: moon run synthetic-datasets:generate-e2e
+
+      - name: Verify e2e dataset hashes
+        working-directory: ${{ github.workspace }}
+        env:
+          EXPECTED_JSON_HASH: "REPLACE_WITH_HASH_FROM_CI_LOGS"
+          EXPECTED_ZIP_HASH: "REPLACE_WITH_HASH_FROM_CI_LOGS"
+        run: |
+          JSON_FILE="e2e/datasets/spotify/Streaming_History_Audio_2006_1000.json"
+          ZIP_FILE="e2e/datasets/spotify/streamings_1000.zip"
+
+          ACTUAL_JSON=$(sha256sum "$JSON_FILE" | cut -d' ' -f1)
+          ACTUAL_ZIP=$(sha256sum "$ZIP_FILE" | cut -d' ' -f1)
+
+          echo "JSON hash: $ACTUAL_JSON"
+          echo "ZIP  hash: $ACTUAL_ZIP"
+
+          FAILED=0
+          if [ "$ACTUAL_JSON" != "$EXPECTED_JSON_HASH" ]; then
+            echo "❌ JSON hash mismatch — expected: $EXPECTED_JSON_HASH"
+            FAILED=1
+          fi
+          if [ "$ACTUAL_ZIP" != "$EXPECTED_ZIP_HASH" ]; then
+            echo "❌ ZIP hash mismatch — expected: $EXPECTED_ZIP_HASH"
+            FAILED=1
+          fi
+
+          if [ $FAILED -eq 1 ]; then
+            echo ""
+            echo "The e2e dataset output has changed."
+            echo "Investigate whether this change is intentional (generator logic, seed, dependencies)."
+            echo "If intentional, update EXPECTED_JSON_HASH / EXPECTED_ZIP_HASH in datasets-test-synthetic.yml and justify the change in the PR."
+            exit 1
+          fi
+
+          echo "✅ Hashes match"

--- a/.github/workflows/datasets-test-synthetic.yml
+++ b/.github/workflows/datasets-test-synthetic.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Verify e2e dataset hashes
         working-directory: ${{ github.workspace }}
         env:
-          EXPECTED_JSON_HASH: "REPLACE_WITH_HASH_FROM_CI_LOGS"
-          EXPECTED_ZIP_HASH: "REPLACE_WITH_HASH_FROM_CI_LOGS"
+          EXPECTED_JSON_HASH: "8594c9e37349369b2cf85dafb6f97cee372c189ad32ec1305cb0962ce5b6d7ca"
+          EXPECTED_ZIP_HASH: "7e1f32655b63cc63c6b612c41e2f960a05a3f03880fe4723be71c87c964f1dcc"
         run: |
           JSON_FILE="e2e/datasets/spotify/Streaming_History_Audio_2006_1000.json"
           ZIP_FILE="e2e/datasets/spotify/streamings_1000.zip"

--- a/synthetic-datasets/README.md
+++ b/synthetic-datasets/README.md
@@ -53,3 +53,14 @@ Generate dataset specifically for e2e tests (uses a fixed seed and number of rec
 ```bash
 moon run synthetic-datasets:generate-e2e
 ```
+
+## 🔒 E2E Dataset Integrity Check
+
+The CI verifies that `generate-e2e` produces byte-for-byte identical output across runs. The SHA256 hashes of both output files are hardcoded in `datasets-test-synthetic.yml`.
+
+If the hash check fails, it means the generator output changed. Before updating the expected hashes:
+
+1. Identify what caused the change (generator logic, seed, library version bump, etc.)
+2. Determine if the change is intentional
+3. If yes: update `EXPECTED_JSON_HASH` and `EXPECTED_ZIP_HASH` in `datasets-test-synthetic.yml` with the new hashes printed in the CI logs, and justify the change in the PR description
+4. If no: fix the generator so it produces the expected output again

--- a/synthetic-datasets/README.md
+++ b/synthetic-datasets/README.md
@@ -58,6 +58,8 @@ moon run synthetic-datasets:generate-e2e
 
 The CI verifies that `generate-e2e` produces byte-for-byte identical output across runs. The SHA256 hashes of both output files are hardcoded in `datasets-test-synthetic.yml`.
 
+Output is deterministic for a given platform, but hashes differ across platforms (macOS vs Linux, x86 vs ARM) due to differences in NumPy floating-point operations and Faker data ordering. Always get the reference hashes from CI logs, not from a local run.
+
 If the hash check fails, it means the generator output changed. Before updating the expected hashes:
 
 1. Identify what caused the change (generator logic, seed, library version bump, etc.)


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

There is no automated check that the e2e dataset generator produces stable, reproducible output. A change in generator logic or a dependency update could silently alter the datasets used by e2e tests, causing flaky or misleading test results.

## 🎹 Proposal

The audit CI now runs `generate-e2e` after the test suite and verifies the SHA256 hashes of both output files against expected values hardcoded in the workflow. If either hash differs, the job fails and instructs the author to investigate whether the change is intentional before updating the expected values.

The README documents why this check exists, the platform-dependency caveat (hashes must come from CI logs, not local runs, as NumPy and Faker output can differ across platforms and architectures), and the process for updating expected hashes when a change is legitimate.

## 🎶 Comments

The expected hashes are currently set to a placeholder. The first CI run will print the actual values to use.

The ZIP file was confirmed to be deterministic, so both the JSON and the ZIP are checked.

## 🎤 Test

1. Retrieve the actual hashes from the first CI run logs ("Verify e2e dataset hashes" step) and set them in the workflow
2. Push a change to the generator that alters output
3. Observe the CI step fail with expected vs actual hashes and a message to investigate before updating
4. Revert the change and confirm the step passes