### PR TITLE
feat(synthetic-datasets): add persona, chapter, and inactivity primitives

### DIFF
--- a/synthetic-datasets/synthetic_datasets/chapters.py
+++ b/synthetic-datasets/synthetic_datasets/chapters.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass, field
+from datetime import date
+from functools import cached_property
+
+from .inactivity import InactivityWindow
+from .personas import PersonaProfile
+
+
+@dataclass
+class Chapter:
+    year: int
+    position: int
+    persona: PersonaProfile | None
+    selected_month_windows: tuple[InactivityWindow, ...] = field(default_factory=tuple)
+    selected_day_windows: tuple[InactivityWindow, ...] = field(default_factory=tuple)
+
+    @cached_property
+    def inactivity_dates(self) -> frozenset[date]:
+        out: set[date] = set()
+        for w in (*self.selected_month_windows, *self.selected_day_windows):
+            out.update(w.to_dates(self.year))
+        return frozenset(out)

--- a/synthetic-datasets/synthetic_datasets/inactivity.py
+++ b/synthetic-datasets/synthetic_datasets/inactivity.py
@@ -1,0 +1,22 @@
+import calendar
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass(frozen=True)
+class InactivityWindow:
+    """A contiguous range of days within a calendar year, year-agnostic.
+    Resolved to actual dates at chapter build time.
+    """
+
+    month: int  # 1-12
+    start_day: int  # 1-31
+    end_day: int  # 1-31, inclusive (clamped to month's last day)
+
+    def to_dates(self, year: int) -> list[date]:
+        last = calendar.monthrange(year, self.month)[1]
+        return [date(year, self.month, d) for d in range(self.start_day, min(self.end_day, last) + 1)]
+
+    @classmethod
+    def full_month(cls, month: int) -> "InactivityWindow":
+        return cls(month=month, start_day=1, end_day=31)

