### PR TITLE
refactor(synthetic-datasets): persona-driven datetime, skip, and shuffle in event generation

### DIFF
--- a/.github/workflows/datasets-test-synthetic.yml
+++ b/.github/workflows/datasets-test-synthetic.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Verify e2e dataset hashes
         working-directory: ${{ github.workspace }}
         env:
-          EXPECTED_JSON_HASH: "986df6877dbdf585d639ec035fb999d05ae45d2c3f5fbfc5c5eeb6da7d3b87ce"
-          EXPECTED_ZIP_HASH: "8da5fb0293424d2660cfe20a773f9d499e770d6ca8e7808dcbeff50b18c748f3"
+          EXPECTED_JSON_HASH: "3021ad3c9c78019a6605aff4dfd61a153fdba788ae870e4ee5abb5ce70e87d21"
+          EXPECTED_ZIP_HASH: "5cc794c530605ab2b2bc575f0c9dc2d1416f0b2a4a9cff8e707f8d809816a92e"
         run: |
           JSON_FILE="e2e/datasets/spotify/Streaming_History_Audio_2006_1000.json"
           ZIP_FILE="e2e/datasets/spotify/streamings_1000.zip"

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -1,4 +1,3 @@
-import calendar
 import random
 from abc import ABC, abstractmethod
 from datetime import date, datetime, timedelta
@@ -12,7 +11,7 @@ from rich.progress import track
 from ..chapters import Chapter
 from ..config import GenerationConfig
 from ..models.base import BaseEvent, BaseTrack
-from ..personas import ACTIVE_PERSONAS, TERMINAL_PERSONA
+from ..personas import ACTIVE_PERSONAS, TERMINAL_PERSONA, PersonaProfile
 
 _console = get_console()
 
@@ -20,15 +19,7 @@ RecordT = TypeVar("RecordT")
 
 
 class BaseFactory(ABC, Generic[RecordT]):
-    month_weights: ClassVar[list[float]] = [0.08, 0.07, 0.07, 0.06, 0.07, 0.08, 0.08, 0.08, 0.1, 0.10, 0.11, 0.1]
-    hour_weights: ClassVar[list[float]] = [
-        0.01, 0.01, 0.01, 0.01, 0.02, 0.04, 0.07, 0.09, 0.08, 0.06, 0.04, 0.04,
-        0.05, 0.03, 0.04, 0.05, 0.05, 0.06, 0.07, 0.06, 0.05, 0.03, 0.02, 0.01,
-    ]  # fmt: skip
-
     ZIPF_A: ClassVar[float] = 1.8
-    SKIP_CHANCE_MIN: ClassVar[float] = 0.15
-    SKIP_CHANCE_MAX: ClassVar[float] = 0.30
     TRACK_DURATION_MIN_MS: ClassVar[int] = 120_000
     TRACK_DURATION_MAX_MS: ClassVar[int] = 360_000
     ROLE_BOOST: ClassVar[dict[str, float]] = {"core": 3.0, "favored": 1.0, "noise": 0.2}
@@ -40,12 +31,6 @@ class BaseFactory(ABC, Generic[RecordT]):
         self.faker = Faker()
         self.faker.seed_instance(config.seed)
         self.now = config.reference_date
-        self.start_year = self.now.year - 4
-        self.skip_chance_trend = np.linspace(
-            self.SKIP_CHANCE_MIN,
-            self.SKIP_CHANCE_MAX,
-            5,
-        )
         print("🎵 Generating music catalog...")
         self._catalog = self._generate_catalog(num_records)
         print("🗂️ Building chapter sequence...")
@@ -60,6 +45,14 @@ class BaseFactory(ABC, Generic[RecordT]):
         self._weighted_tracks_per_chapter = self._generate_weighted_tracks_per_chapter()
         for position, pool in self._weighted_tracks_per_chapter.items():
             print(f" - position {position}: {len(pool)} weighted entries")
