### PR TITLE
refactor(synthetic-datasets): generate-map pipeline

### DIFF
--- a/.github/workflows/datasets-test-synthetic.yml
+++ b/.github/workflows/datasets-test-synthetic.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
     branches: ["main"]
     paths:
-      - "synthetic-datasets/synthetic_datasets/**/*.py"
+      - "synthetic-datasets/**/*.py"
       - "synthetic-datasets/pyproject.toml"
       - "synthetic-datasets/uv.lock"
       - "synthetic-datasets/moon.yml"

--- a/.github/workflows/datasets-test-synthetic.yml
+++ b/.github/workflows/datasets-test-synthetic.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Verify e2e dataset hashes
         working-directory: ${{ github.workspace }}
         env:
-          EXPECTED_JSON_HASH: "8594c9e37349369b2cf85dafb6f97cee372c189ad32ec1305cb0962ce5b6d7ca"
-          EXPECTED_ZIP_HASH: "7e1f32655b63cc63c6b612c41e2f960a05a3f03880fe4723be71c87c964f1dcc"
+          EXPECTED_JSON_HASH: "c368333c4da5af4105707e7043336cb463620da26276d99096f8f1541dd35314"
+          EXPECTED_ZIP_HASH: "c0df9adf694459311af3aacac1b619732f0087d6191efe441142197c93f3b777"
         run: |
           JSON_FILE="e2e/datasets/spotify/Streaming_History_Audio_2006_1000.json"
           ZIP_FILE="e2e/datasets/spotify/streamings_1000.zip"

--- a/synthetic-datasets/synthetic_datasets/factories/apple_music.py
+++ b/synthetic-datasets/synthetic_datasets/factories/apple_music.py
@@ -1,21 +1,21 @@
-from ..config import GenerationConfig
+from typing import ClassVar
+
 from ..models.apple_music import AppleMusicRecord
 from ..models.base import BaseEvent
 from .base import BaseFactory
 
-CLIENT_PLATFORMS = ["FUSE", "TILT"]
-
 
 class AppleMusicFactory(BaseFactory[AppleMusicRecord]):
-    def __init__(self, num_records: int, config: GenerationConfig) -> None:
-        super().__init__(num_records, config)
+    DEVICE_TYPES: ClassVar[list[str]] = ["IPHONE", "MACINTOSH", "HOMEPOD"]
 
     def _map_event(self, event: BaseEvent) -> AppleMusicRecord:
         base = self._catalog[event.track_index]
         return AppleMusicRecord(
             event_start_timestamp=event.timestamp,
             song_name=base.title,
+            album_name=base.album,
             media_type="AUDIO",
             play_duration_ms=int(base.duration_ms * event.duration_ratio),
-            client_platform=self.rng.choice(CLIENT_PLATFORMS),
+            device_type=self.rng.choice(self.DEVICE_TYPES),
+            container_origin_type="STREAM_RADIO_STATION" if self.rng.random() < 0.05 else None,
         )

--- a/synthetic-datasets/synthetic_datasets/factories/apple_music.py
+++ b/synthetic-datasets/synthetic_datasets/factories/apple_music.py
@@ -1,17 +1,7 @@
-import random
-from dataclasses import dataclass
-from datetime import datetime
-
 from ..config import GenerationConfig
 from ..models.apple_music import AppleMusicRecord
+from ..models.base import BaseEvent
 from .base import BaseFactory
-
-
-@dataclass
-class AppleMusicTrack:
-    song_name: str
-    duration_ms: int
-
 
 CLIENT_PLATFORMS = ["FUSE", "TILT"]
 
@@ -20,31 +10,12 @@ class AppleMusicFactory(BaseFactory[AppleMusicRecord]):
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         super().__init__(num_records, config)
 
-    def _generate_catalog(self, num_records: int) -> list[AppleMusicTrack]:
-        num_tracks = max(int(num_records * 0.5), 1)
-        print(f" - records: {num_records}")
-        print(f" - tracks : {num_tracks}")
-        return [
-            AppleMusicTrack(
-                song_name=" ".join(self.faker.words(4)).title(),
-                duration_ms=random.randint(self.TRACK_DURATION_MIN_MS, self.TRACK_DURATION_MAX_MS),
-            )
-            for _ in range(num_tracks)
-        ]
-
-    def _create_one_record(self, ts: datetime) -> AppleMusicRecord:
-        year_index = ts.year - self.start_year
-        is_skipped = random.random() < self.skip_chance_trend[year_index]
-
-        track = random.choice(self.weighted_tracks[ts.year])
-        play_duration_ms = random.randint(1_000, 29_000) if is_skipped else random.randint(30_000, track.duration_ms)
-
-        client_platform = random.choice(CLIENT_PLATFORMS)
-
+    def _map_event(self, event: BaseEvent) -> AppleMusicRecord:
+        base = self._catalog[event.track_index]
         return AppleMusicRecord(
-            event_start_timestamp=ts,
-            song_name=track.song_name,
+            event_start_timestamp=event.timestamp,
+            song_name=base.title,
             media_type="AUDIO",
-            play_duration_ms=play_duration_ms,
-            client_platform=client_platform,
+            play_duration_ms=int(base.duration_ms * event.duration_ratio),
+            client_platform=self.rng.choice(CLIENT_PLATFORMS),
         )

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -9,6 +9,7 @@ from faker import Faker
 from tqdm import tqdm
 
 from ..config import GenerationConfig