--- a/synthetic-datasets/synthetic_datasets/personas.py
+++ b/synthetic-datasets/synthetic_datasets/personas.py
@@ -1,0 +1,211 @@
+from dataclasses import dataclass
+
+from .inactivity import InactivityWindow
+
+
+@dataclass(frozen=True)
+class PersonaProfile:
+    name: str
+    volume_weight: float
+    hour_weights: tuple[float, ...]  # length 24
+    weekday_multipliers: tuple[float, ...]  # length 7, Monday=0
+    month_weights: tuple[float, ...]  # length 12
+    skip_chance: float  # 0.0-1.0
+    shuffle_chance: float  # 0.0-1.0
+    session_avg_minutes: int
+    session_gap_minutes: int
+    catalog_favored_share: float = 0.60
+    inactivity_month_windows: tuple[InactivityWindow, ...] = ()
+    inactivity_day_windows: tuple[InactivityWindow, ...] = ()
+    n_month_gaps: int = 0
+    n_day_gap_windows: int = 0
+
+
+NIGHT_OWL = PersonaProfile(
+    name="NIGHT_OWL",
+    volume_weight=1.0,
+    hour_weights=(
+        0.08,  # 0
+        0.07,  # 1
+        0.05,  # 2
+        0.02,  # 3
+        0.01,  # 4
+        0.01,  # 5
+        0.01,  # 6
+        0.01,  # 7
+        0.01,  # 8
+        0.01,  # 9
+        0.01,  # 10
+        0.01,  # 11
+        0.01,  # 12
+        0.01,  # 13
+        0.01,  # 14
+        0.01,  # 15
+        0.01,  # 16
+        0.01,  # 17
+        0.02,  # 18
+        0.03,  # 19
+        0.04,  # 20
+        0.05,  # 21
+        0.10,  # 22
+        0.10,  # 23
+    ),
+    weekday_multipliers=(0.7, 0.7, 0.7, 0.7, 1.2, 1.5, 1.3),
+    month_weights=(1.0, 1.0, 1.0, 1.0, 1.0, 0.7, 0.8, 1.0, 1.0, 1.0, 1.0, 0.7),
+    skip_chance=0.45,
+    shuffle_chance=0.75,
+    session_avg_minutes=120,
+    session_gap_minutes=25,
+    inactivity_month_windows=(
+        InactivityWindow.full_month(6),
+        InactivityWindow.full_month(12),
+    ),
+    inactivity_day_windows=(
+        InactivityWindow(month=1, start_day=14, end_day=20),
+        InactivityWindow(month=6, start_day=15, end_day=21),
+    ),
+    n_month_gaps=1,
+    n_day_gap_windows=1,
+)
+
+MORNING_COMMUTER = PersonaProfile(
+    name="MORNING_COMMUTER",
+    volume_weight=1.4,
+    hour_weights=(
+        0.01,  # 0
+        0.01,  # 1
+        0.01,  # 2
+        0.01,  # 3
+        0.01,  # 4
+        0.01,  # 5
+        0.01,  # 6
+        0.12,  # 7
+        0.12,  # 8
+        0.08,  # 9
+        0.02,  # 10
+        0.02,  # 11
+        0.02,  # 12
+        0.02,  # 13
+        0.02,  # 14
+        0.02,  # 15
+        0.02,  # 16
+        0.02,  # 17
+        0.10,  # 18
+        0.08,  # 19
+        0.02,  # 20
+        0.02,  # 21
+        0.01,  # 22
+        0.01,  # 23
+    ),
+    weekday_multipliers=(1.2, 1.2, 1.2, 1.2, 1.2, 0.5, 0.5),
+    month_weights=(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.4, 1.0, 1.0, 1.0, 1.0),
+    skip_chance=0.18,
+    shuffle_chance=0.40,
+    session_avg_minutes=35,
+    session_gap_minutes=15,
+    inactivity_month_windows=(InactivityWindow.full_month(8),),
+    inactivity_day_windows=(InactivityWindow(month=12, start_day=24, end_day=31),),
+    n_month_gaps=1,
+    n_day_gap_windows=1,
+)
+
+SETTLED_LISTENER = PersonaProfile(
+    name="SETTLED_LISTENER",
+    volume_weight=1.6,
+    hour_weights=(
+        0.01,  # 0
+        0.01,  # 1
+        0.01,  # 2
+        0.01,  # 3
+        0.01,  # 4
+        0.01,  # 5
+        0.01,  # 6
+        0.01,  # 7
+        0.01,  # 8
+        0.01,  # 9
+        0.01,  # 10
+        0.01,  # 11
+        0.01,  # 12
+        0.01,  # 13
+        0.08,  # 14
+        0.09,  # 15
+        0.09,  # 16
+        0.09,  # 17
+        0.09,  # 18
+        0.08,  # 19
+        0.07,  # 20
+        0.04,  # 21
+        0.03,  # 22
+        0.02,  # 23
+    ),
+    weekday_multipliers=(0.9, 1.0, 1.0, 1.0, 1.0, 1.1, 0.9),
+    month_weights=(0.9, 0.9, 0.9, 0.9, 1.1, 1.1, 1.1, 1.1, 0.9, 0.9, 0.9, 0.9),
+    skip_chance=0.08,
+    shuffle_chance=0.20,
+    session_avg_minutes=60,
+    session_gap_minutes=20,
+    catalog_favored_share=0.50,
+    inactivity_month_windows=(InactivityWindow.full_month(7),),
+    inactivity_day_windows=(),
+    n_month_gaps=1,
+    n_day_gap_windows=0,
+)
+
+CURRENT_ERA = PersonaProfile(
+    name="CURRENT_ERA",
+    volume_weight=1.0,
+    hour_weights=(
+        0.01,  # 0
+        0.01,  # 1
+        0.01,  # 2
+        0.01,  # 3
+        0.02,  # 4
+        0.04,  # 5
+        0.07,  # 6
+        0.08,  # 7
+        0.07,  # 8
+        0.05,  # 9
+        0.04,  # 10
+        0.04,  # 11
+        0.04,  # 12
+        0.04,  # 13
+        0.04,  # 14
+        0.05,  # 15
+        0.06,  # 16
+        0.07,  # 17
+        0.07,  # 18
+        0.06,  # 19
+        0.05,  # 20
+        0.04,  # 21
+        0.02,  # 22
+        0.01,  # 23
+    ),
+    weekday_multipliers=(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
+    month_weights=(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
+    skip_chance=0.22,
+    shuffle_chance=0.45,
+    session_avg_minutes=50,
+    session_gap_minutes=20,
+    inactivity_month_windows=(),
+    inactivity_day_windows=(),
+    n_month_gaps=0,
+    n_day_gap_windows=0,
+)
+
+ACTIVE_PERSONAS = (NIGHT_OWL, MORNING_COMMUTER, SETTLED_LISTENER)
+TERMINAL_PERSONA = CURRENT_ERA
+
+
+def _check_invariants() -> None:
+    if sum(p.n_month_gaps for p in ACTIVE_PERSONAS) < 1:
+        raise ValueError("ACTIVE_PERSONAS must collectively contribute at least one month gap")
+    if sum(p.n_day_gap_windows for p in ACTIVE_PERSONAS) < 1:
+        raise ValueError("ACTIVE_PERSONAS must collectively contribute at least one day gap")
+    for p in (*ACTIVE_PERSONAS, TERMINAL_PERSONA):
+        if p.n_month_gaps > len(p.inactivity_month_windows):
+            raise ValueError(f"{p.name}: n_month_gaps exceeds candidates")
+        if p.n_day_gap_windows > len(p.inactivity_day_windows):
+            raise ValueError(f"{p.name}: n_day_gap_windows exceeds candidates")
+
+
+_check_invariants()

--- a/synthetic-datasets/tests/factories/test_chapters.py
+++ b/synthetic-datasets/tests/factories/test_chapters.py
@@ -1,0 +1,130 @@
+from datetime import date
+
+from synthetic_datasets.chapters import Chapter
+from synthetic_datasets.inactivity import InactivityWindow
+from synthetic_datasets.personas import CURRENT_ERA, NIGHT_OWL
+
+
+def test_chapter_inactivity_dates_resolves_month_windows() -> None:
+    chapter = Chapter(
+        year=2023,
+        position=1,
+        persona=NIGHT_OWL,
+        selected_month_windows=(InactivityWindow.full_month(6),),
+        selected_day_windows=(),
+    )
+    dates = chapter.inactivity_dates
+    assert isinstance(dates, frozenset)
+    assert len(dates) == 30
+    assert date(2023, 6, 1) in dates
+    assert date(2023, 6, 30) in dates
+
+
+def test_chapter_inactivity_dates_resolves_day_windows() -> None:
+    chapter = Chapter(
+        year=2023,
+        position=1,
+        persona=NIGHT_OWL,
+        selected_month_windows=(),
+        selected_day_windows=(InactivityWindow(month=1, start_day=14, end_day=20),),
+    )
+    dates = chapter.inactivity_dates
+    assert len(dates) == 7
+    assert date(2023, 1, 14) in dates
+    assert date(2023, 1, 20) in dates
+
+
+def test_chapter_inactivity_dates_resolves_both_window_types() -> None:
+    chapter = Chapter(
+        year=2023,
+        position=1,
+        persona=NIGHT_OWL,
+        selected_month_windows=(InactivityWindow.full_month(6),),
+        selected_day_windows=(InactivityWindow(month=1, start_day=14, end_day=20),),
+    )
+    dates = chapter.inactivity_dates
+    assert len(dates) == 37  # 30 from June + 7 from Jan
+    assert date(2023, 6, 1) in dates
+    assert date(2023, 1, 20) in dates
+
+
+def test_chapter_inactivity_dates_empty_when_no_windows() -> None:
+    chapter = Chapter(
+        year=2023,
+        position=1,
+        persona=NIGHT_OWL,
+        selected_month_windows=(),
+        selected_day_windows=(),
+    )
+    dates = chapter.inactivity_dates
+    assert len(dates) == 0
+
+
+def test_chapter_inactivity_dates_is_frozenset() -> None:
+    chapter = Chapter(
+        year=2023,
+        position=1,
+        persona=NIGHT_OWL,
+        selected_month_windows=(InactivityWindow.full_month(6),),
+    )
+    dates = chapter.inactivity_dates
+    assert isinstance(dates, frozenset)
+
+
+def test_chapter_inactivity_dates_cached() -> None:
+    chapter = Chapter(
+        year=2023,
+        position=1,
+        persona=NIGHT_OWL,
+        selected_month_windows=(InactivityWindow.full_month(6),),
+    )
+    dates1 = chapter.inactivity_dates
+    dates2 = chapter.inactivity_dates
+    assert dates1 is dates2  # Same object, cached
+
+
+def test_chapter_ghost_with_persona_none() -> None:
+    chapter = Chapter(year=2023, position=2, persona=None)
+    dates = chapter.inactivity_dates
+    assert len(dates) == 0
+
+
+def test_chapter_with_current_era_persona() -> None:
+    chapter = Chapter(
+        year=2026,
+        position=4,
+        persona=CURRENT_ERA,
+        selected_month_windows=(),
+        selected_day_windows=(),
+    )
+    dates = chapter.inactivity_dates
+    assert len(dates) == 0  # CURRENT_ERA has no inactivity windows
+
+
+def test_chapter_leap_year_february() -> None:
+    chapter = Chapter(
+        year=2024,  # leap year
+        position=1,
+        persona=NIGHT_OWL,
+        selected_month_windows=(InactivityWindow.full_month(2),),
+    )
+    dates = chapter.inactivity_dates
+    assert len(dates) == 29
+    assert date(2024, 2, 29) in dates
+
+
+def test_chapter_multiple_day_windows() -> None:
+    chapter = Chapter(
+        year=2023,
+        position=1,
+        persona=NIGHT_OWL,
+        selected_month_windows=(),
+        selected_day_windows=(
+            InactivityWindow(month=1, start_day=14, end_day=20),
+            InactivityWindow(month=6, start_day=15, end_day=21),
+        ),
+    )
+    dates = chapter.inactivity_dates
+    assert len(dates) == 14  # 7 + 7
+    assert date(2023, 1, 14) in dates
+    assert date(2023, 6, 21) in dates

--- a/synthetic-datasets/tests/factories/test_inactivity.py
+++ b/synthetic-datasets/tests/factories/test_inactivity.py
@@ -1,0 +1,54 @@
+from datetime import date
+
+from synthetic_datasets.inactivity import InactivityWindow
+
+
+def test_inactivity_window_to_dates_leap_year() -> None:
+    dates = InactivityWindow(month=2, start_day=1, end_day=31).to_dates(2024)
+    assert len(dates) == 29
+
+
+def test_inactivity_window_to_dates_non_leap_year() -> None:
+    dates = InactivityWindow(month=2, start_day=1, end_day=31).to_dates(2023)
+    assert len(dates) == 28
+
+
+def test_inactivity_window_to_dates_clamps_end_day() -> None:
+    dates = InactivityWindow(month=2, start_day=27, end_day=31).to_dates(2023)
+    assert len(dates) == 2
+    assert date(2023, 2, 27) in dates
+    assert date(2023, 2, 28) in dates
+
+
+def test_inactivity_window_full_month_leap_year() -> None:
+    dates = InactivityWindow.full_month(2).to_dates(2024)
+    assert len(dates) == 29
+    assert date(2024, 2, 1) in dates
+    assert date(2024, 2, 29) in dates
+
+
+def test_inactivity_window_full_month_non_leap_year() -> None:
+    dates = InactivityWindow.full_month(2).to_dates(2023)
+    assert len(dates) == 28
+    assert date(2023, 2, 1) in dates
+    assert date(2023, 2, 28) in dates
+
+
+def test_inactivity_window_partial_month() -> None:
+    dates = InactivityWindow(month=6, start_day=15, end_day=21).to_dates(2023)
+    assert len(dates) == 7
+    assert date(2023, 6, 15) in dates
+    assert date(2023, 6, 21) in dates
+
+
+def test_inactivity_window_single_day() -> None:
+    dates = InactivityWindow(month=6, start_day=15, end_day=15).to_dates(2023)
+    assert len(dates) == 1
+    assert date(2023, 6, 15) in dates
+
+
+def test_inactivity_window_all_months() -> None:
+    for month in range(1, 13):
+        dates = InactivityWindow.full_month(month).to_dates(2023)
+        assert len(dates) > 0
+        assert all(d.month == month for d in dates)

--- a/synthetic-datasets/tests/factories/test_personas.py
+++ b/synthetic-datasets/tests/factories/test_personas.py
@@ -1,0 +1,67 @@
+import pytest
+
+from synthetic_datasets.personas import (
+    ACTIVE_PERSONAS,
+    TERMINAL_PERSONA,
+    PersonaProfile,
+)
+
+ALL_PERSONAS = (*ACTIVE_PERSONAS, TERMINAL_PERSONA)
+
+
+@pytest.mark.parametrize("persona", ALL_PERSONAS, ids=lambda p: p.name)
+def test_hour_weights_length(persona: PersonaProfile) -> None:
+    assert len(persona.hour_weights) == 24
+
+
+@pytest.mark.parametrize("persona", ALL_PERSONAS, ids=lambda p: p.name)
+def test_weekday_multipliers_length(persona: PersonaProfile) -> None:
+    assert len(persona.weekday_multipliers) == 7
+
+
+@pytest.mark.parametrize("persona", ALL_PERSONAS, ids=lambda p: p.name)
+def test_month_weights_length(persona: PersonaProfile) -> None:
+    assert len(persona.month_weights) == 12
+
+
+@pytest.mark.parametrize("persona", ALL_PERSONAS, ids=lambda p: p.name)
+def test_hour_weights_sum_positive(persona: PersonaProfile) -> None:
+    assert sum(persona.hour_weights) > 0
+
+
+@pytest.mark.parametrize("persona", ALL_PERSONAS, ids=lambda p: p.name)
+def test_weekday_multipliers_sum_positive(persona: PersonaProfile) -> None:
+    assert sum(persona.weekday_multipliers) > 0
+
+
+@pytest.mark.parametrize("persona", ALL_PERSONAS, ids=lambda p: p.name)
+def test_month_weights_sum_positive(persona: PersonaProfile) -> None:
+    assert sum(persona.month_weights) > 0
+
+
+@pytest.mark.parametrize("persona", ALL_PERSONAS, ids=lambda p: p.name)
+def test_skip_chance_in_range(persona: PersonaProfile) -> None:
+    assert 0.0 <= persona.skip_chance <= 1.0
+
+
+@pytest.mark.parametrize("persona", ALL_PERSONAS, ids=lambda p: p.name)
+def test_shuffle_chance_in_range(persona: PersonaProfile) -> None:
+    assert 0.0 <= persona.shuffle_chance <= 1.0
+
+
+@pytest.mark.parametrize("persona", ALL_PERSONAS, ids=lambda p: p.name)
+def test_n_month_gaps_does_not_exceed_candidates(persona: PersonaProfile) -> None:
+    assert persona.n_month_gaps <= len(persona.inactivity_month_windows)
+
+
+@pytest.mark.parametrize("persona", ALL_PERSONAS, ids=lambda p: p.name)
+def test_n_day_gap_windows_does_not_exceed_candidates(persona: PersonaProfile) -> None:
+    assert persona.n_day_gap_windows <= len(persona.inactivity_day_windows)
+
+
+def test_active_personas_collective_month_gaps() -> None:
+    assert sum(p.n_month_gaps for p in ACTIVE_PERSONAS) >= 1
+
+
+def test_active_personas_collective_day_gap_windows() -> None:
+    assert sum(p.n_day_gap_windows for p in ACTIVE_PERSONAS) >= 1


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The synthetic dataset generator produces uniform listening history with no personality variation. There is no data model to represent different listener archetypes, their activity patterns, or the quiet periods that make history feel realistic.

## 🎹 Proposal

Introduce three standalone importable modules with no BaseFactory integration yet:

- `inactivity.py`: `InactivityWindow` dataclass representing a year-agnostic contiguous date range, with `to_dates(year)` that clamps to the month's actual last day and a `full_month` constructor.
- `personas.py`: `PersonaProfile` frozen dataclass carrying all behavioral parameters (hour weights, weekday multipliers, month weights, skip/shuffle chances, session timing, inactivity windows). Four persona constants are defined: `NIGHT_OWL`, `MORNING_COMMUTER`, `SETTLED_LISTENER`, and `CURRENT_ERA`. Module-level invariant checks run at import time using `raise ValueError` (never `assert`) to catch misconfiguration regardless of Python optimization flags.
- `chapters.py`: `Chapter` dataclass combining a year, a position, a persona, and the inactivity windows selected for that year. A `cached_property` resolves the selected windows into a `frozenset[date]` on first access.

## 🎶 Comments

These primitives are self-contained and carry no side effects beyond the invariant check at import. They lay the groundwork for persona-driven generation to be wired into `BaseFactory` in a later issue.

## 🎤 Test

```bash
moon run synthetic-datasets:test
```

All 197 tests pass. New tests in `tests/factories/test_personas.py` cover tuple lengths, weight positivity, chance bounds, gap count invariants, leap/non-leap year clamping, and `Chapter.inactivity_dates` resolution.