+        print("🕐 Precomputing day/hour distributions per chapter...")
+        self._day_distribution_per_chapter: dict[int, tuple[list[date], list[float]]] = {}
+        self._hour_distribution_per_chapter: dict[int, list[float]] = {}
+        for chapter in self._chapters:
+            if chapter.persona is None:
+                continue
+            self._day_distribution_per_chapter[chapter.position] = self._build_day_distribution(chapter)
+            self._hour_distribution_per_chapter[chapter.position] = self._build_hour_distribution(chapter.persona)
 
     def _generate_catalog(self, num_records: int) -> list[BaseTrack]:
         n_artists = max(1, int(num_records * 0.20))
@@ -92,36 +85,6 @@ class BaseFactory(ABC, Generic[RecordT]):
     @abstractmethod
     def _map_event(self, event: BaseEvent) -> RecordT: ...
 
-    def _get_random_datetime_for_year(self, year: int) -> datetime:
-        if year < self.now.year:
-            months = np.arange(1, 13)
-            month_weights = np.array(self.month_weights)
-        else:
-            months = np.arange(1, self.now.month + 1)
-            month_weights = np.array(self.month_weights[: self.now.month])
-
-        month_weights = month_weights / month_weights.sum()
-        month = self.np_rng.choice(months, p=month_weights)
-
-        max_day = calendar.monthrange(year, int(month))[1]
-        day = self.rng.randint(1, max_day)
-
-        hour_weights = np.array(self.hour_weights)
-        hour_weights = hour_weights / hour_weights.sum()
-        hour = self.np_rng.choice(range(24), p=hour_weights)
-
-        minute = self.rng.randint(0, 59)
-        second = self.rng.randint(0, 59)
-
-        candidate = datetime(year, int(month), day, int(hour), minute, second)
-
-        if candidate > self.now:
-            start = datetime(year, 1, 1)
-            delta_seconds = int((self.now - start).total_seconds())
-            return start + timedelta(seconds=self.rng.randint(0, delta_seconds))
-
-        return candidate
-
     def _chapter_bounds(self, chapter: Chapter) -> tuple[date, date]:
         first_day = date(chapter.year, 1, 1)
         if chapter.year == self.now.year:
@@ -129,6 +92,29 @@ class BaseFactory(ABC, Generic[RecordT]):
         else:
             last_day = date(chapter.year, 12, 31)
         return first_day, last_day
+
+    def _build_day_distribution(self, chapter: Chapter) -> tuple[list[date], list[float]]:
+        persona = chapter.persona
+        assert persona is not None
+        first_day, last_day = self._chapter_bounds(chapter)
+        inactivity = chapter.inactivity_dates
+        days: list[date] = []
+        weights: list[float] = []
+        current = first_day
+        while current <= last_day:
+            if current not in inactivity:
+                month_w = persona.month_weights[current.month - 1]
+                weekday_w = persona.weekday_multipliers[current.weekday()]
+                days.append(current)
+                weights.append(month_w * weekday_w)
+            current = current + timedelta(days=1)
+        total = sum(weights)
+        probs = [w / total for w in weights]
+        return days, probs
+
+    def _build_hour_distribution(self, persona: PersonaProfile) -> list[float]:
+        total = sum(persona.hour_weights)
+        return [w / total for w in persona.hour_weights]
 
     def _select_gaps_for_chapter(self, chapter: Chapter) -> None:
         persona = chapter.persona
@@ -214,30 +200,42 @@ class BaseFactory(ABC, Generic[RecordT]):
 
         return result
 
