### PR TITLE
feat(synthetic-datasets): wire chapter system into dataset generator

### DIFF
--- a/.github/workflows/datasets-test-synthetic.yml
+++ b/.github/workflows/datasets-test-synthetic.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Verify e2e dataset hashes
         working-directory: ${{ github.workspace }}
         env:
-          EXPECTED_JSON_HASH: "32b325de0cd9597a274a6722d0eeda7fb27fc4724c5283373524d2f7899fda87"
-          EXPECTED_ZIP_HASH: "0830e9e2ae17a736ab11399613e4214cbc1a170a774ff625d8f9cdb20b38578c"
+          EXPECTED_JSON_HASH: "9c647b68791b0581aa9ffc7fe6c74147000cba4d6de7881fcaf9cd2eed1d11a6"
+          EXPECTED_ZIP_HASH: "d6a8e38ba74145ba79f58d4bde37b0ac5c06a692d5375f12cc5799a098e800af"
         run: |
           JSON_FILE="e2e/datasets/spotify/Streaming_History_Audio_2006_1000.json"
           ZIP_FILE="e2e/datasets/spotify/streamings_1000.zip"

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -1,7 +1,7 @@
 import calendar
 import random
 from abc import ABC, abstractmethod
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import ClassVar, Generic, TypeVar
 
 import numpy as np
@@ -9,8 +9,10 @@ from faker import Faker
 from rich import get_console, print
 from rich.progress import track
 
+from ..chapters import Chapter
 from ..config import GenerationConfig
 from ..models.base import BaseEvent, BaseTrack
+from ..personas import ACTIVE_PERSONAS, TERMINAL_PERSONA
 
 _console = get_console()
 
@@ -27,7 +29,6 @@ class BaseFactory(ABC, Generic[RecordT]):
     ZIPF_A: ClassVar[float] = 1.8
     SKIP_CHANCE_MIN: ClassVar[float] = 0.15
     SKIP_CHANCE_MAX: ClassVar[float] = 0.30
-    START_YEAR: ClassVar[int] = 2020
     TRACK_DURATION_MIN_MS: ClassVar[int] = 120_000
     TRACK_DURATION_MAX_MS: ClassVar[int] = 360_000
 
@@ -38,11 +39,11 @@ class BaseFactory(ABC, Generic[RecordT]):
         self.faker = Faker()
         self.faker.seed_instance(config.seed)
         self.now = config.reference_date
-        self.start_year = self.START_YEAR
+        self.start_year = self.now.year - 4
         self.skip_chance_trend = np.linspace(
             self.SKIP_CHANCE_MIN,
             self.SKIP_CHANCE_MAX,
-            self.now.year - self.start_year + 1,
+            5,
         )
         print("🎵 Generating music catalog...")
         self._catalog = self._generate_catalog(num_records)
@@ -50,10 +51,14 @@ class BaseFactory(ABC, Generic[RecordT]):
         self._weighted_tracks = self._generate_weighted_tracks_by_year()
         for year, weighted_records in self._weighted_tracks.items():
             print(f" - {year}: {len(weighted_records)} records")
-        print("📅 Generating distribution over year...")
-        self._records_per_year = self._generate_distribution_over_year(num_records)
-        for year, n in self._records_per_year.items():
-            print(f" - {year}: {n} records")
+        print("🗂️ Building chapter sequence...")
+        self._chapters = self._build_chapters()
+        print("📅 Distributing records per chapter...")
+        self._records_per_chapter = self._distribute_records(num_records)
+        for chapter in self._chapters:
+            count = self._records_per_chapter[chapter.position]
+            label = chapter.persona.name if chapter.persona else "Ghost"
+            print(f" - {chapter.year} ({label}): {count} records")
 
     def _generate_catalog(self, num_records: int) -> list[BaseTrack]:
         n_artists = max(1, int(num_records * 0.20))
@@ -78,6 +83,10 @@ class BaseFactory(ABC, Generic[RecordT]):
                 )
                 for _ in range(n_tracks)
             ]