+from ..models.base import BaseEvent, BaseTrack
 
 RecordT = TypeVar("RecordT")
 
@@ -29,10 +30,10 @@ class BaseFactory(ABC, Generic[RecordT]):
 
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         self.config = config
-        random.seed(config.seed)
-        np.random.seed(config.seed)
-        Faker.seed(config.seed)
+        self.rng = random.Random(config.seed)
+        self.np_rng = np.random.default_rng(config.seed)
         self.faker = Faker()
+        self.faker.seed_instance(config.seed)
         self.now = config.reference_date
         self.start_year = self.START_YEAR
         self.skip_chance_trend = np.linspace(
@@ -41,21 +42,39 @@ class BaseFactory(ABC, Generic[RecordT]):
             self.now.year - self.start_year + 1,
         )
         print("🎵 Generating music catalog...")
-        self.tracks = self._generate_catalog(num_records)
+        self._catalog = self._generate_catalog(num_records)
         print("📈 Generating evolving listening tastes...")
-        self.weighted_tracks = self._generate_weighted_tracks_by_year()
-        for year, weighted_records in self.weighted_tracks.items():
+        self._weighted_tracks = self._generate_weighted_tracks_by_year()
+        for year, weighted_records in self._weighted_tracks.items():
             print(f" - {year}: {len(weighted_records)} records")
         print("📅 Generating distribution over year...")
-        self.records_per_year = self._generate_distribution_over_year(num_records)
-        for year, n in self.records_per_year.items():
+        self._records_per_year = self._generate_distribution_over_year(num_records)
+        for year, n in self._records_per_year.items():
             print(f" - {year}: {n} records")
 
-    @abstractmethod
-    def _generate_catalog(self, num_records: int) -> list: ...
+    def _generate_catalog(self, num_records: int) -> list[BaseTrack]:
+        n_artists = max(1, int(num_records * 0.20))
+        n_albums = max(1, int(num_records * 0.30))
+        n_tracks = max(1, int(num_records * 0.50))
+        print(f" - records: {num_records}")
+        print(f" - artists: {n_artists}")
+        print(f" - albums : {n_albums}")
+        print(f" - tracks : {n_tracks}")
+
+        artists = [self.faker.name() for _ in range(n_artists)]
+        albums = [self.faker.catch_phrase() for _ in range(n_albums)]
+        return [
+            BaseTrack(
+                title=self.faker.bs(),
+                artist=self.rng.choice(artists),
+                album=self.rng.choice(albums),
+                duration_ms=self.rng.randint(self.TRACK_DURATION_MIN_MS, self.TRACK_DURATION_MAX_MS),
+            )
+            for _ in range(n_tracks)
+        ]
 
     @abstractmethod
-    def _create_one_record(self, ts: datetime) -> RecordT: ...
+    def _map_event(self, event: BaseEvent) -> RecordT: ...
 
     def _get_random_datetime_for_year(self, year: int) -> datetime:
         if year < self.now.year:
@@ -66,31 +85,31 @@ class BaseFactory(ABC, Generic[RecordT]):
             month_weights = np.array(self.month_weights[: self.now.month])
 
         month_weights = month_weights / month_weights.sum()
-        month = np.random.choice(months, p=month_weights)
+        month = self.np_rng.choice(months, p=month_weights)
 
-        max_day = calendar.monthrange(year, month)[1]
-        day = random.randint(1, max_day)
+        max_day = calendar.monthrange(year, int(month))[1]
+        day = self.rng.randint(1, max_day)
 
         hour_weights = np.array(self.hour_weights)
         hour_weights = hour_weights / hour_weights.sum()
-        hour = np.random.choice(range(24), p=hour_weights)
+        hour = self.np_rng.choice(range(24), p=hour_weights)
 
-        minute = random.randint(0, 59)
-        second = random.randint(0, 59)
+        minute = self.rng.randint(0, 59)
+        second = self.rng.randint(0, 59)
 
-        candidate = datetime(year, month, day, hour, minute, second)
+        candidate = datetime(year, int(month), day, int(hour), minute, second)
 
         if candidate > self.now:
             start = datetime(year, 1, 1)
             delta_seconds = int((self.now - start).total_seconds())
-            return start + timedelta(seconds=random.randint(0, delta_seconds))
+            return start + timedelta(seconds=self.rng.randint(0, delta_seconds))
 
         return candidate
 
     def _generate_distribution_over_year(self, n_records: int) -> dict[int, int]:
         years = range(self.start_year, self.now.year + 1)
 