+    def _generate_events_for_chapter(self, chapter: Chapter) -> list[BaseEvent]:
+        persona = chapter.persona
+        assert persona is not None
+        count = self._records_per_chapter[chapter.position]
+        weighted_pool = self._weighted_tracks_per_chapter[chapter.position]
+        days, day_probs = self._day_distribution_per_chapter[chapter.position]
+        hour_probs = self._hour_distribution_per_chapter[chapter.position]
+
+        day_indices = self.np_rng.choice(len(days), size=count, p=day_probs)
+        hour_values = self.np_rng.choice(24, size=count, p=hour_probs)
+
+        events: list[BaseEvent] = []
+        for i in range(count):
+            day = days[int(day_indices[i])]
+            hour = int(hour_values[i])
+            minute = self.rng.randint(0, 59)
+            second = self.rng.randint(0, 59)
+            ts = datetime(day.year, day.month, day.day, hour, minute, second)
+            track_index = self.rng.choice(weighted_pool)
+            is_skipped = self.rng.random() < persona.skip_chance
+            duration_ratio = self.rng.uniform(0.05, 0.30) if is_skipped else self.rng.uniform(0.90, 1.00)
+            shuffle = self.rng.random() < persona.shuffle_chance
+            events.append(BaseEvent(ts, track_index, is_skipped, duration_ratio, shuffle))
+        return events
+
     def _generate_base_events(self) -> list[BaseEvent]:
         events: list[BaseEvent] = []
         print("📅 Generating events...")
         for chapter in self._chapters:
             if chapter.persona is None:
                 continue
-            count = self._records_per_chapter[chapter.position]
-            skip_chance = self.skip_chance_trend[chapter.position]
-            for _ in track(range(count), description=f" - {chapter.year} ({chapter.persona.name})"):
-                ts = self._get_random_datetime_for_year(chapter.year)
-                track_index = self.rng.choice(self._weighted_tracks_per_chapter[chapter.position])
-                is_skipped = self.rng.random() < skip_chance
-                if is_skipped:
-                    duration_ratio = self.rng.uniform(0.05, 0.30)
-                else:
-                    duration_ratio = self.rng.uniform(0.90, 1.00)
-                events.append(
-                    BaseEvent(
-                        timestamp=ts,
-                        track_index=track_index,
-                        is_skipped=is_skipped,
-                        duration_ratio=duration_ratio,
-                    )
-                )
+            label = chapter.persona.name
+            chapter_events = self._generate_events_for_chapter(chapter)
+            for _ in track(range(len(chapter_events)), description=f" - {chapter.year} ({label})"):
+                pass
+            events.extend(chapter_events)
         return sorted(events, key=lambda e: e.timestamp)
 
     def create_streaming_history(self) -> list[RecordT]:

--- a/synthetic-datasets/synthetic_datasets/factories/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/factories/spotify.py
@@ -75,7 +75,7 @@ class SpotifyFactory(BaseFactory[Streaming]):
             spotify_track_uri=track.uri,
             reason_start=self.rng.choice(self.reason_start),
             reason_end=ReasonEndEnum.FORWARD_BUTTON if event.is_skipped else ReasonEndEnum.TRACK_DONE,
-            shuffle=bool(self.rng.getrandbits(1)),
+            shuffle=event.shuffle,
             skipped=event.is_skipped,
             offline=is_offline,
             offline_timestamp=int((ts - timedelta(minutes=self.rng.randint(1, 60))).timestamp())

--- a/synthetic-datasets/synthetic_datasets/models/base.py
+++ b/synthetic-datasets/synthetic_datasets/models/base.py
@@ -16,3 +16,4 @@ class BaseEvent:
     track_index: int
     is_skipped: bool
     duration_ratio: float
+    shuffle: bool = False

--- a/synthetic-datasets/tests/factories/test_base_factory.py
+++ b/synthetic-datasets/tests/factories/test_base_factory.py
@@ -29,19 +29,6 @@ def factory(config):
     return ConcreteFactory(num_records=10, config=config)
 
 
-def test_get_random_datetime_for_year_returns_correct_year(factory):
-    for year in range(factory.start_year, factory.now.year + 1):
-        dt = factory._get_random_datetime_for_year(year)
-        assert dt.year == year
-
-
-def test_get_random_datetime_for_current_year_never_future(factory):
-    current_year = factory.now.year
-    for _ in range(100):
-        dt = factory._get_random_datetime_for_year(current_year)
-        assert dt <= factory.now
-
-
 def test_rng_seeding_is_deterministic(config):
     f1 = ConcreteFactory(num_records=50, config=config)
     f2 = ConcreteFactory(num_records=50, config=config)
@@ -213,6 +200,94 @@ def test_global_random_not_used(config):
     r2 = f2.create_streaming_history()
 
     assert r1 == r2