+
+    @property
+    def chapters(self) -> tuple[Chapter, ...]:
+        return tuple(self._chapters)
 
     @abstractmethod
     def _map_event(self, event: BaseEvent) -> RecordT: ...
@@ -112,20 +121,64 @@ class BaseFactory(ABC, Generic[RecordT]):
 
         return candidate
 
-    def _generate_distribution_over_year(self, n_records: int) -> dict[int, int]:
-        years = list(range(self.start_year, self.now.year + 1))
+    def _chapter_bounds(self, chapter: Chapter) -> tuple[date, date]:
+        first_day = date(chapter.year, 1, 1)
+        if chapter.year == self.now.year:
+            last_day = self.now.date()
+        else:
+            last_day = date(chapter.year, 12, 31)
+        return first_day, last_day
 
-        year_weights = [self.rng.uniform(0.5, 1.5) for _ in years]
-        total_weight = sum(year_weights)
+    def _select_gaps_for_chapter(self, chapter: Chapter) -> None:
+        persona = chapter.persona
+        if persona is None:
+            return
+        chapter_rng = random.Random(self.config.seed ^ chapter.position)
+        chapter.selected_month_windows = tuple(
+            chapter_rng.sample(persona.inactivity_month_windows, persona.n_month_gaps)
+        )
+        chapter.selected_day_windows = tuple(
+            chapter_rng.sample(persona.inactivity_day_windows, persona.n_day_gap_windows)
+        )
 
-        exact = {year: n_records * weight / total_weight for year, weight in zip(years, year_weights)}
-        base = {year: int(v) for year, v in exact.items()}
+    def _build_chapters(self) -> list[Chapter]:
+        ref_year = self.now.year
+        chapters: list[Chapter | None] = [None] * 5
+        chapters[4] = Chapter(year=ref_year, position=4, persona=TERMINAL_PERSONA)
+        ghost_position = self.rng.choice([1, 2, 3])
+        chapters[ghost_position] = Chapter(year=ref_year - (4 - ghost_position), position=ghost_position, persona=None)
+        remaining_positions = [p for p in (0, 1, 2, 3) if chapters[p] is None]
+        shuffled = list(ACTIVE_PERSONAS)
+        self.rng.shuffle(shuffled)
+        for position, persona in zip(remaining_positions, shuffled):
+            chapter = Chapter(
+                year=ref_year - (4 - position),
+                position=position,
+                persona=persona,
+            )
+            self._select_gaps_for_chapter(chapter)
+            chapters[position] = chapter
+        self._select_gaps_for_chapter(chapters[4])  # type: ignore[index]
+        return [ch for ch in chapters if ch is not None]
 
-        leftover = n_records - sum(base.values())
-        remainders = sorted(years, key=lambda y: exact[y] - base[y], reverse=True)
-        for year in remainders[:leftover]:
-            base[year] += 1
+    def _distribute_records(self, num_records: int) -> dict[int, int]:
+        share_units: dict[int, float] = {}
+        for chapter in self._chapters:
+            if chapter.persona is None:
+                share_units[chapter.position] = 0.0
+                continue
+            first_day, last_day = self._chapter_bounds(chapter)
+            duration_factor = (last_day - first_day).days / 365
+            share_units[chapter.position] = chapter.persona.volume_weight * duration_factor
 
+        total = sum(share_units.values())
+        exact = {pos: num_records * unit / total for pos, unit in share_units.items()}
+        base = {pos: int(value) for pos, value in exact.items()}
+        leftover = num_records - sum(base.values())
+
+        fractions = sorted(exact.items(), key=lambda kv: kv[1] - int(kv[1]), reverse=True)
+        for pos, _ in fractions[:leftover]:
+            base[pos] += 1
         return base
 
     def _generate_weighted_tracks_by_year(self) -> dict[int, list[int]]:
@@ -149,11 +202,14 @@ class BaseFactory(ABC, Generic[RecordT]):
     def _generate_base_events(self) -> list[BaseEvent]:
         events: list[BaseEvent] = []
         print("📅 Generating events...")
