### PR TITLE
refactor(synthetic-datasets): migrate CLI from argparse to Typer

### DIFF
--- a/synthetic-datasets/pyproject.toml
+++ b/synthetic-datasets/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "numpy==2.4.6",
     "openpyxl==3.1.5",
     "pydantic==2.13.4",
-    "tqdm==4.67.3",
     "typer==0.26.4",
 ]
 

--- a/synthetic-datasets/pyproject.toml
+++ b/synthetic-datasets/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "openpyxl==3.1.5",
     "pydantic==2.13.4",
     "tqdm==4.67.3",
+    "typer==0.26.4",
 ]
 
 [dependency-groups]

--- a/synthetic-datasets/synthetic_datasets/app.py
+++ b/synthetic-datasets/synthetic_datasets/app.py
@@ -21,7 +21,7 @@ class Provider(str, Enum):
     apple_music = "apple-music"
 
 
-app = typer.Typer(no_args_is_help=True)
+app = typer.Typer()
 
 
 def _apple_music(num_records: int, output_dir: Path, config: GenerationConfig) -> None:

--- a/synthetic-datasets/synthetic_datasets/app.py
+++ b/synthetic-datasets/synthetic_datasets/app.py
@@ -6,6 +6,7 @@ from typing import Annotated
 
 import typer
 from rich import print
+from rich.panel import Panel
 
 from synthetic_datasets.config import GenerationConfig
 from synthetic_datasets.factories.apple_music import AppleMusicFactory
@@ -78,10 +79,9 @@ def generate(
     ] = Provider.spotify,
 ) -> None:
     """Generate synthetic streaming datasets."""
-    start = time.time()
+    start = time.perf_counter()
 
     config = GenerationConfig.create(seed=seed, reference_date=reference_date)
-    config.log_config()
 
     match provider:
         case Provider.deezer:
@@ -91,7 +91,9 @@ def generate(
         case Provider.spotify:
             _spotify(num_records, output_dir, config)
 
-    print(f"--- {time.time() - start:.2f} seconds ---")
+    elapsed = time.perf_counter() - start
+    print(Panel(f"Completed in [bold]{elapsed:.2f}s[/bold]", title="✨ Result", style="green"))
+    config.log_config()
 
 
 def main() -> None:

--- a/synthetic-datasets/synthetic_datasets/app.py
+++ b/synthetic-datasets/synthetic_datasets/app.py
@@ -22,7 +22,7 @@ class Provider(str, Enum):
     apple_music = "apple-music"
 
 
-app = typer.Typer()
+app = typer.Typer(add_completion=False)
 
 
 def _apple_music(num_records: int, output_dir: Path, config: GenerationConfig) -> None:

--- a/synthetic-datasets/synthetic_datasets/app.py
+++ b/synthetic-datasets/synthetic_datasets/app.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
+from rich import print
 
 from synthetic_datasets.config import GenerationConfig
 from synthetic_datasets.factories.apple_music import AppleMusicFactory
@@ -90,7 +91,7 @@ def generate(
         case Provider.spotify:
             _spotify(num_records, output_dir, config)
 
-    typer.echo(f"--- {time.time() - start:.2f} seconds ---")
+    print(f"--- {time.time() - start:.2f} seconds ---")
 
 
 def main() -> None:

--- a/synthetic-datasets/synthetic_datasets/app.py
+++ b/synthetic-datasets/synthetic_datasets/app.py
@@ -1,7 +1,10 @@
-import argparse
 import time
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
+from typing import Annotated
+
+import typer
 
 from synthetic_datasets.config import GenerationConfig
 from synthetic_datasets.factories.apple_music import AppleMusicFactory
@@ -12,84 +15,86 @@ from synthetic_datasets.writers.deezer import DeezerWriter
 from synthetic_datasets.writers.spotify import SpotifyWriter
 
 
-def apple_music(num_records: int, output_dir: Path, config: GenerationConfig):
+class Provider(str, Enum):
+    spotify = "spotify"
+    deezer = "deezer"
+    apple_music = "apple-music"
+
+
+app = typer.Typer(no_args_is_help=True)
+
+
+def _apple_music(num_records: int, output_dir: Path, config: GenerationConfig) -> None:
     factory = AppleMusicFactory(num_records, config=config)
-    all_streamings = factory.create_streaming_history()
-
     writer = AppleMusicWriter(output_dir=output_dir, reference_date=config.reference_date)
-    writer.write(all_streamings)
+    writer.write(factory.create_streaming_history())
 
 
-def spotify(num_records: int, output_dir: Path, config: GenerationConfig):
+def _spotify(num_records: int, output_dir: Path, config: GenerationConfig) -> None:
     factory = SpotifyFactory(num_records, config=config)
-    all_streamings = factory.create_streaming_history()
-
     writer = SpotifyWriter(output_dir=output_dir, reference_date=config.reference_date)
-    writer.write(all_streamings)
+    writer.write(factory.create_streaming_history())
 
 
-def deezer(num_records: int, output_dir: Path, config: GenerationConfig):
+def _deezer(num_records: int, output_dir: Path, config: GenerationConfig) -> None:
     factory = DeezerFactory(num_records, config=config)
-    all_streamings = factory.create_streaming_history()
-
     writer = DeezerWriter(output_dir=output_dir, reference_date=config.reference_date)
-    writer.write(all_streamings)
+    writer.write(factory.create_streaming_history())
 
 
-def min_int(min_value):
-    def checker(value):
-        ivalue = int(value)
-        if ivalue < min_value:
-            raise argparse.ArgumentTypeError(f"Minimal value is: {min_value}")
-        return ivalue
-
-    return checker
+def _validate_num_records(value: int) -> int:
+    if value < 100:
+        raise typer.BadParameter("Minimal value is: 100")
+    return value
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Generate synthetic streaming datasets",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
+@app.command(
+    epilog="""
 Examples:
-  generate 1000                                      # Generate 1000 records with random data
-  generate 1000 --seed 42                            # Generate 1000 records with seed 42
-        """,
-    )
-    parser.add_argument("num_records", type=min_int(100), help="Number of lines to be generated (>= 100)")
-    parser.add_argument(
-        "-o",
-        "--output-dir",
-        type=Path,
-        default=Path("datasets"),
-        help="Output directory for generated datasets",
-    )
-    parser.add_argument("--seed", type=int, help="Seed for reproducible generation (optional)")
-    parser.add_argument(
-        "--reference-date",
-        type=lambda s: datetime.fromisoformat(s),
-        help="Overwrite reference date for generation in ISO format (optional, e.g., 2026-02-08 or 2026-02-08T14:30:00)",
-    )
-    parser.add_argument(
-        "--provider",
-        choices=["spotify", "deezer", "apple-music"],
-        default="spotify",
-        help="Streaming provider to generate data for (default: spotify)",
-    )
-    args = parser.parse_args()
 
-    start_data_generation = time.time()
+  generate 1000
 
-    config = GenerationConfig.create(seed=args.seed, reference_date=args.reference_date)
+  generate 1000 --seed 42
+"""
+)
+def generate(
+    num_records: Annotated[
+        int,
+        typer.Argument(help="Number of lines to be generated (>= 100)", callback=_validate_num_records),
+    ],
+    output_dir: Annotated[
+        Path,
+        typer.Option("-o", "--output-dir", help="Output directory for generated datasets"),
+    ] = Path("datasets"),
+    seed: Annotated[int | None, typer.Option(help="Seed for reproducible generation")] = None,
+    reference_date: Annotated[
+        datetime | None,
+        typer.Option(help="Overwrite reference date in ISO format (e.g., 2026-02-08 or 2026-02-08T14:30:00)"),
+    ] = None,
+    provider: Annotated[
+        Provider,
+        typer.Option(help="Streaming provider to generate data for"),
+    ] = Provider.spotify,
+) -> None:
+    """Generate synthetic streaming datasets."""
+    start = time.time()
+
+    config = GenerationConfig.create(seed=seed, reference_date=reference_date)
     config.log_config()
 
-    if args.provider == "deezer":
-        deezer(args.num_records, args.output_dir, config)
-    elif args.provider == "apple-music":
-        apple_music(args.num_records, args.output_dir, config)
-    else:
-        spotify(args.num_records, args.output_dir, config)
-    print("--- %s seconds ---" % (time.time() - start_data_generation))
+    match provider:
+        case Provider.deezer:
+            _deezer(num_records, output_dir, config)
+        case Provider.apple_music:
+            _apple_music(num_records, output_dir, config)
+        case Provider.spotify:
+            _spotify(num_records, output_dir, config)
+
+    typer.echo(f"--- {time.time() - start:.2f} seconds ---")
+
+
+def main() -> None:
+    app()
 
 
 if __name__ == "__main__":

--- a/synthetic-datasets/synthetic_datasets/config.py
+++ b/synthetic-datasets/synthetic_datasets/config.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from rich import print
+from rich.panel import Panel
+from rich.table import Table
 
 
 def derive_reference_date_from_seed(seed: int) -> datetime:
@@ -53,12 +55,17 @@ class GenerationConfig:
         )
 
     def log_config(self) -> None:
-        print("=" * 60)
-        print("🔧 Generation Configuration")
-        print(f"  Seed: {self.seed} {'(auto-generated)' if self.is_seed_auto_generated else '(provided)'}")
-        print(
-            f"  Reference Date: {self.reference_date.isoformat()} {'(derived from seed)' if self.is_reference_date_auto_generated else '(provided)'}"
+        table = Table(show_header=False, box=None, padding=(0, 1))
+        table.add_row("Seed", str(self.seed), "(auto-generated)" if self.is_seed_auto_generated else "(provided)")
+        table.add_row(
+            "Reference Date",
+            self.reference_date.isoformat(),
+            "(derived from seed)" if self.is_reference_date_auto_generated else "(provided)",
         )
-        print("=" * 60)
-        print(f"To reproduce: --seed {self.seed} --reference-date {self.reference_date.isoformat()}")
-        print("=" * 60)
+        print(
+            Panel(
+                table,
+                title="🔧 Generation Configuration",
+                subtitle=f"To reproduce: --seed {self.seed} --reference-date {self.reference_date.isoformat()}",
+            )
+        )

--- a/synthetic-datasets/synthetic_datasets/config.py
+++ b/synthetic-datasets/synthetic_datasets/config.py
@@ -2,7 +2,7 @@ import random
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
-import typer
+from rich import print
 
 
 def derive_reference_date_from_seed(seed: int) -> datetime:
@@ -32,18 +32,18 @@ class GenerationConfig:
         if seed is None:
             seed = random.randint(0, 2**31 - 1)
             is_seed_auto = True
-            typer.echo(f"🌱 Auto-generated seed: {seed} (use --seed {seed} to reproduce)")
+            print(f"🌱 Auto-generated seed: {seed} (use --seed {seed} to reproduce)")
         else:
             is_seed_auto = False
-            typer.echo(f"🌱 Using provided seed: {seed}")
+            print(f"🌱 Using provided seed: {seed}")
 
         if reference_date is None:
             reference_date = derive_reference_date_from_seed(seed)
             is_date_auto = True
-            typer.echo(f"📅 Derived reference date from seed: {reference_date.isoformat()}")
+            print(f"📅 Derived reference date from seed: {reference_date.isoformat()}")
         else:
             is_date_auto = False
-            typer.echo(f"📅 Using provided reference date: {reference_date.isoformat()}")
+            print(f"📅 Using provided reference date: {reference_date.isoformat()}")
 
         return cls(
             seed=seed,
@@ -53,12 +53,12 @@ class GenerationConfig:
         )
 
     def log_config(self) -> None:
-        typer.echo("=" * 60)
-        typer.echo("🔧 Generation Configuration")
-        typer.echo(f"  Seed: {self.seed} {'(auto-generated)' if self.is_seed_auto_generated else '(provided)'}")
-        typer.echo(
+        print("=" * 60)
+        print("🔧 Generation Configuration")
+        print(f"  Seed: {self.seed} {'(auto-generated)' if self.is_seed_auto_generated else '(provided)'}")
+        print(
             f"  Reference Date: {self.reference_date.isoformat()} {'(derived from seed)' if self.is_reference_date_auto_generated else '(provided)'}"
         )
-        typer.echo("=" * 60)
-        typer.echo(f"To reproduce: --seed {self.seed} --reference-date {self.reference_date.isoformat()}")
-        typer.echo("=" * 60)
+        print("=" * 60)
+        print(f"To reproduce: --seed {self.seed} --reference-date {self.reference_date.isoformat()}")
+        print("=" * 60)

--- a/synthetic-datasets/synthetic_datasets/config.py
+++ b/synthetic-datasets/synthetic_datasets/config.py
@@ -2,6 +2,8 @@ import random
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
+import typer
+
 
 def derive_reference_date_from_seed(seed: int) -> datetime:
     rng = random.Random(seed)
@@ -30,18 +32,18 @@ class GenerationConfig:
         if seed is None:
             seed = random.randint(0, 2**31 - 1)
             is_seed_auto = True
-            print(f"🌱 Auto-generated seed: {seed} (use --seed {seed} to reproduce)")
+            typer.echo(f"🌱 Auto-generated seed: {seed} (use --seed {seed} to reproduce)")
         else:
             is_seed_auto = False
-            print(f"🌱 Using provided seed: {seed}")
+            typer.echo(f"🌱 Using provided seed: {seed}")
 
         if reference_date is None:
             reference_date = derive_reference_date_from_seed(seed)
             is_date_auto = True
-            print(f"📅 Derived reference date from seed: {reference_date.isoformat()}")
+            typer.echo(f"📅 Derived reference date from seed: {reference_date.isoformat()}")
         else:
             is_date_auto = False
-            print(f"📅 Using provided reference date: {reference_date.isoformat()}")
+            typer.echo(f"📅 Using provided reference date: {reference_date.isoformat()}")
 
         return cls(
             seed=seed,
@@ -51,12 +53,12 @@ class GenerationConfig:
         )
 
     def log_config(self) -> None:
-        print("=" * 60)
-        print("🔧 Generation Configuration")
-        print(f"  Seed: {self.seed} {'(auto-generated)' if self.is_seed_auto_generated else '(provided)'}")
-        print(
+        typer.echo("=" * 60)
+        typer.echo("🔧 Generation Configuration")
+        typer.echo(f"  Seed: {self.seed} {'(auto-generated)' if self.is_seed_auto_generated else '(provided)'}")
+        typer.echo(
             f"  Reference Date: {self.reference_date.isoformat()} {'(derived from seed)' if self.is_reference_date_auto_generated else '(provided)'}"
         )
-        print("=" * 60)
-        print(f"To reproduce: --seed {self.seed} --reference-date {self.reference_date.isoformat()}")
-        print("=" * 60)
+        typer.echo("=" * 60)
+        typer.echo(f"To reproduce: --seed {self.seed} --reference-date {self.reference_date.isoformat()}")
+        typer.echo("=" * 60)

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -7,10 +7,13 @@ from typing import ClassVar, Generic, TypeVar
 import numpy as np
 from faker import Faker
 from rich import print
+from rich.console import Console
 from rich.progress import track
 
 from ..config import GenerationConfig
 from ..models.base import BaseEvent, BaseTrack
+
+_console = Console()
 
 RecordT = TypeVar("RecordT")
 
@@ -44,12 +47,12 @@ class BaseFactory(ABC, Generic[RecordT]):
         )
         print("🎵 Generating music catalog...")
         self._catalog = self._generate_catalog(num_records)
-        print("📈 Generating evolving listening tastes...")
-        self._weighted_tracks = self._generate_weighted_tracks_by_year()
+        with _console.status("📈 Generating listening tastes..."):
+            self._weighted_tracks = self._generate_weighted_tracks_by_year()
         for year, weighted_records in self._weighted_tracks.items():
             print(f" - {year}: {len(weighted_records)} records")
-        print("📅 Generating distribution over year...")
-        self._records_per_year = self._generate_distribution_over_year(num_records)
+        with _console.status("📅 Generating distribution over year..."):
+            self._records_per_year = self._generate_distribution_over_year(num_records)
         for year, n in self._records_per_year.items():
             print(f" - {year}: {n} records")
 

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from typing import ClassVar, Generic, TypeVar
 
 import numpy as np
+import typer
 from faker import Faker
 from tqdm import tqdm
 
@@ -41,25 +42,25 @@ class BaseFactory(ABC, Generic[RecordT]):
             self.SKIP_CHANCE_MAX,
             self.now.year - self.start_year + 1,
         )
-        print("🎵 Generating music catalog...")
+        typer.echo("🎵 Generating music catalog...")
         self._catalog = self._generate_catalog(num_records)
-        print("📈 Generating evolving listening tastes...")
+        typer.echo("📈 Generating evolving listening tastes...")
         self._weighted_tracks = self._generate_weighted_tracks_by_year()
         for year, weighted_records in self._weighted_tracks.items():
-            print(f" - {year}: {len(weighted_records)} records")
-        print("📅 Generating distribution over year...")
+            typer.echo(f" - {year}: {len(weighted_records)} records")
+        typer.echo("📅 Generating distribution over year...")
         self._records_per_year = self._generate_distribution_over_year(num_records)
         for year, n in self._records_per_year.items():
-            print(f" - {year}: {n} records")
+            typer.echo(f" - {year}: {n} records")
 
     def _generate_catalog(self, num_records: int) -> list[BaseTrack]:
         n_artists = max(1, int(num_records * 0.20))
         n_albums = max(1, int(num_records * 0.30))
         n_tracks = max(1, int(num_records * 0.50))
-        print(f" - records: {num_records}")
-        print(f" - artists: {n_artists}")
-        print(f" - albums : {n_albums}")
-        print(f" - tracks : {n_tracks}")
+        typer.echo(f" - records: {num_records}")
+        typer.echo(f" - artists: {n_artists}")
+        typer.echo(f" - albums : {n_albums}")
+        typer.echo(f" - tracks : {n_tracks}")
 
         artists = [self.faker.name() for _ in range(n_artists)]
         albums = [self.faker.catch_phrase() for _ in range(n_albums)]

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -5,8 +5,8 @@ from datetime import datetime, timedelta
 from typing import ClassVar, Generic, TypeVar
 
 import numpy as np
-import typer
 from faker import Faker
+from rich import print
 from rich.progress import track
 
 from ..config import GenerationConfig
@@ -42,25 +42,25 @@ class BaseFactory(ABC, Generic[RecordT]):
             self.SKIP_CHANCE_MAX,
             self.now.year - self.start_year + 1,
         )
-        typer.echo("🎵 Generating music catalog...")
+        print("🎵 Generating music catalog...")
         self._catalog = self._generate_catalog(num_records)
-        typer.echo("📈 Generating evolving listening tastes...")
+        print("📈 Generating evolving listening tastes...")
         self._weighted_tracks = self._generate_weighted_tracks_by_year()
         for year, weighted_records in self._weighted_tracks.items():
-            typer.echo(f" - {year}: {len(weighted_records)} records")
-        typer.echo("📅 Generating distribution over year...")
+            print(f" - {year}: {len(weighted_records)} records")
+        print("📅 Generating distribution over year...")
         self._records_per_year = self._generate_distribution_over_year(num_records)
         for year, n in self._records_per_year.items():
-            typer.echo(f" - {year}: {n} records")
+            print(f" - {year}: {n} records")
 
     def _generate_catalog(self, num_records: int) -> list[BaseTrack]:
         n_artists = max(1, int(num_records * 0.20))
         n_albums = max(1, int(num_records * 0.30))
         n_tracks = max(1, int(num_records * 0.50))
-        typer.echo(f" - records: {num_records}")
-        typer.echo(f" - artists: {n_artists}")
-        typer.echo(f" - albums : {n_albums}")
-        typer.echo(f" - tracks : {n_tracks}")
+        print(f" - records: {num_records}")
+        print(f" - artists: {n_artists}")
+        print(f" - albums : {n_albums}")
+        print(f" - tracks : {n_tracks}")
 
         artists = [self.faker.name() for _ in range(n_artists)]
         albums = [self.faker.catch_phrase() for _ in range(n_albums)]

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -60,10 +60,7 @@ class BaseFactory(ABC, Generic[RecordT]):
         n_artists = max(1, int(num_records * 0.20))
         n_albums = max(1, int(num_records * 0.30))
         n_tracks = max(1, int(num_records * 0.50))
-        print(f" - records: {num_records}")
-        print(f" - artists: {n_artists}")
-        print(f" - albums : {n_albums}")
-        print(f" - tracks : {n_tracks}")
+        print(f" - {num_records} records → {n_artists} artists, {n_albums} albums, {n_tracks} tracks")
 
         artists = [self.faker.name() for _ in range(n_artists)]
         albums = [self.faker.catch_phrase() for _ in range(n_albums)]
@@ -74,7 +71,7 @@ class BaseFactory(ABC, Generic[RecordT]):
                 album=self.rng.choice(albums),
                 duration_ms=self.rng.randint(self.TRACK_DURATION_MIN_MS, self.TRACK_DURATION_MAX_MS),
             )
-            for _ in range(n_tracks)
+            for _ in track(range(n_tracks), description=" - Generating tracks")
         ]
 
     @abstractmethod

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -8,7 +8,7 @@ import numpy as np
 from faker import Faker
 from rich import print
 from rich.console import Console
-from rich.progress import track
+from rich.progress import Progress, track
 
 from ..config import GenerationConfig
 from ..models.base import BaseEvent, BaseTrack
@@ -137,25 +137,29 @@ class BaseFactory(ABC, Generic[RecordT]):
         return weighted_tracks_by_year
 
     def _generate_base_events(self) -> list[BaseEvent]:
+        total = sum(self._records_per_year.values())
         events: list[BaseEvent] = []
-        for year, count in self._records_per_year.items():
-            skip_chance = self.skip_chance_trend[year - self.start_year]
-            for _ in range(count):
-                ts = self._get_random_datetime_for_year(year)
-                track_index = self.rng.choice(self._weighted_tracks[year])
-                is_skipped = self.rng.random() < skip_chance
-                if is_skipped:
-                    duration_ratio = self.rng.uniform(0.05, 0.30)
-                else:
-                    duration_ratio = self.rng.uniform(0.90, 1.00)
-                events.append(
-                    BaseEvent(
-                        timestamp=ts,
-                        track_index=track_index,
-                        is_skipped=is_skipped,
-                        duration_ratio=duration_ratio,
+        with Progress() as progress:
+            task = progress.add_task("📅 Generating events...", total=total)
+            for year, count in self._records_per_year.items():
+                skip_chance = self.skip_chance_trend[year - self.start_year]
+                for _ in range(count):
+                    ts = self._get_random_datetime_for_year(year)
+                    track_index = self.rng.choice(self._weighted_tracks[year])
+                    is_skipped = self.rng.random() < skip_chance
+                    if is_skipped:
+                        duration_ratio = self.rng.uniform(0.05, 0.30)
+                    else:
+                        duration_ratio = self.rng.uniform(0.90, 1.00)
+                    events.append(
+                        BaseEvent(
+                            timestamp=ts,
+                            track_index=track_index,
+                            is_skipped=is_skipped,
+                            duration_ratio=duration_ratio,
+                        )
                     )
-                )
+                    progress.advance(task)
         return sorted(events, key=lambda e: e.timestamp)
 
     def create_streaming_history(self) -> list[RecordT]:

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -7,7 +7,7 @@ from typing import ClassVar, Generic, TypeVar
 import numpy as np
 from faker import Faker
 from rich import get_console, print
-from rich.progress import Progress, track
+from rich.progress import track
 
 from ..config import GenerationConfig
 from ..models.base import BaseEvent, BaseTrack
@@ -46,12 +46,12 @@ class BaseFactory(ABC, Generic[RecordT]):
         )
         print("🎵 Generating music catalog...")
         self._catalog = self._generate_catalog(num_records)
-        with _console.status("📈 Generating listening tastes..."):
-            self._weighted_tracks = self._generate_weighted_tracks_by_year()
+        print("📈 Generating listening tastes...")
+        self._weighted_tracks = self._generate_weighted_tracks_by_year()
         for year, weighted_records in self._weighted_tracks.items():
             print(f" - {year}: {len(weighted_records)} records")
-        with _console.status("📅 Generating distribution over year..."):
-            self._records_per_year = self._generate_distribution_over_year(num_records)
+        print("📅 Generating distribution over year...")
+        self._records_per_year = self._generate_distribution_over_year(num_records)
         for year, n in self._records_per_year.items():
             print(f" - {year}: {n} records")
 
@@ -59,19 +59,25 @@ class BaseFactory(ABC, Generic[RecordT]):
         n_artists = max(1, int(num_records * 0.20))
         n_albums = max(1, int(num_records * 0.30))
         n_tracks = max(1, int(num_records * 0.50))
-        print(f" - {num_records} records → {n_artists} artists, {n_albums} albums, {n_tracks} tracks")
+        print(f" - {num_records} records")
+        print(f" - {n_artists} artists")
+        print(f" - {n_albums} albums")
+        print(f" - {n_tracks} tracks")
 
-        artists = [self.faker.name() for _ in range(n_artists)]
-        albums = [self.faker.catch_phrase() for _ in range(n_albums)]
-        return [
-            BaseTrack(
-                title=self.faker.bs(),
-                artist=self.rng.choice(artists),
-                album=self.rng.choice(albums),
-                duration_ms=self.rng.randint(self.TRACK_DURATION_MIN_MS, self.TRACK_DURATION_MAX_MS),
-            )
-            for _ in track(range(n_tracks), description=" - Generating tracks")
-        ]
+        with _console.status("Generating artists..."):
+            artists = [self.faker.name() for _ in range(n_artists)]
+        with _console.status("Generating albums..."):
+            albums = [self.faker.catch_phrase() for _ in range(n_albums)]
+        with _console.status("Generating tracks..."):
+            return [
+                BaseTrack(
+                    title=self.faker.bs(),
+                    artist=self.rng.choice(artists),
+                    album=self.rng.choice(albums),
+                    duration_ms=self.rng.randint(self.TRACK_DURATION_MIN_MS, self.TRACK_DURATION_MAX_MS),
+                )
+                for _ in range(n_tracks)
+            ]
 
     @abstractmethod
     def _map_event(self, event: BaseEvent) -> RecordT: ...
@@ -136,29 +142,26 @@ class BaseFactory(ABC, Generic[RecordT]):
         return weighted_tracks_by_year
 
     def _generate_base_events(self) -> list[BaseEvent]:
-        total = sum(self._records_per_year.values())
         events: list[BaseEvent] = []
-        with Progress() as progress:
-            task = progress.add_task("📅 Generating events...", total=total)
-            for year, count in self._records_per_year.items():
-                skip_chance = self.skip_chance_trend[year - self.start_year]
-                for _ in range(count):
-                    ts = self._get_random_datetime_for_year(year)
-                    track_index = self.rng.choice(self._weighted_tracks[year])
-                    is_skipped = self.rng.random() < skip_chance
-                    if is_skipped:
-                        duration_ratio = self.rng.uniform(0.05, 0.30)
-                    else:
-                        duration_ratio = self.rng.uniform(0.90, 1.00)
-                    events.append(
-                        BaseEvent(
-                            timestamp=ts,
-                            track_index=track_index,
-                            is_skipped=is_skipped,
-                            duration_ratio=duration_ratio,
-                        )
+        print("📅 Generating events...")
+        for year, count in self._records_per_year.items():
+            skip_chance = self.skip_chance_trend[year - self.start_year]
+            for _ in track(range(count), description=f" - {year}"):
+                ts = self._get_random_datetime_for_year(year)
+                track_index = self.rng.choice(self._weighted_tracks[year])
+                is_skipped = self.rng.random() < skip_chance
+                if is_skipped:
+                    duration_ratio = self.rng.uniform(0.05, 0.30)
+                else:
+                    duration_ratio = self.rng.uniform(0.90, 1.00)
+                events.append(
+                    BaseEvent(
+                        timestamp=ts,
+                        track_index=track_index,
+                        is_skipped=is_skipped,
+                        duration_ratio=duration_ratio,
                     )
-                    progress.advance(task)
+                )
         return sorted(events, key=lambda e: e.timestamp)
 
     def create_streaming_history(self) -> list[RecordT]:

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -6,14 +6,13 @@ from typing import ClassVar, Generic, TypeVar
 
 import numpy as np
 from faker import Faker
-from rich import print
-from rich.console import Console
+from rich import get_console, print
 from rich.progress import Progress, track
 
 from ..config import GenerationConfig
 from ..models.base import BaseEvent, BaseTrack
 
-_console = Console()
+_console = get_console()
 
 RecordT = TypeVar("RecordT")
 

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -7,7 +7,7 @@ from typing import ClassVar, Generic, TypeVar
 import numpy as np
 import typer
 from faker import Faker
-from tqdm import tqdm
+from rich.progress import track
 
 from ..config import GenerationConfig
 from ..models.base import BaseEvent, BaseTrack
@@ -160,4 +160,4 @@ class BaseFactory(ABC, Generic[RecordT]):
 
     def create_streaming_history(self) -> list[RecordT]:
         events = self._generate_base_events()
-        return [self._map_event(e) for e in tqdm(events, desc="💿 Generating streamings", leave=True)]
+        return [self._map_event(e) for e in track(events, description="💿 Generating streamings")]

--- a/synthetic-datasets/synthetic_datasets/factories/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/factories/deezer.py
@@ -3,11 +3,14 @@ from dataclasses import dataclass
 from ipaddress import ip_address
 
 from rich import print
+from rich.console import Console
 
 from ..config import GenerationConfig
 from ..models.base import BaseEvent
 from ..models.deezer import DeezerStreaming
 from .base import BaseFactory
+
+_console = Console()
 
 
 @dataclass
@@ -23,17 +26,17 @@ class DeezerFactory(BaseFactory[DeezerStreaming]):
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         super().__init__(num_records, config)
 
-        print("🎵 Enriching Deezer catalog...")
-        self._deezer_catalog: list[_DeezerTrack] = [
-            _DeezerTrack(
-                isrc=self._generate_isrc(),
-                title=t.title,
-                artist=t.artist,
-                album_title=t.album,
-                duration_sec=t.duration_ms // 1000,
-            )
-            for t in self._catalog
-        ]
+        with _console.status("🎵 Enriching Deezer catalog..."):
+            self._deezer_catalog: list[_DeezerTrack] = [
+                _DeezerTrack(
+                    isrc=self._generate_isrc(),
+                    title=t.title,
+                    artist=t.artist,
+                    album_title=t.album,
+                    duration_sec=t.duration_ms // 1000,
+                )
+                for t in self._catalog
+            ]
 
         print("💻 Generating platforms...")
         self.platforms = ["web", "ios", "android", "desktop", "tv"]

--- a/synthetic-datasets/synthetic_datasets/factories/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/factories/deezer.py
@@ -2,15 +2,14 @@ import string
 from dataclasses import dataclass
 from ipaddress import ip_address
 
-from rich import print
-from rich.console import Console
+from rich import get_console, print
 
 from ..config import GenerationConfig
 from ..models.base import BaseEvent
 from ..models.deezer import DeezerStreaming
 from .base import BaseFactory
 
-_console = Console()
+_console = get_console()
 
 
 @dataclass

--- a/synthetic-datasets/synthetic_datasets/factories/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/factories/deezer.py
@@ -2,7 +2,7 @@ import string
 from dataclasses import dataclass
 from ipaddress import ip_address
 
-import typer
+from rich import print
 
 from ..config import GenerationConfig
 from ..models.base import BaseEvent
@@ -23,7 +23,7 @@ class DeezerFactory(BaseFactory[DeezerStreaming]):
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         super().__init__(num_records, config)
 
-        typer.echo("🎵 Enriching Deezer catalog...")
+        print("🎵 Enriching Deezer catalog...")
         self._deezer_catalog: list[_DeezerTrack] = [
             _DeezerTrack(
                 isrc=self._generate_isrc(),
@@ -35,10 +35,10 @@ class DeezerFactory(BaseFactory[DeezerStreaming]):
             for t in self._catalog
         ]
 
-        typer.echo("💻 Generating platforms...")
+        print("💻 Generating platforms...")
         self.platforms = ["web", "ios", "android", "desktop", "tv"]
 
-        typer.echo("🛜 Generating IPs...")
+        print("🛜 Generating IPs...")
         self.ip_addresses = [ip_address(self.faker.ipv4()) for _ in range(20)]
 
     def _generate_isrc(self) -> str:

--- a/synthetic-datasets/synthetic_datasets/factories/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/factories/deezer.py
@@ -25,17 +25,17 @@ class DeezerFactory(BaseFactory[DeezerStreaming]):
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         super().__init__(num_records, config)
 
-        with _console.status("🎵 Enriching Deezer catalog..."):
-            self._deezer_catalog: list[_DeezerTrack] = [
-                _DeezerTrack(
-                    isrc=self._generate_isrc(),
-                    title=t.title,
-                    artist=t.artist,
-                    album_title=t.album,
-                    duration_sec=t.duration_ms // 1000,
-                )
-                for t in self._catalog
-            ]
+        print("🎵 Enriching Deezer catalog...")
+        self._deezer_catalog: list[_DeezerTrack] = [
+            _DeezerTrack(
+                isrc=self._generate_isrc(),
+                title=t.title,
+                artist=t.artist,
+                album_title=t.album,
+                duration_sec=t.duration_ms // 1000,
+            )
+            for t in self._catalog
+        ]
 
         print("💻 Generating platforms...")
         self.platforms = ["web", "ios", "android", "desktop", "tv"]

--- a/synthetic-datasets/synthetic_datasets/factories/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/factories/deezer.py
@@ -2,6 +2,8 @@ import string
 from dataclasses import dataclass
 from ipaddress import ip_address
 
+import typer
+
 from ..config import GenerationConfig
 from ..models.base import BaseEvent
 from ..models.deezer import DeezerStreaming
@@ -21,7 +23,7 @@ class DeezerFactory(BaseFactory[DeezerStreaming]):
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         super().__init__(num_records, config)
 
-        print("🎵 Enriching Deezer catalog...")
+        typer.echo("🎵 Enriching Deezer catalog...")
         self._deezer_catalog: list[_DeezerTrack] = [
             _DeezerTrack(
                 isrc=self._generate_isrc(),
@@ -33,10 +35,10 @@ class DeezerFactory(BaseFactory[DeezerStreaming]):
             for t in self._catalog
         ]
 
-        print("💻 Generating platforms...")
+        typer.echo("💻 Generating platforms...")
         self.platforms = ["web", "ios", "android", "desktop", "tv"]
 
-        print("🛜 Generating IPs...")
+        typer.echo("🛜 Generating IPs...")
         self.ip_addresses = [ip_address(self.faker.ipv4()) for _ in range(20)]
 
     def _generate_isrc(self) -> str:

--- a/synthetic-datasets/synthetic_datasets/factories/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/factories/spotify.py
@@ -2,6 +2,8 @@ from datetime import timedelta
 from ipaddress import ip_address
 from typing import ClassVar
 
+import typer
+
 from ..config import GenerationConfig
 from ..models.base import BaseEvent
 from ..models.spotify import Album, Artist, ReasonEndEnum, ReasonStartEnum, Streaming, Track
@@ -19,7 +21,7 @@ class SpotifyFactory(BaseFactory[Streaming]):
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         super().__init__(num_records, config)
 
-        print("🎵 Enriching Spotify catalog...")
+        typer.echo("🎵 Enriching Spotify catalog...")
         self._spotify_catalog: list[Track] = [
             Track(
                 uri=f"spotify:track:{self.faker.uuid4().replace('-', '')[:22]}",
@@ -37,7 +39,7 @@ class SpotifyFactory(BaseFactory[Streaming]):
         num_countries = 5
         num_ip_addresses = 20
 
-        print("💻 Generating platforms...")
+        typer.echo("💻 Generating platforms...")
         self.platforms = [
             self.faker.random_element(
                 [
@@ -51,9 +53,9 @@ class SpotifyFactory(BaseFactory[Streaming]):
             for _ in range(0, num_platforms)
         ]
 
-        print("🌏 Generating country codes...")
+        typer.echo("🌏 Generating country codes...")
         self.countries = [self.faker.country_code() for _ in range(0, num_countries)]
-        print("🛜 Generating IPs...")
+        typer.echo("🛜 Generating IPs...")
         self.ip_addr = [ip_address(self.faker.ipv4()) for _ in range(0, num_ip_addresses)]
 
     def _map_event(self, event: BaseEvent) -> Streaming:

--- a/synthetic-datasets/synthetic_datasets/factories/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/factories/spotify.py
@@ -23,19 +23,16 @@ class SpotifyFactory(BaseFactory[Streaming]):
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         super().__init__(num_records, config)
 
-        with _console.status("🎵 Enriching Spotify catalog..."):
-            self._spotify_catalog: list[Track] = [
-                Track(
-                    uri=f"spotify:track:{self.faker.uuid4().replace('-', '')[:22]}",
-                    name=t.title,
-                    album=Album(
-                        name=t.album,
-                        artist=Artist(name=t.artist),
-                    ),
-                    duration_ms=t.duration_ms,
-                )
-                for t in self._catalog
-            ]
+        print("🎵 Enriching Spotify catalog...")
+        self._spotify_catalog: list[Track] = [
+            Track(
+                uri=f"spotify:track:{self.faker.uuid4().replace('-', '')[:22]}",
+                name=t.title,
+                album=Album(name=t.album, artist=Artist(name=t.artist)),
+                duration_ms=t.duration_ms,
+            )
+            for t in self._catalog
+        ]
 
         num_platforms = 5
         num_countries = 5

--- a/synthetic-datasets/synthetic_datasets/factories/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/factories/spotify.py
@@ -3,11 +3,14 @@ from ipaddress import ip_address
 from typing import ClassVar
 
 from rich import print
+from rich.console import Console
 
 from ..config import GenerationConfig
 from ..models.base import BaseEvent
 from ..models.spotify import Album, Artist, ReasonEndEnum, ReasonStartEnum, Streaming, Track
 from .base import BaseFactory
+
+_console = Console()
 
 
 class SpotifyFactory(BaseFactory[Streaming]):
@@ -21,19 +24,19 @@ class SpotifyFactory(BaseFactory[Streaming]):
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         super().__init__(num_records, config)
 
-        print("🎵 Enriching Spotify catalog...")
-        self._spotify_catalog: list[Track] = [
-            Track(
-                uri=f"spotify:track:{self.faker.uuid4().replace('-', '')[:22]}",
-                name=t.title,
-                album=Album(
-                    name=t.album,
-                    artist=Artist(name=t.artist),
-                ),
-                duration_ms=t.duration_ms,
-            )
-            for t in self._catalog
-        ]
+        with _console.status("🎵 Enriching Spotify catalog..."):
+            self._spotify_catalog: list[Track] = [
+                Track(
+                    uri=f"spotify:track:{self.faker.uuid4().replace('-', '')[:22]}",
+                    name=t.title,
+                    album=Album(
+                        name=t.album,
+                        artist=Artist(name=t.artist),
+                    ),
+                    duration_ms=t.duration_ms,
+                )
+                for t in self._catalog
+            ]
 
         num_platforms = 5
         num_countries = 5

--- a/synthetic-datasets/synthetic_datasets/factories/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/factories/spotify.py
@@ -2,15 +2,14 @@ from datetime import timedelta
 from ipaddress import ip_address
 from typing import ClassVar
 
-from rich import print
-from rich.console import Console
+from rich import get_console, print
 
 from ..config import GenerationConfig
 from ..models.base import BaseEvent
 from ..models.spotify import Album, Artist, ReasonEndEnum, ReasonStartEnum, Streaming, Track
 from .base import BaseFactory
 
-_console = Console()
+_console = get_console()
 
 
 class SpotifyFactory(BaseFactory[Streaming]):

--- a/synthetic-datasets/synthetic_datasets/factories/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/factories/spotify.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from ipaddress import ip_address
 from typing import ClassVar
 
-import typer
+from rich import print
 
 from ..config import GenerationConfig
 from ..models.base import BaseEvent
@@ -21,7 +21,7 @@ class SpotifyFactory(BaseFactory[Streaming]):
     def __init__(self, num_records: int, config: GenerationConfig) -> None:
         super().__init__(num_records, config)
 
-        typer.echo("🎵 Enriching Spotify catalog...")
+        print("🎵 Enriching Spotify catalog...")
         self._spotify_catalog: list[Track] = [
             Track(
                 uri=f"spotify:track:{self.faker.uuid4().replace('-', '')[:22]}",
@@ -39,7 +39,7 @@ class SpotifyFactory(BaseFactory[Streaming]):
         num_countries = 5
         num_ip_addresses = 20
 
-        typer.echo("💻 Generating platforms...")
+        print("💻 Generating platforms...")
         self.platforms = [
             self.faker.random_element(
                 [
@@ -53,9 +53,9 @@ class SpotifyFactory(BaseFactory[Streaming]):
             for _ in range(0, num_platforms)
         ]
 
-        typer.echo("🌏 Generating country codes...")
+        print("🌏 Generating country codes...")
         self.countries = [self.faker.country_code() for _ in range(0, num_countries)]
-        typer.echo("🛜 Generating IPs...")
+        print("🛜 Generating IPs...")
         self.ip_addr = [ip_address(self.faker.ipv4()) for _ in range(0, num_ip_addresses)]
 
     def _map_event(self, event: BaseEvent) -> Streaming:

--- a/synthetic-datasets/synthetic_datasets/writers/apple_music.py
+++ b/synthetic-datasets/synthetic_datasets/writers/apple_music.py
@@ -28,9 +28,7 @@ class AppleMusicWriter:
         self.reference_date = reference_date
 
     def write(self, records: list[AppleMusicRecord]) -> None:
-        print(
-            f"Write `csv` file: status: `starting`, path: `{self.output_path.absolute()}`, count_records: `{len(records)}`"
-        )
+        print(f"Write csv: [yellow]starting[/yellow] {self.output_path.absolute()} ({len(records)} records)")
         self.output_path.parent.mkdir(parents=True, exist_ok=True)
         with open(self.output_path, "w", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=COLUMNS)
@@ -48,6 +46,4 @@ class AppleMusicWriter:
                         "Container Origin Type": record.container_origin_type or self.NULL_VALUE,
                     }
                 )
-        print(
-            f"Write `csv` file: status: `success`, path: `{self.output_path.absolute()}`, count_records: `{len(records)}`"
-        )
+        print(f"Write csv: [green]success[/green] {self.output_path.absolute()} ({len(records)} records)")

--- a/synthetic-datasets/synthetic_datasets/writers/apple_music.py
+++ b/synthetic-datasets/synthetic_datasets/writers/apple_music.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import ClassVar
 
+import typer
 from tqdm import tqdm
 
 from ..models.apple_music import AppleMusicRecord
@@ -27,7 +28,7 @@ class AppleMusicWriter:
         self.reference_date = reference_date
 
     def write(self, records: list[AppleMusicRecord]) -> None:
-        print(
+        typer.echo(
             f"Write `csv` file: status: `starting`, path: `{self.output_path.absolute()}`, count_records: `{len(records)}`"
         )
         self.output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -51,6 +52,6 @@ class AppleMusicWriter:
                         "Container Origin Type": record.container_origin_type or self.NULL_VALUE,
                     }
                 )
-        print(
+        typer.echo(
             f"Write `csv` file: status: `success`, path: `{self.output_path.absolute()}`, count_records: `{len(records)}`"
         )

--- a/synthetic-datasets/synthetic_datasets/writers/apple_music.py
+++ b/synthetic-datasets/synthetic_datasets/writers/apple_music.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import ClassVar
 
-import typer
+from rich import print
 from rich.progress import track
 
 from ..models.apple_music import AppleMusicRecord
@@ -28,7 +28,7 @@ class AppleMusicWriter:
         self.reference_date = reference_date
 
     def write(self, records: list[AppleMusicRecord]) -> None:
-        typer.echo(
+        print(
             f"Write `csv` file: status: `starting`, path: `{self.output_path.absolute()}`, count_records: `{len(records)}`"
         )
         self.output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -48,6 +48,6 @@ class AppleMusicWriter:
                         "Container Origin Type": record.container_origin_type or self.NULL_VALUE,
                     }
                 )
-        typer.echo(
+        print(
             f"Write `csv` file: status: `success`, path: `{self.output_path.absolute()}`, count_records: `{len(records)}`"
         )

--- a/synthetic-datasets/synthetic_datasets/writers/apple_music.py
+++ b/synthetic-datasets/synthetic_datasets/writers/apple_music.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import ClassVar
 
 import typer
-from tqdm import tqdm
+from rich.progress import track
 
 from ..models.apple_music import AppleMusicRecord
 
@@ -35,11 +35,7 @@ class AppleMusicWriter:
         with open(self.output_path, "w", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=COLUMNS)
             writer.writeheader()
-            for record in tqdm(
-                records,
-                desc=f"📦 Writing {self.output_path.name}",
-                unit=" records",
-            ):
+            for record in track(records, description=f"📦 Writing {self.output_path.name}"):
                 writer.writerow(
                     {
                         "Event Start Timestamp": record.serialize_event_start_timestamp(record.event_start_timestamp),

--- a/synthetic-datasets/synthetic_datasets/writers/apple_music.py
+++ b/synthetic-datasets/synthetic_datasets/writers/apple_music.py
@@ -3,10 +3,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import ClassVar
 
-from rich import print
+from rich import get_console, print
 from rich.progress import track
 
 from ..models.apple_music import AppleMusicRecord
+
+_console = get_console()
 
 COLUMNS = [
     "Event Start Timestamp",
@@ -28,22 +30,24 @@ class AppleMusicWriter:
         self.reference_date = reference_date
 
     def write(self, records: list[AppleMusicRecord]) -> None:
-        print(f"Write csv: [yellow]starting[/yellow] {self.output_path.absolute()} ({len(records)} records)")
-        self.output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(self.output_path, "w", newline="", encoding="utf-8") as f:
-            writer = csv.DictWriter(f, fieldnames=COLUMNS)
-            writer.writeheader()
-            for record in track(records, description=f"📦 Writing {self.output_path.name}"):
-                writer.writerow(
-                    {
-                        "Event Start Timestamp": record.serialize_event_start_timestamp(record.event_start_timestamp),
-                        "Song Name": record.song_name,
-                        "Album Name": record.album_name,
-                        "Container Artist Name": self.NULL_VALUE,
-                        "Media Type": record.media_type,
-                        "Play Duration Milliseconds": str(record.play_duration_ms),
-                        "Device Type": record.device_type,
-                        "Container Origin Type": record.container_origin_type or self.NULL_VALUE,
-                    }
-                )
-        print(f"Write csv: [green]success[/green] {self.output_path.absolute()} ({len(records)} records)")
+        with _console.status("🖍️ Writing csv..."):
+            self.output_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.output_path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(f, fieldnames=COLUMNS)
+                writer.writeheader()
+                for record in track(records, description=f"📦 Writing {self.output_path.name}"):
+                    writer.writerow(
+                        {
+                            "Event Start Timestamp": record.serialize_event_start_timestamp(
+                                record.event_start_timestamp
+                            ),
+                            "Song Name": record.song_name,
+                            "Album Name": record.album_name,
+                            "Container Artist Name": self.NULL_VALUE,
+                            "Media Type": record.media_type,
+                            "Play Duration Milliseconds": str(record.play_duration_ms),
+                            "Device Type": record.device_type,
+                            "Container Origin Type": record.container_origin_type or self.NULL_VALUE,
+                        }
+                    )
+        print(f"🖍️ Write csv: [green]success[/green] {self.output_path.absolute()} ({len(records)} records)")

--- a/synthetic-datasets/synthetic_datasets/writers/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/writers/deezer.py
@@ -2,10 +2,12 @@ from datetime import datetime
 from pathlib import Path
 
 import openpyxl
-from rich import print
+from rich import get_console, print
 from rich.progress import track
 
 from ..models.deezer import DeezerStreaming
+
+_console = get_console()
 
 SHEET_NAME = "10_listeningHistory"
 COLUMNS = [
@@ -30,9 +32,9 @@ class DeezerWriter:
     def write(self, records: list[DeezerStreaming]) -> None:
         timestamp = int(self.reference_date.timestamp())
         xlsx_path = Path(self.xlsx_path_template.format(timestamp=timestamp))
-        print(f"Write xlsx: [yellow]starting[/yellow] {xlsx_path.absolute()} ({len(records)} records)")
-        write_xlsx(xlsx_path, records, self.reference_date)
-        print(f"Write xlsx: [green]success[/green] {xlsx_path.absolute()} ({len(records)} records)")
+        with _console.status("🖍️ Writing xlsx..."):
+            write_xlsx(xlsx_path, records, self.reference_date)
+        print(f"🖍️ Write xlsx: [green]success[/green] {xlsx_path.absolute()} ({len(records)} records)")
 
 
 def write_xlsx(path: Path, streamings: list[DeezerStreaming], date: datetime) -> None:

--- a/synthetic-datasets/synthetic_datasets/writers/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/writers/deezer.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pathlib import Path
 
 import openpyxl
+import typer
 from tqdm import tqdm
 
 from ..models.deezer import DeezerStreaming
@@ -29,9 +30,13 @@ class DeezerWriter:
     def write(self, records: list[DeezerStreaming]) -> None:
         timestamp = int(self.reference_date.timestamp())
         xlsx_path = Path(self.xlsx_path_template.format(timestamp=timestamp))
-        print(f"Write `xlsx` file: status: `starting`, path: `{xlsx_path.absolute()}`, count_records: `{len(records)}`")
+        typer.echo(
+            f"Write `xlsx` file: status: `starting`, path: `{xlsx_path.absolute()}`, count_records: `{len(records)}`"
+        )
         write_xlsx(xlsx_path, records, self.reference_date)
-        print(f"Write `xlsx` file: status: `success`, path: `{xlsx_path.absolute()}`, count_records: `{len(records)}`")
+        typer.echo(
+            f"Write `xlsx` file: status: `success`, path: `{xlsx_path.absolute()}`, count_records: `{len(records)}`"
+        )
 
 
 def write_xlsx(path: Path, streamings: list[DeezerStreaming], date: datetime) -> None:

--- a/synthetic-datasets/synthetic_datasets/writers/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/writers/deezer.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from pathlib import Path
 
 import openpyxl
-import typer
+from rich import print
 from rich.progress import track
 
 from ..models.deezer import DeezerStreaming
@@ -30,13 +30,9 @@ class DeezerWriter:
     def write(self, records: list[DeezerStreaming]) -> None:
         timestamp = int(self.reference_date.timestamp())
         xlsx_path = Path(self.xlsx_path_template.format(timestamp=timestamp))
-        typer.echo(
-            f"Write `xlsx` file: status: `starting`, path: `{xlsx_path.absolute()}`, count_records: `{len(records)}`"
-        )
+        print(f"Write `xlsx` file: status: `starting`, path: `{xlsx_path.absolute()}`, count_records: `{len(records)}`")
         write_xlsx(xlsx_path, records, self.reference_date)
-        typer.echo(
-            f"Write `xlsx` file: status: `success`, path: `{xlsx_path.absolute()}`, count_records: `{len(records)}`"
-        )
+        print(f"Write `xlsx` file: status: `success`, path: `{xlsx_path.absolute()}`, count_records: `{len(records)}`")
 
 
 def write_xlsx(path: Path, streamings: list[DeezerStreaming], date: datetime) -> None:

--- a/synthetic-datasets/synthetic_datasets/writers/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/writers/deezer.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import openpyxl
 import typer
-from tqdm import tqdm
+from rich.progress import track
 
 from ..models.deezer import DeezerStreaming
 
@@ -53,7 +53,7 @@ def write_xlsx(path: Path, streamings: list[DeezerStreaming], date: datetime) ->
 
     ws.append(COLUMNS)
 
-    for streaming in tqdm(streamings, desc=f"📦 Writing {path.name}", unit=" records"):
+    for streaming in track(streamings, description=f"📦 Writing {path.name}"):
         ws.append(
             [
                 streaming.song_title,

--- a/synthetic-datasets/synthetic_datasets/writers/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/writers/deezer.py
@@ -30,9 +30,9 @@ class DeezerWriter:
     def write(self, records: list[DeezerStreaming]) -> None:
         timestamp = int(self.reference_date.timestamp())
         xlsx_path = Path(self.xlsx_path_template.format(timestamp=timestamp))
-        print(f"Write `xlsx` file: status: `starting`, path: `{xlsx_path.absolute()}`, count_records: `{len(records)}`")
+        print(f"Write xlsx: [yellow]starting[/yellow] {xlsx_path.absolute()} ({len(records)} records)")
         write_xlsx(xlsx_path, records, self.reference_date)
-        print(f"Write `xlsx` file: status: `success`, path: `{xlsx_path.absolute()}`, count_records: `{len(records)}`")
+        print(f"Write xlsx: [green]success[/green] {xlsx_path.absolute()} ({len(records)} records)")
 
 
 def write_xlsx(path: Path, streamings: list[DeezerStreaming], date: datetime) -> None:

--- a/synthetic-datasets/synthetic_datasets/writers/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/writers/spotify.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 
 import typer
-from tqdm import tqdm
+from rich.progress import track
 
 from ..models.spotify import Streaming
 
@@ -49,8 +49,7 @@ class SpotifyWriter:
 
 def write_json(path: Path, streamings: list[Streaming]):
     data = [
-        streaming.model_dump(mode="json")
-        for streaming in tqdm(streamings, desc=f"📦 Preparing {path.name}", unit=" records")
+        streaming.model_dump(mode="json") for streaming in track(streamings, description=f"📦 Preparing {path.name}")
     ]
 
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -65,7 +64,7 @@ def write_zip(path: Path, files_to_add: dict[str, list[Streaming]], base_zipped_
     sorted_files = sorted(files_to_add.items())
 
     with ZipFile(path, "w", ZIP_DEFLATED, compresslevel=6) as myzip:
-        for filename, streamings in tqdm(sorted_files, desc="🗜️ Zipping files", unit=" file"):
+        for filename, streamings in track(sorted_files, description="🗜️ Zipping files"):
             data = [streaming.model_dump(mode="json") for streaming in streamings]
             json_content = json.dumps(data, indent=4, sort_keys=True)
 

--- a/synthetic-datasets/synthetic_datasets/writers/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/writers/spotify.py
@@ -4,9 +4,12 @@ from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 
 from rich import print
+from rich.console import Console
 from rich.progress import track
 
 from ..models.spotify import Streaming
+
+_console = Console()
 
 
 class SpotifyWriter:
@@ -57,8 +60,8 @@ def write_zip(path: Path, files_to_add: dict[str, list[Streaming]], base_zipped_
 
     sorted_files = sorted(files_to_add.items())
 
-    with ZipFile(path, "w", ZIP_DEFLATED, compresslevel=6) as myzip:
-        for filename, streamings in track(sorted_files, description="🗜️ Zipping files"):
+    with _console.status("🗜️ Zipping files..."), ZipFile(path, "w", ZIP_DEFLATED, compresslevel=6) as myzip:
+        for filename, streamings in sorted_files:
             data = [streaming.model_dump(mode="json") for streaming in streamings]
             json_content = json.dumps(data, indent=4, sort_keys=True)
 

--- a/synthetic-datasets/synthetic_datasets/writers/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/writers/spotify.py
@@ -24,9 +24,9 @@ class SpotifyWriter:
 
     def write(self, records):
         json_path = Path(self.json_path_template.format(num_records=str(len(records))))
-        print(f"Write json: [yellow]starting[/yellow] {json_path.absolute()} ({len(records)} records)")
-        write_json(json_path, records)
-        print(f"Write json: [green]success[/green] {json_path.absolute()} ({len(records)} records)")
+        with _console.status("🖍️ Writing json..."):
+            write_json(json_path, records)
+        print(f"🖍️ Write json: [green]success[/green] {json_path.absolute()} ({len(records)} records)")
 
         chunk_size = int(max(len(records) / max(len(records) / self.max_chunk_size, 4), 10))
         files_for_chunked_zip = {}
@@ -38,9 +38,9 @@ class SpotifyWriter:
             files_for_chunked_zip[filename] = chunk
 
         zip_path = Path(self.zip_path_template.format(num_records=str(len(records))))
-        print(f"Write zip: [yellow]starting[/yellow] {zip_path.absolute()} ({len(files_for_chunked_zip)} files)")
-        write_zip(zip_path, files_for_chunked_zip, self.chunked_zip_folder, self.reference_date)
-        print(f"Write zip: [green]success[/green] {zip_path.absolute()}")
+        with _console.status("🖍️ Writing zip..."):
+            write_zip(zip_path, files_for_chunked_zip, self.chunked_zip_folder, self.reference_date)
+        print(f"🖍️ Write zip: [green]success[/green] {zip_path.absolute()} ({len(files_for_chunked_zip)} files)")
 
 
 def write_json(path: Path, streamings: list[Streaming]):

--- a/synthetic-datasets/synthetic_datasets/writers/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/writers/spotify.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 
+import typer
 from tqdm import tqdm
 
 from ..models.spotify import Streaming
@@ -21,9 +22,13 @@ class SpotifyWriter:
 
     def write(self, records):
         json_path = Path(self.json_path_template.format(num_records=str(len(records))))
-        print(f"Write `json` file: status: `starting`, path: `{json_path.absolute()}`, count_records: `{len(records)}`")
+        typer.echo(
+            f"Write `json` file: status: `starting`, path: `{json_path.absolute()}`, count_records: `{len(records)}`"
+        )
         write_json(json_path, records)
-        print(f"Write `json` file: status: `success`, path: `{json_path.absolute()}`, count_records: `{len(records)}`")
+        typer.echo(
+            f"Write `json` file: status: `success`, path: `{json_path.absolute()}`, count_records: `{len(records)}`"
+        )
 
         chunk_size = int(max(len(records) / max(len(records) / self.max_chunk_size, 4), 10))
         files_for_chunked_zip = {}
@@ -35,11 +40,11 @@ class SpotifyWriter:
             files_for_chunked_zip[filename] = chunk
 
         zip_path = Path(self.zip_path_template.format(num_records=str(len(records))))
-        print(
+        typer.echo(
             f"Write `zip` file: status: `starting`, path: `{zip_path.absolute()}`, count_files: `{len(files_for_chunked_zip)}`"
         )
         write_zip(zip_path, files_for_chunked_zip, self.chunked_zip_folder, self.reference_date)
-        print(f"Write `zip` file: status: `success`, path: `{zip_path.absolute()}`")
+        typer.echo(f"Write `zip` file: status: `success`, path: `{zip_path.absolute()}`")
 
 
 def write_json(path: Path, streamings: list[Streaming]):

--- a/synthetic-datasets/synthetic_datasets/writers/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/writers/spotify.py
@@ -3,13 +3,12 @@ from datetime import datetime
 from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 
-from rich import print
-from rich.console import Console
+from rich import get_console, print
 from rich.progress import track
 
 from ..models.spotify import Streaming
 
-_console = Console()
+_console = get_console()
 
 
 class SpotifyWriter:

--- a/synthetic-datasets/synthetic_datasets/writers/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/writers/spotify.py
@@ -22,9 +22,9 @@ class SpotifyWriter:
 
     def write(self, records):
         json_path = Path(self.json_path_template.format(num_records=str(len(records))))
-        print(f"Write `json` file: status: `starting`, path: `{json_path.absolute()}`, count_records: `{len(records)}`")
+        print(f"Write json: [yellow]starting[/yellow] {json_path.absolute()} ({len(records)} records)")
         write_json(json_path, records)
-        print(f"Write `json` file: status: `success`, path: `{json_path.absolute()}`, count_records: `{len(records)}`")
+        print(f"Write json: [green]success[/green] {json_path.absolute()} ({len(records)} records)")
 
         chunk_size = int(max(len(records) / max(len(records) / self.max_chunk_size, 4), 10))
         files_for_chunked_zip = {}
@@ -36,11 +36,9 @@ class SpotifyWriter:
             files_for_chunked_zip[filename] = chunk
 
         zip_path = Path(self.zip_path_template.format(num_records=str(len(records))))
-        print(
-            f"Write `zip` file: status: `starting`, path: `{zip_path.absolute()}`, count_files: `{len(files_for_chunked_zip)}`"
-        )
+        print(f"Write zip: [yellow]starting[/yellow] {zip_path.absolute()} ({len(files_for_chunked_zip)} files)")
         write_zip(zip_path, files_for_chunked_zip, self.chunked_zip_folder, self.reference_date)
-        print(f"Write `zip` file: status: `success`, path: `{zip_path.absolute()}`")
+        print(f"Write zip: [green]success[/green] {zip_path.absolute()}")
 
 
 def write_json(path: Path, streamings: list[Streaming]):

--- a/synthetic-datasets/synthetic_datasets/writers/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/writers/spotify.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 
-import typer
+from rich import print
 from rich.progress import track
 
 from ..models.spotify import Streaming
@@ -22,13 +22,9 @@ class SpotifyWriter:
 
     def write(self, records):
         json_path = Path(self.json_path_template.format(num_records=str(len(records))))
-        typer.echo(
-            f"Write `json` file: status: `starting`, path: `{json_path.absolute()}`, count_records: `{len(records)}`"
-        )
+        print(f"Write `json` file: status: `starting`, path: `{json_path.absolute()}`, count_records: `{len(records)}`")
         write_json(json_path, records)
-        typer.echo(
-            f"Write `json` file: status: `success`, path: `{json_path.absolute()}`, count_records: `{len(records)}`"
-        )
+        print(f"Write `json` file: status: `success`, path: `{json_path.absolute()}`, count_records: `{len(records)}`")
 
         chunk_size = int(max(len(records) / max(len(records) / self.max_chunk_size, 4), 10))
         files_for_chunked_zip = {}
@@ -40,11 +36,11 @@ class SpotifyWriter:
             files_for_chunked_zip[filename] = chunk
 
         zip_path = Path(self.zip_path_template.format(num_records=str(len(records))))
-        typer.echo(
+        print(
             f"Write `zip` file: status: `starting`, path: `{zip_path.absolute()}`, count_files: `{len(files_for_chunked_zip)}`"
         )
         write_zip(zip_path, files_for_chunked_zip, self.chunked_zip_folder, self.reference_date)
-        typer.echo(f"Write `zip` file: status: `success`, path: `{zip_path.absolute()}`")
+        print(f"Write `zip` file: status: `success`, path: `{zip_path.absolute()}`")
 
 
 def write_json(path: Path, streamings: list[Streaming]):

--- a/synthetic-datasets/tests/test_app.py
+++ b/synthetic-datasets/tests/test_app.py
@@ -82,3 +82,12 @@ def test_generate_with_seed(mock_create, mock_spotify, seed):
 def test_generate_invalid_provider(tmp_path):
     result = runner.invoke(app, ["100", "--seed", "42", "--provider", "napster", "-o", str(tmp_path)])
     assert result.exit_code == 2
+
+
+def test_log_config_output(tmp_path):
+    result = runner.invoke(app, ["100", "--seed", "42", "-o", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "Generation Configuration" in result.output
+    assert "42" in result.output
+    assert "provided" in result.output
+    assert "derived from seed" in result.output

--- a/synthetic-datasets/tests/test_app.py
+++ b/synthetic-datasets/tests/test_app.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+from unittest.mock import patch
+
+from pytest import mark
 from typer.testing import CliRunner
 
 from synthetic_datasets.app import app
@@ -47,18 +51,34 @@ def test_generate_apple_music(tmp_path):
     assert (tmp_path / "apple_music").exists()
 
 
-def test_generate_with_reference_date(tmp_path):
-    result = runner.invoke(app, ["100", "--seed", "42", "--reference-date", "2026-01-15T01:02:03", "-o", str(tmp_path)])
+@patch("synthetic_datasets.app._spotify")
+@patch("synthetic_datasets.app.GenerationConfig.create")
+@mark.parametrize(
+    ["reference_date_str", "expected_datetime"],
+    [
+        ("2026-01-15T01:02:03", datetime(2026, 1, 15, 1, 2, 3)),
+        ("2025-12-31T23:59:59", datetime(2025, 12, 31, 23, 59, 59)),
+        ("2024-02-29T12:00:00", datetime(2024, 2, 29, 12, 0, 0)),
+    ],
+)
+def test_generate_with_reference_date(mock_create, mock_spotify, reference_date_str, expected_datetime):
+    result = runner.invoke(app, ["100", "--reference-date", reference_date_str])
+
     assert result.exit_code == 0
-    assert "2026-01-15" in result.output
+    mock_create.assert_called_once_with(seed=None, reference_date=expected_datetime)
+    mock_spotify.assert_called_once()
 
 
-def test_generate_output_mentions_seed(tmp_path):
-    result = runner.invoke(app, ["100", "--seed", "42", "-o", str(tmp_path)])
+@patch("synthetic_datasets.app._spotify")
+@patch("synthetic_datasets.app.GenerationConfig.create")
+@mark.parametrize("seed", [0, 42, 1234567890])
+def test_generate_with_seed(mock_create, mock_spotify, seed):
+    result = runner.invoke(app, ["100", "--seed", seed])
     assert result.exit_code == 0
-    assert "42" in result.output
+    mock_create.assert_called_once_with(seed=seed, reference_date=None)
+    mock_spotify.assert_called_once()
 
 
 def test_generate_invalid_provider(tmp_path):
     result = runner.invoke(app, ["100", "--seed", "42", "--provider", "napster", "-o", str(tmp_path)])
-    assert result.exit_code != 0
+    assert result.exit_code == 2

--- a/synthetic-datasets/tests/test_app.py
+++ b/synthetic-datasets/tests/test_app.py
@@ -1,0 +1,64 @@
+from typer.testing import CliRunner
+
+from synthetic_datasets.app import app
+
+runner = CliRunner()
+
+
+def test_help():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "Generate synthetic streaming datasets" in result.output
+    assert "provider" in result.stdout
+    assert "seed" in result.stdout
+
+
+def test_num_records_below_minimum():
+    result = runner.invoke(app, ["50"])
+    assert result.exit_code != 0
+    assert "Minimal value is: 100" in result.output
+
+
+def test_num_records_boundary_rejected(tmp_path):
+    result = runner.invoke(app, ["99", "-o", str(tmp_path)])
+    assert result.exit_code != 0
+
+
+def test_num_records_boundary_accepted(tmp_path):
+    result = runner.invoke(app, ["100", "--seed", "42", "-o", str(tmp_path)])
+    assert result.exit_code == 0
+
+
+def test_generate_spotify(tmp_path):
+    result = runner.invoke(app, ["100", "--seed", "42", "-o", str(tmp_path)])
+    assert result.exit_code == 0
+    assert (tmp_path / "spotify").exists()
+
+
+def test_generate_deezer(tmp_path):
+    result = runner.invoke(app, ["100", "--seed", "42", "--provider", "deezer", "-o", str(tmp_path)])
+    assert result.exit_code == 0
+    assert (tmp_path / "deezer").exists()
+
+
+def test_generate_apple_music(tmp_path):
+    result = runner.invoke(app, ["100", "--seed", "42", "--provider", "apple-music", "-o", str(tmp_path)])
+    assert result.exit_code == 0
+    assert (tmp_path / "apple_music").exists()
+
+
+def test_generate_with_reference_date(tmp_path):
+    result = runner.invoke(app, ["100", "--seed", "42", "--reference-date", "2026-01-15T01:02:03", "-o", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "2026-01-15" in result.output
+
+
+def test_generate_output_mentions_seed(tmp_path):
+    result = runner.invoke(app, ["100", "--seed", "42", "-o", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "42" in result.output
+
+
+def test_generate_invalid_provider(tmp_path):
+    result = runner.invoke(app, ["100", "--seed", "42", "--provider", "napster", "-o", str(tmp_path)])
+    assert result.exit_code != 0

--- a/synthetic-datasets/tests/test_config.py
+++ b/synthetic-datasets/tests/test_config.py
@@ -52,13 +52,6 @@ def test_create_with_seed_and_date():
     assert config.reference_date != date_from_seed
 
 
-def test_log_config(capsys):
-    seed = 42
-    config = GenerationConfig.create(seed=seed)
-    config.log_config()
-
-    captured = capsys.readouterr()
-    assert "Generation Configuration" in captured.out
-    assert str(seed) in captured.out
-    assert "provided" in captured.out
-    assert "derived from seed" in captured.out
+def test_log_config_returns_none():
+    config = GenerationConfig.create(seed=42)
+    assert config.log_config() is None

--- a/synthetic-datasets/tests/test_config.py
+++ b/synthetic-datasets/tests/test_config.py
@@ -59,6 +59,6 @@ def test_log_config(capsys):
 
     captured = capsys.readouterr()
     assert "Generation Configuration" in captured.out
-    assert f"Seed: {seed}" in captured.out
+    assert str(seed) in captured.out
     assert "provided" in captured.out
     assert "derived from seed" in captured.out

--- a/synthetic-datasets/uv.lock
+++ b/synthetic-datasets/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12, <3.14"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -48,6 +57,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -206,6 +236,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.14"
 source = { registry = "https://pypi.org/simple" }
@@ -231,6 +274,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "synthetic-datasets"
 version = "0.3.0"
 source = { editable = "." }
@@ -240,6 +292,7 @@ dependencies = [
     { name = "openpyxl" },
     { name = "pydantic" },
     { name = "tqdm" },
+    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -256,6 +309,7 @@ requires-dist = [
     { name = "openpyxl", specifier = "==3.1.5" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "tqdm", specifier = "==4.67.3" },
+    { name = "typer", specifier = "==0.26.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -300,6 +354,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/e8/02f4dd4a12bcdbda0006f9c7ff3b99a4be06bd0d257d3bd4a5b66de074e6/ty-0.0.39-py3-none-win32.whl", hash = "sha256:891c3262314dbc80bf3e872634d23dd216306945daa9a9fcc206ce5ed21ac4c9", size = 10615377, upload-time = "2026-05-22T21:09:43.167Z" },
     { url = "https://files.pythonhosted.org/packages/b5/5a/aaeb22faa8d4dae90a287d4c3636c671edcff3b99be5f4fc8b79ad71eef6/ty-0.0.39-py3-none-win_amd64.whl", hash = "sha256:ba7f2d54452535419e90f6f03ff39282999e87b43c21c00559f6d7ad711a36d5", size = 11710711, upload-time = "2026-05-22T21:09:53.179Z" },
     { url = "https://files.pythonhosted.org/packages/a3/17/ae7339651bfcaa5f54698c8c70eaf5031baa400ecb67baec31d03a56cbd4/ty-0.0.39-py3-none-win_arm64.whl", hash = "sha256:eb4cf0fefbbfedf9a352597bb2431ebdcb7eb3a595c0f825f228e897a0ec285d", size = 11081409, upload-time = "2026-05-22T21:09:03.741Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/d3/90c1ee19209cb59f6ad185883fd4ccfcf72f8f0bfd549d5a8b70474611d0/typer-0.26.4.tar.gz", hash = "sha256:25b128964de66c5ea36d5ac82adc579e5e113509b17469edf9f5a4a1864ff2a9", size = 201191, upload-time = "2026-05-30T17:05:04.213Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/6d/5a525c69df4a90892135e5d490b00e9e46402491f3416d4395fcb0d0201e/typer-0.26.4-py3-none-any.whl", hash = "sha256:11bfd7b43557137e373c2b10f6967a555f9678a61ed72c808968b011d95534d6", size = 122436, upload-time = "2026-05-30T17:05:05.812Z" },
 ]
 
 [[package]]

--- a/synthetic-datasets/uv.lock
+++ b/synthetic-datasets/uv.lock
@@ -291,7 +291,6 @@ dependencies = [
     { name = "numpy" },
     { name = "openpyxl" },
     { name = "pydantic" },
-    { name = "tqdm" },
     { name = "typer" },
 ]
 
@@ -308,7 +307,6 @@ requires-dist = [
     { name = "numpy", specifier = "==2.4.6" },
     { name = "openpyxl", specifier = "==3.1.5" },
     { name = "pydantic", specifier = "==2.13.4" },
-    { name = "tqdm", specifier = "==4.67.3" },
     { name = "typer", specifier = "==0.26.4" },
 ]
 
@@ -317,18 +315,6 @@ dev = [
     { name = "pytest", specifier = "==9.0.3" },
     { name = "ruff", specifier = "==0.15.14" },
     { name = "ty", specifier = "==0.0.39" },
-]
-
-[[package]]
-name = "tqdm"
-version = "4.67.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The `synthetic-datasets` CLI used `argparse` and bare `print()` calls, with no tests covering the CLI entry point. This made the interface harder to extend and left argument validation untested.

## 🎹 Proposal

Replace `argparse` with Typer, the library recommended for FastAPI-style CLIs. Argument declarations use the `Annotated` style, and provider choices are expressed as a typed `Provider` enum. Validation for `num_records >= 100` is handled via a Typer callback.

Status output now uses `rich.print` (recommended over the legacy `typer.echo`), and progress bars use `rich.progress.track` instead of `tqdm`, which is now removed as a dependency. Rich is already bundled with Typer.

CLI tests using `typer.testing.CliRunner` cover help output, argument validation, all three providers, seed and reference date options, and invalid input.

## 🎶 Comments

No behavior changes. Output format and all existing tests are preserved.

> [!NOTE]
> Mostly for fun, no real impact on the app or its users. The Typer migration and the progress indicator tweaks are both cosmetic improvements to the dev experience.


## 🎤 Test

```bash
moon run synthetic-datasets:generate -- --help
moon run synthetic-datasets:generate -- 100 --seed 42
moon run synthetic-datasets:generate -- 100 --seed 42 --provider deezer
moon run synthetic-datasets:generate -- 50  # should fail: below minimum
moon run synthetic-datasets:test
```