+
+
+class TestPersonaDrivenGeneration:
+    def test_no_timestamp_in_inactivity_dates(self, config):
+        factory = ConcreteFactory(num_records=200, config=config)
+        events = factory._generate_base_events()
+        for chapter in factory.chapters:
+            if chapter.persona is None:
+                continue
+            chapter_events = [e for e in events if e.timestamp.year == chapter.year]
+            for event in chapter_events:
+                assert event.timestamp.date() not in chapter.inactivity_dates, (
+                    f"Event on {event.timestamp.date()} falls in inactivity for {chapter.year}"
+                )
+
+    def test_no_timestamp_outside_chapter_year(self, config):
+        factory = ConcreteFactory(num_records=200, config=config)
+        events = factory._generate_base_events()
+        valid_years = {ch.year for ch in factory.chapters}
+        for event in events:
+            assert event.timestamp.year in valid_years
+
+    def test_no_timestamp_exceeds_reference_date(self, config):
+        factory = ConcreteFactory(num_records=200, config=config)
+        events = factory._generate_base_events()
+        for event in events:
+            assert event.timestamp <= factory.now
+
+    def test_skip_chance_constants_removed(self):
+        assert not hasattr(ConcreteFactory, "SKIP_CHANCE_MIN")
+        assert not hasattr(ConcreteFactory, "SKIP_CHANCE_MAX")
+
+    def test_skip_chance_trend_not_on_instance(self, config):
+        factory = ConcreteFactory(num_records=10, config=config)
+        assert not hasattr(factory, "skip_chance_trend")
+
+    def test_class_level_month_weights_removed(self):
+        assert not hasattr(ConcreteFactory, "month_weights")
+
+    def test_class_level_hour_weights_removed(self):
+        assert not hasattr(ConcreteFactory, "hour_weights")
+
+    def test_get_random_datetime_for_year_removed(self, config):
+        factory = ConcreteFactory(num_records=10, config=config)
+        assert not hasattr(factory, "_get_random_datetime_for_year")
+
+    def test_day_distribution_per_chapter_exists(self, config):
+        factory = ConcreteFactory(num_records=50, config=config)
+        assert hasattr(factory, "_day_distribution_per_chapter")
+        for chapter in factory.chapters:
+            if chapter.persona is None:
+                continue
+            days, probs = factory._day_distribution_per_chapter[chapter.position]
+            assert len(days) > 0
+            assert abs(sum(probs) - 1.0) < 1e-9
+
+    def test_hour_distribution_per_chapter_exists(self, config):
+        factory = ConcreteFactory(num_records=50, config=config)
+        assert hasattr(factory, "_hour_distribution_per_chapter")
+        for chapter in factory.chapters:
+            if chapter.persona is None:
+                continue
+            hour_probs = factory._hour_distribution_per_chapter[chapter.position]
+            assert len(hour_probs) == 24
+            assert abs(sum(hour_probs) - 1.0) < 1e-9
+
+    def test_base_event_has_shuffle(self, config):
+        factory = ConcreteFactory(num_records=100, config=config)
+        events = factory._generate_base_events()
+        assert all(hasattr(e, "shuffle") for e in events)
+        assert any(e.shuffle for e in events)
+        assert any(not e.shuffle for e in events)
+
+    def test_day_distribution_excludes_inactivity(self, config):
+        factory = ConcreteFactory(num_records=50, config=config)
+        for chapter in factory.chapters:
+            if chapter.persona is None or not chapter.inactivity_dates:
+                continue
+            days, _ = factory._day_distribution_per_chapter[chapter.position]
+            for day in days:
+                assert day not in chapter.inactivity_dates
+
+    def test_current_era_day_distribution_clamped(self, config):
+        factory = ConcreteFactory(num_records=50, config=config)
+        era_chapter = factory.chapters[4]
+        days, _ = factory._day_distribution_per_chapter[era_chapter.position]
+        for day in days:
+            assert day <= factory.now.date()
 
 
 class TestCrossProviderCatalogConsistency:

--- a/synthetic-datasets/tests/factories/test_spotify.py
+++ b/synthetic-datasets/tests/factories/test_spotify.py
@@ -14,3 +14,18 @@ def test_create_streaming_history(num_records, default_generation_config):
     assert len(streamings) == num_records
     for streaming in streamings:
         assert isinstance(streaming, Streaming)
+
+
+def test_shuffle_read_from_event(default_generation_config):
+    factory = SpotifyFactory(num_records=100, config=default_generation_config)
+    streamings = factory.create_streaming_history()
+    assert any(s.shuffle for s in streamings)
+    assert any(not s.shuffle for s in streamings)
+
+
+def test_shuffle_deterministic_from_seed(default_generation_config):
+    f1 = SpotifyFactory(num_records=50, config=default_generation_config)
+    r1 = f1.create_streaming_history()
+    f2 = SpotifyFactory(num_records=50, config=default_generation_config)
+    r2 = f2.create_streaming_history()
+    assert [s.shuffle for s in r1] == [s.shuffle for s in r2]

--- a/synthetic-datasets/tests/models/test_base.py
+++ b/synthetic-datasets/tests/models/test_base.py
@@ -18,6 +18,13 @@ def test_base_event_fields():
     assert event.track_index == 3
     assert event.is_skipped is False
     assert event.duration_ratio == 0.95
+    assert event.shuffle is False
+
+
+def test_base_event_shuffle_field():
+    ts = datetime(2024, 1, 1, 12, 0, 0)
+    event = BaseEvent(timestamp=ts, track_index=0, is_skipped=True, duration_ratio=0.1, shuffle=True)
+    assert event.shuffle is True
 
 
 def test_base_track_is_dataclass():


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Synthetic datasets produce uniform listening patterns regardless of seed. Every year looks the same: timestamps scatter evenly across months and hours, skip rates follow a linear trend, and shuffle is a coin flip. Charts in SimpleView never reach the extremes needed to trigger meaningful classifications -- Skip Master, Marathon sessions, strong hour-of-day peaks, or visible gaps in the calendar heatmap all stay out of reach.

## 🎹 Proposal

Event generation is now driven entirely by the persona assigned to each chapter.

Timestamps come from a joint day/hour distribution precomputed once per chapter. Each day in the chapter year is weighted by the persona's `month_weights` and `weekday_multipliers`, and any day that falls inside the chapter's inactivity windows is excluded before the distribution is built. Hour selection uses the persona's `hour_weights`. Both dimensions are sampled with a single `np_rng.choice` call -- no rejection loops, no unbounded retries, no timestamps leaking past the reference date.

Skip and shuffle are persona constants. `SKIP_CHANCE_MIN`, `SKIP_CHANCE_MAX`, and the linear `skip_chance_trend` are removed; each event draws from `persona.skip_chance`. Shuffle is now a field on `BaseEvent`, computed from `persona.shuffle_chance` during generation. Spotify reads `event.shuffle`; Apple Music and Deezer are unaffected. `incognito_mode` remains a coin flip.

The class-level `month_weights` and `hour_weights` on `BaseFactory` are removed alongside `_get_random_datetime_for_year`.

## 🎶 Comments

Part of the chapter-based synthetic dataset system. Blocked on the chapter sequence, gap selection, and per-chapter catalog work that landed earlier on this branch's parent work.

The Night Owl persona concentrates hour weights between 22h and 02h with high skip chance (0.45) and shuffle (0.75). Morning Commuter peaks at 07h-09h and 18h-19h on weekdays with low skip (0.18). Settled Listener fills 14h-20h with very low skip (0.08). These distributions are starting points; calibration against SimpleView charts is the next step.

## 🎤 Test

```bash
moon run synthetic-datasets:generate -- 1000 --provider spotify
```

Load the generated file in the app and open SimpleView. Inspect:
- SkipRate: Night Owl year should trend toward Skip Master
- SessionAnalysis: Night Owl year should show Marathon
- ListeningRhythm: distinct hour peaks per year (night, morning, afternoon)
- Calendar heatmap: empty month and empty day-range visible in active chapters
- EvolutionOverTime: one fully empty year (Ghost chapter)