-        for year, count in self._records_per_year.items():
-            skip_chance = self.skip_chance_trend[year - self.start_year]
-            for _ in track(range(count), description=f" - {year}"):
-                ts = self._get_random_datetime_for_year(year)
-                track_index = self.rng.choice(self._weighted_tracks[year])
+        for chapter in self._chapters:
+            if chapter.persona is None:
+                continue
+            count = self._records_per_chapter[chapter.position]
+            skip_chance = self.skip_chance_trend[chapter.position]
+            for _ in track(range(count), description=f" - {chapter.year} ({chapter.persona.name})"):
+                ts = self._get_random_datetime_for_year(chapter.year)
+                track_index = self.rng.choice(self._weighted_tracks[chapter.year])
                 is_skipped = self.rng.random() < skip_chance
                 if is_skipped:
                     duration_ratio = self.rng.uniform(0.05, 0.30)

--- a/synthetic-datasets/tests/factories/test_base_factory.py
+++ b/synthetic-datasets/tests/factories/test_base_factory.py
@@ -1,3 +1,4 @@
+import dataclasses
 import random
 from datetime import datetime
 
@@ -29,7 +30,7 @@ def factory(config):
 
 
 def test_get_random_datetime_for_year_returns_correct_year(factory):
-    for year in range(2020, 2026):
+    for year in range(factory.start_year, factory.now.year + 1):
         dt = factory._get_random_datetime_for_year(year)
         assert dt.year == year
 
@@ -41,53 +42,10 @@ def test_get_random_datetime_for_current_year_never_future(factory):
         assert dt <= factory.now
 
 
-def test_generate_distribution_over_year_sums_to_n(factory):
-    for n in [0, 1, 50, 100, 999]:
-        result = factory._generate_distribution_over_year(n)
-        assert sum(result.values()) == n
-
-
-def test_generate_distribution_over_year_largest_remainder(factory, config):
-    # Edge cases: sum must always equal n_records
-    for n in [0, 1, 3, 100, 1000]:
-        result = factory._generate_distribution_over_year(n)
-        assert sum(result.values()) == n, f"sum mismatch for n={n}"
-
-    # Determinism: same seed produces same distribution
-    factory_a = ConcreteFactory(num_records=10, config=config)
-    factory_b = ConcreteFactory(num_records=10, config=config)
-    assert factory_a._generate_distribution_over_year(97) == factory_b._generate_distribution_over_year(97)
-
-    # Largest remainder correctness: monkey-patch weights so we can predict the result.
-    # With equal weights across N years, each year gets exactly n_records / N.
-    # When not evenly divisible the remainder must be spread one per year starting
-    # from the first years (all fractional parts are equal so ordering is stable).
-
-    years = list(range(factory.start_year, factory.now.year + 1))
-    n_years = len(years)
-    n = n_years * 3 + 1  # e.g. 19 for 6 years => floor=3 per year, leftover=1
-
-    # Temporarily replace rng.uniform to return a constant weight
-    original_uniform = factory.rng.uniform
-    factory.rng.uniform = lambda a, b: 1.0  # type: ignore[method-assign]
-    result = factory._generate_distribution_over_year(n)
-    factory.rng.uniform = original_uniform  # type: ignore[method-assign]
-
-    assert sum(result.values()) == n
-    floor_val = n // n_years
-    ceil_val = floor_val + 1
-    leftover = n - floor_val * n_years
-    assert sum(1 for v in result.values() if v == ceil_val) == leftover
-    assert sum(1 for v in result.values() if v == floor_val) == n_years - leftover
-    # All values must be floor or ceil — no other values allowed
-    for v in result.values():
-        assert v in (floor_val, ceil_val), f"unexpected count {v}"
-
-
 def test_rng_seeding_is_deterministic(config):
     f1 = ConcreteFactory(num_records=50, config=config)
     f2 = ConcreteFactory(num_records=50, config=config)
