### PR TITLE
style(charts): fix card labels in SimpleView

### DIFF
--- a/app/src/components/Charts/SimpleCharts/ArtistLoyalty/ArtistLoyalty.tsx
+++ b/app/src/components/Charts/SimpleCharts/ArtistLoyalty/ArtistLoyalty.tsx
@@ -56,7 +56,7 @@ export const ArtistLoyalty: FC<Props> = ({ data, isLoading }) => {
             title="Artist Loyalty"
             emoji="🤝"
             isLoading={isLoading}
-            question="How are my streams distributed by how much I listen to each artist?"
+            question="How loyal am I to my favorite artists?"
             className="h-full"
         >
             {!data?.length ? (

--- a/app/src/components/Charts/SimpleCharts/CalendarHeatmap/CalendarHeatmap.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/CalendarHeatmap/CalendarHeatmap.test.tsx
@@ -15,9 +15,10 @@ describe('CalendarHeatmap', () => {
         screen.getByText('No data for this year')
     })
 
-    it('shows the year in the card title', () => {
+    it('renders card title without year', () => {
         render(<CalendarHeatmap data={[]} year={2024} />)
-        screen.getByText(/Listening activity 2024/)
+        screen.getByText(/Listening activity/)
+        expect(screen.queryByText(/Listening activity 2024/)).toBeNull()
     })
 
     it('renders cells for the full year including leading/trailing nulls', () => {

--- a/app/src/components/Charts/SimpleCharts/CalendarHeatmap/CalendarHeatmap.tsx
+++ b/app/src/components/Charts/SimpleCharts/CalendarHeatmap/CalendarHeatmap.tsx
@@ -45,7 +45,7 @@ export const CalendarHeatmap: FC<Props> = ({ data, year, isLoading }) => {
     if (!data) {
         return (
             <ChartCard
-                title={`Listening activity ${year}`}
+                title="Listening activity"
                 emoji="🗓️"
                 isLoading={isLoading}
             >
@@ -89,11 +89,7 @@ export const CalendarHeatmap: FC<Props> = ({ data, year, isLoading }) => {
     const minGridWidth = LABEL_WIDTH + weekCount * (CELL_GAP + MIN_CELL)
 
     return (
-        <ChartCard
-            title={`Listening activity ${year}`}
-            emoji="🗓️"
-            isLoading={isLoading}
-        >
+        <ChartCard title="Listening activity" emoji="🗓️" isLoading={isLoading}>
             {data && (
                 <div className="overflow-x-auto">
                     <div

--- a/app/src/components/Charts/SimpleCharts/RepeatBehavior/RepeatBehavior.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/RepeatBehavior/RepeatBehavior.test.tsx
@@ -29,7 +29,7 @@ describe('RepeatBehavior Component', () => {
 
         render(<RepeatBehavior data={data} />)
 
-        screen.getByRole('heading', { name: /🔁Replay Energy/ })
+        screen.getByRole('heading', { name: /🔁Replay Style/ })
         screen.getByText('"track_name"')
         screen.getByText('5 times in a row 🎸')
         screen.getByText(/15 repeated sequences/)

--- a/app/src/components/Charts/SimpleCharts/RepeatBehavior/RepeatBehavior.tsx
+++ b/app/src/components/Charts/SimpleCharts/RepeatBehavior/RepeatBehavior.tsx
@@ -24,7 +24,7 @@ export const RepeatBehavior: FC<Props> = ({ data, isLoading }) => {
 
     return (
         <ChartCard
-            title="Replay Energy"
+            title="Replay Style"
             emoji="🔁"
             isLoading={isLoading}
             question="Do I replay the same tracks over and over?"

--- a/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.tsx
+++ b/app/src/components/Charts/SimpleCharts/SessionAnalysis/SessionAnalysis.tsx
@@ -27,7 +27,7 @@ export const SessionAnalysis: FC<Props> = ({ data, isLoading }) => {
     return (
         <ChartCard
             title="Listening sessions"
-            emoji="🎵"
+            emoji="🎛️"
             isLoading={isLoading}
             question="How are my listening sessions structured?"
             className="h-full"

--- a/app/src/components/Charts/SimpleView.test.tsx
+++ b/app/src/components/Charts/SimpleView.test.tsx
@@ -282,7 +282,7 @@ it('renders all SimpleView', async () => {
     await screen.findByRole('heading', { name: '🌺Seasonal Mood' })
     await screen.findByRole('heading', { name: '🆕Fresh vs Familiar' })
     await screen.findByRole('heading', { name: '⏭️Skip Mood' })
-    await screen.findByRole('heading', { name: '🔁Replay Energy' })
+    await screen.findByRole('heading', { name: '🔁Replay Style' })
     await screen.findByRole('heading', { name: '📱Your Sound Machine' })
     await screen.findByRole('heading', { name: '📅Your Power Day' })
     await screen.findByRole('heading', { name: '🕐Around the Clock' })


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Four display strings in SimpleView cards were inaccurate or redundant:
- "Replay Energy" described intensity, but the classification labels (Obsessive/Variated/Moderate) describe behavioral style, not energy level.
- SessionAnalysis and TopTracks both showed 🎵, creating a visual collision when both cards appear simultaneously.
- The ArtistLoyalty question described the chart mechanism instead of the user's mental model.
- CalendarHeatmap appended the selected year to its title, while the year selector is always visible and no other card does this.

## 🎹 Proposal

Correct each string in its source component and update the affected test assertions:
- "Replay Energy" becomes "Replay Style" to match its behavioral labels.
- SessionAnalysis emoji changes from 🎵 to 🎛️ to eliminate the collision with TopTracks.
- ArtistLoyalty question becomes "How loyal am I to my favorite artists?" — concise and closer to what the user is actually asking.
- CalendarHeatmap title becomes "Listening activity" with no year suffix.

## 🎶 Comments

No behavior changes. No SQL changes. No new components.

## 🎤 Test

1. Upload a Spotify or Deezer export and open the SimpleView tab.
2. Confirm the RepeatBehavior card heading reads "Replay Style".
3. Confirm TopTracks shows 🎵 and Listening sessions shows 🎛️ with no collision.
4. Confirm Artist Loyalty question reads "How loyal am I to my favorite artists?".
5. Confirm the calendar card heading reads "Listening activity" regardless of which year is selected.