-        year_weights = [random.uniform(0.5, 1.5) for _ in years]
+        year_weights = [self.rng.uniform(0.5, 1.5) for _ in years]
         base_records_per_year = n_records / sum(year_weights)
         records_per_year = {
             year: int(base_records_per_year * year_weight) for year, year_weight in zip(years, year_weights)
@@ -98,32 +117,46 @@ class BaseFactory(ABC, Generic[RecordT]):
         records_per_year[self.now.year] += n_records - sum(records_per_year.values())
         return records_per_year
 
-    def _generate_weighted_tracks_by_year(self) -> dict[int, list]:
-        weighted_tracks_by_year = {}
+    def _generate_weighted_tracks_by_year(self) -> dict[int, list[int]]:
+        weighted_tracks_by_year: dict[int, list[int]] = {}
         for year in range(self.start_year, self.now.year + 1):
-            popularity = np.random.zipf(a=self.ZIPF_A, size=len(self.tracks))
-            np.random.shuffle(popularity)
+            popularity = self.np_rng.zipf(a=self.ZIPF_A, size=len(self._catalog))
+            self.np_rng.shuffle(popularity)
 
-            weighted = []
-            for track, weight in zip(self.tracks, popularity):
+            weighted: list[int] = []
+            for i, weight in enumerate(popularity):
                 repeats = min(int(weight / 10), 100)
                 if repeats > 0:
-                    weighted.extend([track] * repeats)
+                    weighted.extend([i] * repeats)
                 else:
-                    weighted.extend([track])
+                    weighted.append(i)
 
             weighted_tracks_by_year[year] = weighted
 
         return weighted_tracks_by_year
 
+    def _generate_base_events(self) -> list[BaseEvent]:
+        events: list[BaseEvent] = []
+        for year, count in self._records_per_year.items():
+            skip_chance = self.skip_chance_trend[year - self.start_year]
+            for _ in range(count):
+                ts = self._get_random_datetime_for_year(year)
+                track_index = self.rng.choice(self._weighted_tracks[year])
+                is_skipped = self.rng.random() < skip_chance
+                if is_skipped:
+                    duration_ratio = self.rng.uniform(0.05, 0.30)
+                else:
+                    duration_ratio = self.rng.uniform(0.90, 1.00)
+                events.append(
+                    BaseEvent(
+                        timestamp=ts,
+                        track_index=track_index,
+                        is_skipped=is_skipped,
+                        duration_ratio=duration_ratio,
+                    )
+                )
+        return sorted(events, key=lambda e: e.timestamp)
+
     def create_streaming_history(self) -> list[RecordT]:
-        all_records: list[RecordT] = []
-
-        for year, num_records_for_year in self.records_per_year.items():
-            year_records = [
-                self._create_one_record(self._get_random_datetime_for_year(year))
-                for _ in tqdm(range(num_records_for_year), desc=f"💿 Generating streamings for {year}", leave=True)
-            ]
-            all_records.extend(year_records)
-
-        return all_records
+        events = self._generate_base_events()
+        return [self._map_event(e) for e in tqdm(events, desc="💿 Generating streamings", leave=True)]

--- a/synthetic-datasets/synthetic_datasets/factories/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/factories/deezer.py
@@ -1,4 +1,5 @@
 import string
+from dataclasses import dataclass
 from ipaddress import ip_address
 
 from ..config import GenerationConfig
@@ -7,9 +8,30 @@ from ..models.deezer import DeezerStreaming
 from .base import BaseFactory
 
 
+@dataclass
+class _DeezerTrack:
+    isrc: str
+    title: str
+    artist: str
+    album_title: str
+    duration_sec: int
+
+
 class DeezerFactory(BaseFactory[DeezerStreaming]):
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         super().__init__(num_records, config)
+
+        print("🎵 Enriching Deezer catalog...")
+        self._deezer_catalog: list[_DeezerTrack] = [
+            _DeezerTrack(
+                isrc=self._generate_isrc(),
+                title=t.title,
+                artist=t.artist,
+                album_title=t.album,
+                duration_sec=t.duration_ms // 1000,
+            )
+            for t in self._catalog
+        ]
 
         print("💻 Generating platforms...")
         self.platforms = ["web", "ios", "android", "desktop", "tv"]
@@ -26,15 +48,15 @@ class DeezerFactory(BaseFactory[DeezerStreaming]):
         return f"{country}{registrant}{year}{designation}"
 
     def _map_event(self, event: BaseEvent) -> DeezerStreaming:
-        base = self._catalog[event.track_index]
-        listening_time = int(base.duration_ms / 1000 * event.duration_ratio)
+        track = self._deezer_catalog[event.track_index]
+        listening_time = int(track.duration_sec * event.duration_ratio)
         platform_name = self.rng.choice(self.platforms)
         platform_model = "" if self.rng.random() < 0.4 else self.faker.user_agent()
         return DeezerStreaming(
-            song_title=base.title,
-            artist=base.artist,
-            isrc=self._generate_isrc(),
-            album_title=base.album,
+            song_title=track.title,
+            artist=track.artist,
+            isrc=track.isrc,
+            album_title=track.album_title,
             ip_address=self.rng.choice(self.ip_addresses),
             listening_time=listening_time,
             platform_name=platform_name,

--- a/synthetic-datasets/synthetic_datasets/factories/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/factories/deezer.py
@@ -1,86 +1,43 @@
-import random
 import string
-from dataclasses import dataclass
-from datetime import datetime
 from ipaddress import ip_address
 
 from ..config import GenerationConfig
+from ..models.base import BaseEvent
 from ..models.deezer import DeezerStreaming
 from .base import BaseFactory
-
-
-@dataclass
-class DeezerTrack:
-    isrc: str
-    song_title: str
-    artist: str
-    album_title: str
-    duration_sec: int
 
 
 class DeezerFactory(BaseFactory[DeezerStreaming]):
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         super().__init__(num_records, config)
 
-        num_ip_addresses = 20
-
         print("💻 Generating platforms...")
         self.platforms = ["web", "ios", "android", "desktop", "tv"]
 
         print("🛜 Generating IPs...")
-        self.ip_addresses = [ip_address(self.faker.ipv4()) for _ in range(num_ip_addresses)]
+        self.ip_addresses = [ip_address(self.faker.ipv4()) for _ in range(20)]
 
     def _generate_isrc(self) -> str:
         countries = ["US", "GB", "FR", "DE", "JP", "CA", "AU"]
-        country = random.choice(countries)
-        registrant = "".join(random.choices(string.ascii_uppercase + string.digits, k=3))
+        country = self.rng.choice(countries)
+        registrant = "".join(self.rng.choices(string.ascii_uppercase + string.digits, k=3))
         year = str(self.now.year % 100).zfill(2)
-        designation = str(random.randint(0, 99999)).zfill(5)
+        designation = str(self.rng.randint(0, 99999)).zfill(5)
         return f"{country}{registrant}{year}{designation}"
 
-    def _generate_catalog(self, num_records: int) -> list[DeezerTrack]:
-        num_artists = max(int(num_records * 0.2), 1)
-        num_albums = max(int(num_records * 0.3), 1)
-        num_tracks = max(int(num_records * 0.5), 1)
-        print(f" - records: {num_records}")
-        print(f" - artists: {num_artists}")
-        print(f" - albums : {num_albums}")
-        print(f" - tracks : {num_tracks}")
-
-        artists = [self.faker.name() for _ in range(num_artists)]
-        album_names = [" ".join(self.faker.words(3)).title() for _ in range(num_albums)]
-        albums = [(name, random.choice(artists)) for name in album_names]
-        tracks = [
-            DeezerTrack(
-                isrc=self._generate_isrc(),
-                song_title=" ".join(self.faker.words(4)).title(),
-                artist=random.choice(albums)[1],
-                album_title=random.choice(albums)[0],
-                duration_sec=random.randint(self.TRACK_DURATION_MIN_MS // 1000, self.TRACK_DURATION_MAX_MS // 1000),
-            )
-            for _ in range(num_tracks)
-        ]
-        return tracks
-
-    def _create_one_record(self, ts: datetime) -> DeezerStreaming:
-        year_index = ts.year - self.start_year
-
-        is_skipped = random.random() < self.skip_chance_trend[year_index]
-
-        track = random.choice(self.weighted_tracks[ts.year])
-        platform_name = random.choice(self.platforms)
-        platform_model = "" if random.random() < 0.4 else self.faker.user_agent()
-
+    def _map_event(self, event: BaseEvent) -> DeezerStreaming:
+        base = self._catalog[event.track_index]
+        listening_time = int(base.duration_ms / 1000 * event.duration_ratio)
+        platform_name = self.rng.choice(self.platforms)
+        platform_model = "" if self.rng.random() < 0.4 else self.faker.user_agent()
         return DeezerStreaming(
-            song_title=track.song_title,
-            artist=track.artist,
-            isrc=track.isrc,
-            album_title=track.album_title,
-            ip_address=random.choice(self.ip_addresses),
-            listening_time=random.randint(1, 29)
-            if is_skipped
-            else random.randint(int(track.duration_sec * 0.95), track.duration_sec),
+            song_title=base.title,
+            artist=base.artist,
+            isrc=self._generate_isrc(),
+            album_title=base.album,
+            ip_address=self.rng.choice(self.ip_addresses),
+            listening_time=listening_time,
             platform_name=platform_name,
             platform_model=platform_model,
-            date=ts,
+            date=event.timestamp,
         )

--- a/synthetic-datasets/synthetic_datasets/factories/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/factories/spotify.py
@@ -1,11 +1,10 @@
-import string
 from datetime import timedelta
 from ipaddress import ip_address
 from typing import ClassVar
 
 from ..config import GenerationConfig
 from ..models.base import BaseEvent
-from ..models.spotify import ReasonEndEnum, ReasonStartEnum, Streaming
+from ..models.spotify import Album, Artist, ReasonEndEnum, ReasonStartEnum, Streaming, Track
 from .base import BaseFactory
 
 
@@ -16,10 +15,23 @@ class SpotifyFactory(BaseFactory[Streaming]):
         ReasonStartEnum.BACK_BUTTON,
         ReasonStartEnum.CLICK_ROW,
     ]
-    _TRACK_URI_CHARS: ClassVar[str] = string.ascii_letters + string.digits
 
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         super().__init__(num_records, config)
+
+        print("🎵 Enriching Spotify catalog...")
+        self._spotify_catalog: list[Track] = [
+            Track(
+                uri=f"spotify:track:{self.faker.uuid4().replace('-', '')[:22]}",
+                name=t.title,
+                album=Album(
+                    name=t.album,
+                    artist=Artist(name=t.artist),
+                ),
+                duration_ms=t.duration_ms,
+            )
+            for t in self._catalog
+        ]
 
         num_platforms = 5
         num_countries = 5
@@ -45,22 +57,21 @@ class SpotifyFactory(BaseFactory[Streaming]):
         self.ip_addr = [ip_address(self.faker.ipv4()) for _ in range(0, num_ip_addresses)]
 
     def _map_event(self, event: BaseEvent) -> Streaming:
-        base = self._catalog[event.track_index]
+        track = self._spotify_catalog[event.track_index]
         ts = event.timestamp
-        ms_played = int(base.duration_ms * event.duration_ratio)
+        ms_played = int(track.duration_ms * event.duration_ratio)
         is_offline = self.rng.random() < 0.1
         platform = self.rng.choice(self.platforms)
-        uri_suffix = "".join(self.rng.choices(self._TRACK_URI_CHARS, k=22))
         return Streaming(
             ts=ts,
             platform=platform,
             ms_played=ms_played,
             conn_country=self.rng.choice(self.countries),
             ip_addr=self.rng.choice(self.ip_addr),
-            master_metadata_track_name=base.title,
-            master_metadata_album_artist_name=base.artist,
-            master_metadata_album_album_name=base.album,
-            spotify_track_uri=f"spotify:track:{uri_suffix}",
+            master_metadata_track_name=track.name,
+            master_metadata_album_artist_name=track.album.artist.name,
+            master_metadata_album_album_name=track.album.name,
+            spotify_track_uri=track.uri,
             reason_start=self.rng.choice(self.reason_start),
             reason_end=ReasonEndEnum.FORWARD_BUTTON if event.is_skipped else ReasonEndEnum.TRACK_DONE,
             shuffle=bool(self.rng.getrandbits(1)),

--- a/synthetic-datasets/synthetic_datasets/factories/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/factories/spotify.py
@@ -1,11 +1,11 @@
-import random
 import string
-from datetime import datetime, timedelta
+from datetime import timedelta
 from ipaddress import ip_address
 from typing import ClassVar
 
 from ..config import GenerationConfig
-from ..models.spotify import Album, Artist, ReasonEndEnum, ReasonStartEnum, Streaming, Track
+from ..models.base import BaseEvent
+from ..models.spotify import ReasonEndEnum, ReasonStartEnum, Streaming
 from .base import BaseFactory
 
 
@@ -16,6 +16,7 @@ class SpotifyFactory(BaseFactory[Streaming]):
         ReasonStartEnum.BACK_BUTTON,
         ReasonStartEnum.CLICK_ROW,
     ]
+    _TRACK_URI_CHARS: ClassVar[str] = string.ascii_letters + string.digits
 
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         super().__init__(num_records, config)
@@ -40,58 +41,33 @@ class SpotifyFactory(BaseFactory[Streaming]):
 
         print("🌏 Generating country codes...")
         self.countries = [self.faker.country_code() for _ in range(0, num_countries)]
-        print("🛜 Generatin IPs...")
+        print("🛜 Generating IPs...")
         self.ip_addr = [ip_address(self.faker.ipv4()) for _ in range(0, num_ip_addresses)]
 
-    def _generate_catalog(self, num_records: int) -> list[Track]:
-        num_artists = max(int(num_records * 0.2), 1)
-        num_albums = max(int(num_records * 0.3), 1)
-        num_tracks = max(int(num_records * 0.5), 1)
-        print(f" - records: {num_records}")
-        print(f" - artists: {num_artists}")
-        print(f" - albums : {num_albums}")
-        print(f" - tracks : {num_tracks}")
-
-        track_uri_chars = string.ascii_letters + string.digits
-        artists = [Artist(name=self.faker.name()) for _ in range(num_artists)]
-        albums = [
-            Album(name=" ".join(self.faker.words(3)).title(), artist=random.choice(artists)) for _ in range(num_albums)
-        ]
-        tracks = [
-            Track(
-                uri=f"spotify:track:{''.join(random.choices(track_uri_chars, k=22))}",
-                name=" ".join(self.faker.words(4)).title(),
-                album=random.choice(albums),
-                duration_ms=random.randint(self.TRACK_DURATION_MIN_MS, self.TRACK_DURATION_MAX_MS),
-            )
-            for _ in range(num_tracks)
-        ]
-        return tracks
-
-    def _create_one_record(self, ts: datetime) -> Streaming:
-        year_index = ts.year - self.start_year
-
-        is_skipped = random.random() < self.skip_chance_trend[year_index]
-        is_offline = random.random() < 0.1
-
-        track = random.choice(self.weighted_tracks[ts.year])
-        platform = random.choice(self.platforms)
-
+    def _map_event(self, event: BaseEvent) -> Streaming:
+        base = self._catalog[event.track_index]
+        ts = event.timestamp
+        ms_played = int(base.duration_ms * event.duration_ratio)
+        is_offline = self.rng.random() < 0.1
+        platform = self.rng.choice(self.platforms)
+        uri_suffix = "".join(self.rng.choices(self._TRACK_URI_CHARS, k=22))
         return Streaming(
             ts=ts,
             platform=platform,
-            ms_played=random.randint(1000, 29000) if is_skipped else int(track.duration_ms * random.uniform(0.95, 1.0)),
-            conn_country=random.choice(self.countries),
-            ip_addr=random.choice(self.ip_addr),
-            master_metadata_track_name=track.name,
-            master_metadata_album_artist_name=track.album.artist.name,
-            master_metadata_album_album_name=track.album.name,
-            spotify_track_uri=track.uri,
-            reason_start=random.choice(self.reason_start),
-            reason_end=ReasonEndEnum.FORWARD_BUTTON if is_skipped else ReasonEndEnum.TRACK_DONE,
-            shuffle=bool(random.getrandbits(1)),
-            skipped=is_skipped,
+            ms_played=ms_played,
+            conn_country=self.rng.choice(self.countries),
+            ip_addr=self.rng.choice(self.ip_addr),
+            master_metadata_track_name=base.title,
+            master_metadata_album_artist_name=base.artist,
+            master_metadata_album_album_name=base.album,
+            spotify_track_uri=f"spotify:track:{uri_suffix}",
+            reason_start=self.rng.choice(self.reason_start),
+            reason_end=ReasonEndEnum.FORWARD_BUTTON if event.is_skipped else ReasonEndEnum.TRACK_DONE,
+            shuffle=bool(self.rng.getrandbits(1)),
+            skipped=event.is_skipped,
             offline=is_offline,
-            offline_timestamp=int((ts - timedelta(minutes=random.randint(1, 60))).timestamp()) if is_offline else None,
-            incognito_mode=bool(random.getrandbits(1)),
+            offline_timestamp=int((ts - timedelta(minutes=self.rng.randint(1, 60))).timestamp())
+            if is_offline
+            else None,
+            incognito_mode=bool(self.rng.getrandbits(1)),
         )

--- a/synthetic-datasets/synthetic_datasets/models/apple_music.py
+++ b/synthetic-datasets/synthetic_datasets/models/apple_music.py
@@ -6,9 +6,11 @@ from pydantic import BaseModel, PastDatetime, field_serializer
 class AppleMusicRecord(BaseModel):
     event_start_timestamp: PastDatetime
     song_name: str
+    album_name: str
     media_type: str = "AUDIO"
-    play_duration_ms: int  # milliseconds; always >= 0
-    client_platform: str  # e.g. "FUSE", "TILT"
+    play_duration_ms: int
+    device_type: str
+    container_origin_type: str | None = None
 
     @field_serializer("event_start_timestamp")
     def serialize_event_start_timestamp(self, ts: datetime) -> str:

--- a/synthetic-datasets/synthetic_datasets/models/base.py
+++ b/synthetic-datasets/synthetic_datasets/models/base.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class BaseTrack:
+    title: str
+    artist: str
+    album: str
+    duration_ms: int
+
+
+@dataclass
+class BaseEvent:
+    timestamp: datetime
+    track_index: int
+    is_skipped: bool
+    duration_ratio: float

--- a/synthetic-datasets/synthetic_datasets/writers/apple_music.py
+++ b/synthetic-datasets/synthetic_datasets/writers/apple_music.py
@@ -1,6 +1,7 @@
 import csv
 from datetime import datetime
 from pathlib import Path
+from typing import ClassVar
 
 from tqdm import tqdm
 
@@ -9,14 +10,18 @@ from ..models.apple_music import AppleMusicRecord
 COLUMNS = [
     "Event Start Timestamp",
     "Song Name",
+    "Album Name",
     "Container Artist Name",
     "Media Type",
     "Play Duration Milliseconds",
-    "Feature Name",
+    "Device Type",
+    "Container Origin Type",
 ]
 
 
 class AppleMusicWriter:
+    NULL_VALUE: ClassVar[str] = ""
+
     def __init__(self, output_dir: Path, reference_date: datetime) -> None:
         self.output_path = output_dir / "apple_music" / "Apple Music Play Activity.csv"
         self.reference_date = reference_date
@@ -38,10 +43,12 @@ class AppleMusicWriter:
                     {
                         "Event Start Timestamp": record.serialize_event_start_timestamp(record.event_start_timestamp),
                         "Song Name": record.song_name,
-                        "Container Artist Name": "",
+                        "Album Name": record.album_name,
+                        "Container Artist Name": self.NULL_VALUE,
                         "Media Type": record.media_type,
                         "Play Duration Milliseconds": str(record.play_duration_ms),
-                        "Feature Name": record.client_platform,
+                        "Device Type": record.device_type,
+                        "Container Origin Type": record.container_origin_type or self.NULL_VALUE,
                     }
                 )
         print(

--- a/synthetic-datasets/tests/conftest.py
+++ b/synthetic-datasets/tests/conftest.py
@@ -50,9 +50,11 @@ def apple_music_record():
     return AppleMusicRecord(
         event_start_timestamp=datetime.fromisoformat("2020-08-07T11:48:23"),
         song_name="Never Gonna Give You Up",
+        album_name="Whenever You Need Somebody",
         media_type="AUDIO",
         play_duration_ms=213_000,
-        client_platform="FUSE",
+        device_type="IPHONE",
+        container_origin_type=None,
     )
 
 

--- a/synthetic-datasets/tests/factories/test_apple_music.py
+++ b/synthetic-datasets/tests/factories/test_apple_music.py
@@ -65,12 +65,12 @@ def test_all_records_are_audio(default_generation_config):
         assert record.media_type == "AUDIO"
 
 
-def test_records_have_valid_client_platforms(default_generation_config):
-    valid_platforms = {"FUSE", "TILT"}
+def test_records_have_valid_device_types(default_generation_config):
+    valid_device_types = {"IPHONE", "MACINTOSH", "HOMEPOD"}
     factory = AppleMusicFactory(num_records=200, config=default_generation_config)
     records = factory.create_streaming_history()
     for record in records:
-        assert record.client_platform in valid_platforms
+        assert record.device_type in valid_device_types
 
 
 def test_play_duration_is_non_negative(default_generation_config):
@@ -85,3 +85,17 @@ def test_song_names_are_non_empty(default_generation_config):
     records = factory.create_streaming_history()
     for record in records:
         assert record.song_name.strip() != ""
+
+
+def test_album_names_are_non_empty(default_generation_config):
+    factory = AppleMusicFactory(num_records=50, config=default_generation_config)
+    records = factory.create_streaming_history()
+    for record in records:
+        assert record.album_name.strip() != ""
+
+
+def test_container_origin_type_values(default_generation_config):
+    factory = AppleMusicFactory(num_records=500, config=default_generation_config)
+    records = factory.create_streaming_history()
+    values = {r.container_origin_type for r in records}
+    assert values <= {None, "STREAM_RADIO_STATION"}

--- a/synthetic-datasets/tests/factories/test_base_factory.py
+++ b/synthetic-datasets/tests/factories/test_base_factory.py
@@ -6,7 +6,10 @@ from faker import Faker
 from numpy.random import Generator
 
 from synthetic_datasets.config import GenerationConfig
+from synthetic_datasets.factories.apple_music import AppleMusicFactory
 from synthetic_datasets.factories.base import BaseFactory
+from synthetic_datasets.factories.deezer import DeezerFactory
+from synthetic_datasets.factories.spotify import SpotifyFactory
 from synthetic_datasets.models.base import BaseEvent, BaseTrack
 
 
@@ -120,3 +123,16 @@ def test_global_random_not_used(config):
     r2 = f2.create_streaming_history()
 
     assert r1 == r2
+
+
+class TestCrossProviderCatalogConsistency:
+    def test_same_seed_produces_same_catalog(self, config):
+        spotify = SpotifyFactory(100, config)
+        deezer = DeezerFactory(100, config)
+        apple = AppleMusicFactory(100, config)
+
+        for i, base_track in enumerate(spotify._catalog):
+            assert deezer._catalog[i].title == base_track.title
+            assert deezer._catalog[i].artist == base_track.artist
+            assert apple._catalog[i].title == base_track.title
+            assert apple._catalog[i].album == base_track.album

--- a/synthetic-datasets/tests/factories/test_base_factory.py
+++ b/synthetic-datasets/tests/factories/test_base_factory.py
@@ -1,17 +1,18 @@
+import random
 from datetime import datetime
 
 import pytest
+from faker import Faker
+from numpy.random import Generator
 
 from synthetic_datasets.config import GenerationConfig
 from synthetic_datasets.factories.base import BaseFactory
+from synthetic_datasets.models.base import BaseEvent, BaseTrack
 
 
 class ConcreteFactory(BaseFactory[str]):
-    def _generate_catalog(self, num_records: int) -> list:
-        return []
-
-    def _create_one_record(self, ts: datetime) -> str:
-        return "record"
+    def _map_event(self, event: BaseEvent) -> str:
+        return f"record:{event.track_index}"
 
 
 @pytest.fixture
@@ -46,4 +47,76 @@ def test_generate_distribution_over_year_sums_to_n(factory):
 def test_rng_seeding_is_deterministic(config):
     f1 = ConcreteFactory(num_records=50, config=config)
     f2 = ConcreteFactory(num_records=50, config=config)
-    assert f1.records_per_year == f2.records_per_year
+    assert f1._records_per_year == f2._records_per_year
+
+
+def test_instance_level_rngs_exist(factory):
+    assert isinstance(factory.rng, random.Random)
+    assert isinstance(factory.np_rng, Generator)
+    assert isinstance(factory.faker, Faker)
+
+
+def test_generate_catalog_returns_base_tracks(factory):
+    assert len(factory._catalog) > 0
+    for track in factory._catalog:
+        assert isinstance(track, BaseTrack)
+        assert track.title
+        assert track.artist
+        assert track.album
+        assert factory.TRACK_DURATION_MIN_MS <= track.duration_ms <= factory.TRACK_DURATION_MAX_MS
+
+
+def test_weighted_tracks_contains_indices(factory):
+    for year, indices in factory._weighted_tracks.items():
+        assert len(indices) > 0
+        for idx in indices:
+            assert isinstance(idx, int)
+            assert 0 <= idx < len(factory._catalog)
+
+
+def test_generate_base_events_returns_sorted_events(factory):
+    events = factory._generate_base_events()
+    timestamps = [e.timestamp for e in events]
+    assert timestamps == sorted(timestamps)
+
+
+def test_generate_base_events_count_matches_records_per_year(factory):
+    events = factory._generate_base_events()
+    assert len(events) == sum(factory._records_per_year.values())
+
+
+def test_base_event_duration_ratio_skipped(config):
+    factory = ConcreteFactory(num_records=200, config=config)
+    events = factory._generate_base_events()
+    for event in events:
+        if event.is_skipped:
+            assert 0.05 <= event.duration_ratio <= 0.30
+        else:
+            assert 0.90 <= event.duration_ratio <= 1.00
+
+
+def test_create_streaming_history_count(config):
+    factory = ConcreteFactory(num_records=50, config=config)
+    records = factory.create_streaming_history()
+    assert len(records) == sum(factory._records_per_year.values())
+
+
+def test_same_seed_same_output(config):
+    f1 = ConcreteFactory(num_records=50, config=config)
+    r1 = f1.create_streaming_history()
+    f2 = ConcreteFactory(num_records=50, config=config)
+    r2 = f2.create_streaming_history()
+    assert r1 == r2
+
+
+def test_global_random_not_used(config):
+    """Instance-level rng; global random state must not affect output."""
+    random.seed(999)
+    f1 = ConcreteFactory(num_records=30, config=config)
+    r1 = f1.create_streaming_history()
+
+    random.seed(0)
+    f2 = ConcreteFactory(num_records=30, config=config)
+    r2 = f2.create_streaming_history()
+
+    assert r1 == r2

--- a/synthetic-datasets/tests/models/test_base.py
+++ b/synthetic-datasets/tests/models/test_base.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+from synthetic_datasets.models.base import BaseEvent, BaseTrack
+
+
+def test_base_track_fields():
+    track = BaseTrack(title="Song", artist="Artist", album="Album", duration_ms=180_000)
+    assert track.title == "Song"
+    assert track.artist == "Artist"
+    assert track.album == "Album"
+    assert track.duration_ms == 180_000
+
+
+def test_base_event_fields():
+    ts = datetime(2024, 1, 1, 12, 0, 0)
+    event = BaseEvent(timestamp=ts, track_index=3, is_skipped=False, duration_ratio=0.95)
+    assert event.timestamp == ts
+    assert event.track_index == 3
+    assert event.is_skipped is False
+    assert event.duration_ratio == 0.95
+
+
+def test_base_track_is_dataclass():
+    import dataclasses
+
+    assert dataclasses.is_dataclass(BaseTrack)
+    assert dataclasses.is_dataclass(BaseEvent)

--- a/synthetic-datasets/tests/writers/test_apple_music.py
+++ b/synthetic-datasets/tests/writers/test_apple_music.py
@@ -81,6 +81,9 @@ def test_write_csv_record_values(tmp_path, apple_music_record):
         reader = csv.DictReader(f)
         row = next(reader)
     assert row["Song Name"] == apple_music_record.song_name
+    assert row["Album Name"] == apple_music_record.album_name
     assert row["Media Type"] == apple_music_record.media_type
     assert row["Play Duration Milliseconds"] == str(apple_music_record.play_duration_ms)
     assert row["Container Artist Name"] == ""
+    assert row["Device Type"] == apple_music_record.device_type
+    assert row["Container Origin Type"] == ""


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Streaming history generation duplicated skip logic, duration computation, and track selection across all three provider factories. Same seed produced different catalogs (different track names and artists) per provider, making cross-provider consistency impossible. Apple Music CSV output was also misaligned with the schema the app reads (missing `Album Name`, `Device Type`, `Container Origin Type`; wrong column name `Feature Name`).

## 🎹 Proposal

Split generation into two phases:

1. **Generate**: `BaseFactory` produces provider-agnostic `BaseEvent` objects (timestamp, track index, skip flag, duration ratio) from a shared `BaseTrack` catalog. Skip logic and duration ratio now live once in `BaseFactory._generate_base_events`.

2. **Map**: each provider factory implements `_map_event(event: BaseEvent) -> RecordT`, enriching events with provider-specific fields (Spotify URIs, Deezer ISRCs, Apple Music device types, etc.) using a pre-built enriched catalog constructed in `__init__`.

Global `random.seed`, `np.random.seed`, and `Faker.seed` calls are replaced with instance-level RNGs (`self.rng`, `self.np_rng`, `self.faker`) so factory instances are fully isolated. `_generate_weighted_tracks_by_year` now stores catalog indices (integers) instead of track objects, preventing silent index corruption when two tracks share identical fields.

Apple Music field alignment: `AppleMusicRecord` gains `album_name`, replaces `client_platform` with `device_type`, and adds `container_origin_type`. `AppleMusicWriter` now outputs `Album Name`, `Device Type`, and `Container Origin Type` columns with a `NULL_VALUE` constant for absent fields.

## 🎶 Comments

Snapshot SHA256 hashes in CI will change for two reasons:

1. Instance-level RNGs produce different sequences than global seeds for the same value.
2. Skip duration changed: previously a flat `randint(1000, 29000)` ms for all skipped tracks; now `int(duration_ms * ratio)` where `ratio ∈ [0.05, 0.30]` and `duration_ms ∈ [120_000, 360_000]`, giving a proportional range of ~6–108 seconds. The new approach is more realistic (skip duration scales with track length) but is a semantic change to generated output.

The e2e snapshot test runs in CI only; a follow-up commit will update the hashes once CI reports the new values.

## 🎤 Test

```bash
moon run synthetic-datasets:format synthetic-datasets:lint-fix synthetic-datasets:typecheck
moon run synthetic-datasets:test
moon run synthetic-datasets:generate -- 100 --provider spotify
moon run synthetic-datasets:generate -- 100 --provider deezer
moon run synthetic-datasets:generate -- 100 --provider apple-music
```

All 182 local tests pass. Verify the Apple Music CSV contains columns `Album Name`, `Device Type`, `Container Origin Type` and no longer contains `Feature Name`.