-    assert f1._records_per_year == f2._records_per_year
+    assert f1._records_per_chapter == f2._records_per_chapter
 
 
 def test_instance_level_rngs_exist(factory):
@@ -120,9 +78,9 @@ def test_generate_base_events_returns_sorted_events(factory):
     assert timestamps == sorted(timestamps)
 
 
-def test_generate_base_events_count_matches_records_per_year(factory):
+def test_generate_base_events_count_matches_records_per_chapter(factory):
     events = factory._generate_base_events()
-    assert len(events) == sum(factory._records_per_year.values())
+    assert len(events) == sum(factory._records_per_chapter.values())
 
 
 def test_base_event_duration_ratio_skipped(config):
@@ -138,7 +96,7 @@ def test_base_event_duration_ratio_skipped(config):
 def test_create_streaming_history_count(config):
     factory = ConcreteFactory(num_records=50, config=config)
     records = factory.create_streaming_history()
-    assert len(records) == sum(factory._records_per_year.values())
+    assert len(records) == sum(factory._records_per_chapter.values())
 
 
 def test_same_seed_same_output(config):
@@ -147,6 +105,79 @@ def test_same_seed_same_output(config):
     f2 = ConcreteFactory(num_records=50, config=config)
     r2 = f2.create_streaming_history()
     assert r1 == r2
+
+
+def test_build_chapters_returns_five(factory):
+    assert len(factory.chapters) == 5
+
+
+def test_position_four_is_current_era(factory):
+    assert factory.chapters[4].position == 4
+    from synthetic_datasets.personas import CURRENT_ERA
+
+    assert factory.chapters[4].persona == CURRENT_ERA
+
+
+def test_position_zero_never_ghost(factory):
+    assert factory.chapters[0].persona is not None
+
+
+def test_exactly_one_ghost(factory):
+    ghost_count = sum(1 for ch in factory.chapters if ch.persona is None)
+    assert ghost_count == 1
+
+
+def test_same_seed_same_chapter_ordering(config):
+    f1 = ConcreteFactory(num_records=50, config=config)
+    f2 = ConcreteFactory(num_records=50, config=config)
+    for ch1, ch2 in zip(f1.chapters, f2.chapters):
+        assert ch1.position == ch2.position
+        assert ch1.year == ch2.year
+        assert (ch1.persona is None) == (ch2.persona is None)
+        if ch1.persona is not None and ch2.persona is not None:
+            assert ch1.persona.name == ch2.persona.name
+
+
+def test_different_seeds_different_ordering(config):
+    configs = [
+        config,
+        dataclasses.replace(config, seed=42),
+        dataclasses.replace(config, seed=999),
+    ]
+    factories = [ConcreteFactory(num_records=50, config=c) for c in configs]
+    chapter_sequences = [
+        tuple((ch.position, ch.persona.name if ch.persona else None) for ch in f.chapters) for f in factories
+    ]
+    assert len(set(chapter_sequences)) >= 2  # At least 2 different orderings among 3 seeds
+
+
+def test_ghost_gets_zero_records(factory):
+    for chapter in factory.chapters:
+        if chapter.persona is None:
+            assert factory._records_per_chapter[chapter.position] == 0
+
+
+def test_records_sum_equals_num_records(config):
+    for num in [50, 100, 500, 1000]:
+        factory = ConcreteFactory(num_records=num, config=config)
+        assert sum(factory._records_per_chapter.values()) == num
+
+
+def test_chapters_property_is_tuple_of_chapter(factory):
+    from synthetic_datasets.chapters import Chapter
+
+    assert isinstance(factory.chapters, tuple)
+    assert all(isinstance(ch, Chapter) for ch in factory.chapters)
+
+
+def test_at_least_one_active_chapter_has_month_windows(factory):
+    active_chapters = [ch for ch in factory.chapters if ch.persona is not None]
+    assert any(ch.selected_month_windows for ch in active_chapters)
+
+
+def test_at_least_one_active_chapter_has_day_windows(factory):
+    active_chapters = [ch for ch in factory.chapters if ch.persona is not None]
+    assert any(ch.selected_day_windows for ch in active_chapters)
 
 
 def test_global_random_not_used(config):

