### PR TITLE
refactor(synthetic-datasets): distribute records via largest remainder method

### DIFF
--- a/.github/workflows/datasets-test-synthetic.yml
+++ b/.github/workflows/datasets-test-synthetic.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Verify e2e dataset hashes
         working-directory: ${{ github.workspace }}
         env:
-          EXPECTED_JSON_HASH: "c368333c4da5af4105707e7043336cb463620da26276d99096f8f1541dd35314"
-          EXPECTED_ZIP_HASH: "c0df9adf694459311af3aacac1b619732f0087d6191efe441142197c93f3b777"
+          EXPECTED_JSON_HASH: "32b325de0cd9597a274a6722d0eeda7fb27fc4724c5283373524d2f7899fda87"
+          EXPECTED_ZIP_HASH: "0830e9e2ae17a736ab11399613e4214cbc1a170a774ff625d8f9cdb20b38578c"
         run: |
           JSON_FILE="e2e/datasets/spotify/Streaming_History_Audio_2006_1000.json"
           ZIP_FILE="e2e/datasets/spotify/streamings_1000.zip"

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -113,15 +113,20 @@ class BaseFactory(ABC, Generic[RecordT]):
         return candidate
 
     def _generate_distribution_over_year(self, n_records: int) -> dict[int, int]:
-        years = range(self.start_year, self.now.year + 1)
+        years = list(range(self.start_year, self.now.year + 1))
 
         year_weights = [self.rng.uniform(0.5, 1.5) for _ in years]
-        base_records_per_year = n_records / sum(year_weights)
-        records_per_year = {
-            year: int(base_records_per_year * year_weight) for year, year_weight in zip(years, year_weights)
-        }
-        records_per_year[self.now.year] += n_records - sum(records_per_year.values())
-        return records_per_year
+        total_weight = sum(year_weights)
+
+        exact = {year: n_records * weight / total_weight for year, weight in zip(years, year_weights)}
+        base = {year: int(v) for year, v in exact.items()}
+
+        leftover = n_records - sum(base.values())
+        remainders = sorted(years, key=lambda y: exact[y] - base[y], reverse=True)
+        for year in remainders[:leftover]:
+            base[year] += 1
+
+        return base
 
     def _generate_weighted_tracks_by_year(self) -> dict[int, list[int]]:
         weighted_tracks_by_year: dict[int, list[int]] = {}

--- a/synthetic-datasets/tests/factories/test_base_factory.py
+++ b/synthetic-datasets/tests/factories/test_base_factory.py
@@ -47,6 +47,43 @@ def test_generate_distribution_over_year_sums_to_n(factory):
         assert sum(result.values()) == n
 
 
+def test_generate_distribution_over_year_largest_remainder(factory, config):
+    # Edge cases: sum must always equal n_records
+    for n in [0, 1, 3, 100, 1000]:
+        result = factory._generate_distribution_over_year(n)
+        assert sum(result.values()) == n, f"sum mismatch for n={n}"
+
+    # Determinism: same seed produces same distribution
+    factory_a = ConcreteFactory(num_records=10, config=config)
+    factory_b = ConcreteFactory(num_records=10, config=config)
+    assert factory_a._generate_distribution_over_year(97) == factory_b._generate_distribution_over_year(97)
+
+    # Largest remainder correctness: monkey-patch weights so we can predict the result.
+    # With equal weights across N years, each year gets exactly n_records / N.
+    # When not evenly divisible the remainder must be spread one per year starting
+    # from the first years (all fractional parts are equal so ordering is stable).
+
+    years = list(range(factory.start_year, factory.now.year + 1))
+    n_years = len(years)
+    n = n_years * 3 + 1  # e.g. 19 for 6 years => floor=3 per year, leftover=1
+
+    # Temporarily replace rng.uniform to return a constant weight
+    original_uniform = factory.rng.uniform
+    factory.rng.uniform = lambda a, b: 1.0  # type: ignore[method-assign]
+    result = factory._generate_distribution_over_year(n)
+    factory.rng.uniform = original_uniform  # type: ignore[method-assign]
+
+    assert sum(result.values()) == n
+    floor_val = n // n_years
+    ceil_val = floor_val + 1
+    leftover = n - floor_val * n_years
+    assert sum(1 for v in result.values() if v == ceil_val) == leftover
+    assert sum(1 for v in result.values() if v == floor_val) == n_years - leftover
+    # All values must be floor or ceil — no other values allowed
+    for v in result.values():
+        assert v in (floor_val, ceil_val), f"unexpected count {v}"
+
+
 def test_rng_seeding_is_deterministic(config):
     f1 = ConcreteFactory(num_records=50, config=config)
     f2 = ConcreteFactory(num_records=50, config=config)


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Year record distribution in `_generate_distribution_over_year` used integer truncation to floor each year's share, then dumped the entire rounding error onto the last year. This gave the final year a disproportionately higher count and made the distribution unfair.

## 🎹 Proposal

Replace the truncation approach with the largest remainder method. Each year's exact quota is computed as `n_records * weight / total_weight`. Each year starts with its floored value, and the remaining units are handed out one at a time to the years with the largest fractional remainders. This guarantees the total always equals `n_records` and distributes the rounding error proportionally.

## 🎶 Comments

The method signature is unchanged. Existing tests (`test_generate_distribution_over_year_sums_to_n`, `test_rng_seeding_is_deterministic`) continue to pass without modification.

## 🎤 Test

```bash
moon run synthetic-datasets:test
```

A new test `test_generate_distribution_over_year_largest_remainder` is added to `tests/factories/test_base_factory.py`. It verifies:
- Sum equals `n_records` for edge cases (0, 1, 3, 100, 1000).
- Output is deterministic for the same seed.
- With equal weights, every year gets either floor or ceil value and the number of ceil years equals the leftover count.