--- a/synthetic-datasets/tests/factories/test_gaps.py
+++ b/synthetic-datasets/tests/factories/test_gaps.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+
+import pytest
+
+from synthetic_datasets.config import GenerationConfig
+from synthetic_datasets.factories.base import BaseFactory
+from synthetic_datasets.models.base import BaseEvent
+
+
+class ConcreteFactory(BaseFactory[str]):
+    def _map_event(self, event: BaseEvent) -> str:
+        return f"record:{event.track_index}"
+
+
+@pytest.fixture
+def config():
+    return GenerationConfig(seed=42, reference_date=datetime(2026, 2, 8))
+
+
+@pytest.fixture
+def factory(config):
+    return ConcreteFactory(num_records=10, config=config)
+
+
+def test_year_gap_present(factory):
+    ghost_count = sum(1 for ch in factory.chapters if ch.persona is None)
+    assert ghost_count == 1
+
+
+def test_month_gap_present(factory):
+    active_chapters = [ch for ch in factory.chapters if ch.persona is not None]
+    assert any(ch.selected_month_windows for ch in active_chapters)
+
+
+def test_day_gap_present(factory):
+    active_chapters = [ch for ch in factory.chapters if ch.persona is not None]
+    assert any(ch.selected_day_windows for ch in active_chapters)
+
+
+def test_gap_layout_deterministic(config):
+    f1 = ConcreteFactory(num_records=10, config=config)
+    f2 = ConcreteFactory(num_records=10, config=config)
+    for ch1, ch2 in zip(f1.chapters, f2.chapters):
+        assert ch1.selected_month_windows == ch2.selected_month_windows
+        assert ch1.selected_day_windows == ch2.selected_day_windows
+
+
+def test_selected_windows_dates_within_chapter_year(factory):
+    for chapter in factory.chapters:
+        for date_obj in chapter.inactivity_dates:
+            assert date_obj.year == chapter.year
+
+
+def test_day_windows_taken_whole(factory):
+    for chapter in factory.chapters:
+        for window in chapter.selected_day_windows:
+            window_dates = set(window.to_dates(chapter.year))
+            assert window_dates.issubset(chapter.inactivity_dates)


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Generated datasets look monotone across all years. Demo charts in SimpleView show flat distributions: SkipRate never reaches Skip Master, SessionAnalysis never surfaces Marathon, EvolutionOverTime shows no narrative. Every year looks the same.

## 🎹 Proposal

Introduce a chapter system where each year is driven by a distinct persona. Five chapters per dataset: Night Owl, Morning Commuter, Settled Listener, Current Era, and one Ghost (completely empty year). Each persona biases the volume, inactivity periods, and skip behavior for its year.

Records are distributed across chapters proportionally using each persona's volume weight and year duration, so a high-volume persona naturally produces more events than a quieter one.

Gap selection is deterministic: inactivity windows are sampled per chapter using an isolated RNG seeded by position, so the same seed always produces the same gap layout.

Datetime, catalog selection, and skip logic remain on the existing per-year path for now. They migrate to per-chapter in the next issues.

## 🎶 Comments

Closes part of issue #436. This slice delivers the year gap (Ghost chapter) and the month/day gap selection. The persona-driven datetime and skip behavior that fully satisfies the month/day acceptance criteria comes in future issues.

No PR-only acceptance test commit in this slice. That commit is added in issue 6.

## 🎤 Test

```bash
moon run synthetic-datasets:generate -- 1000 --provider spotify
moon run app:dev
```

Load the generated file in the app. In SimpleView, confirm:
- EvolutionOverTime shows one completely empty year (Ghost chapter)
- Calendar heatmap shows empty months and day blocks in active years
- Stream count varies across years (chapter volume weights differ)