### PR TITLE
docs: per-subproject AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,138 +1,70 @@
 # AGENTS.md
 
 ## Project Overview
-Tracksy: privacy-first music streaming data viz tool. Monorepo via [Moon](https://moonrepo.dev/), three components:
 
-- **`app/`**: Astro + React web app, DuckDB WASM for client-side data processing
-- **`synthetic-datasets/`**: Python scripts for synthetic music streaming history generation
-- **`blog/`**: Gohugo-based site
+Tracksy: privacy-first music streaming data viz tool. Monorepo via [Moon](https://moonrepo.dev/).
 
-**Tech Stack:**
-- **App:** Astro, React, TypeScript, TailwindCSS, DuckDB WASM, Vitest
-- **Synthetic Datasets:** Python, Faker, NumPy, openpyxl, Pydantic, pytest, Ruff, ty
-- **Blog:** Gohugo
+| Component | Stack | Guide |
+|-----------|-------|-------|
+| `app/` | Astro, React, TypeScript, TailwindCSS, DuckDB WASM, Vitest | [app/AGENTS.md](app/AGENTS.md) |
+| `synthetic-datasets/` | Python, Faker, NumPy, openpyxl, Pydantic, pytest, Ruff, ty | [synthetic-datasets/AGENTS.md](synthetic-datasets/AGENTS.md) |
+| `blog/` | Gohugo | [blog/AGENTS.md](blog/AGENTS.md) |
+| `e2e/` | Playwright | [e2e/AGENTS.md](e2e/AGENTS.md) |
 
-**Privacy:** All processing client-side in browser.
+**Privacy:** All processing client-side in browser. No server-side storage, no external API calls with user data.
 
 ## Setup
-Initialize workspace:
 
 ```bash
 moon setup  # Downloads Node.js, Python, and dependencies
 ```
 
-## Dev Environment Tips
+## Common Commands
+
+- `moon run :test` — run all tests across monorepo
 - `moon run app:dev` — start web app dev server
 - `moon run blog:dev` — start blog dev server
-- `moon run synthetic-datasets:generate -- 100 --provider spotify` — generate 100 Spotify records
-- `moon run synthetic-datasets:generate -- --seed 42` — generate deterministic records with seed
-- `moon run synthetic-datasets:generate -- --help` — show generation help
-- `moon run :test` — run all tests across monorepo
-- Prefer moon tasks in `app/moon.yml` and `synthetic-datasets/moon.yml` over raw `moon run app:pnpm` or `moon run synthetic-datasets:uv`.
-
-## Code Style
-- TypeScript strict mode enabled
-- Prettier: `moon run app:format`
-- Lint before commit: `moon run app:lint`
-- Components: `.astro` for static content, `.tsx` for interactive React components
-- Follow Astro's islands architecture pattern
-- File naming: kebab-case files, PascalCase components, camelCase functions
-- Components: focused, single-purpose
-- Separate business logic from UI components
-
-## Testing Instructions
-
-### App testing
-- `moon run app:test` — run all app tests
-- `moon run app:test-coverage` — coverage report
-- Focus specific test: `moon run app:test -- -t "<test name>"`
-- Focus specific file: `moon run app:test -- <file path : src/component.test.ts>`
-- All tests must pass before committing
-- **IMPORTANT:** Use `vi.spyOn()` not `vi.mock()` (ESLint enforced)
-  ```ts
-  // ❌ Bad
-  vi.mock("../db/queries", () => ({ getUser: vi.fn() }));
-
-  // ✅ Good
-  import * as queries from "../db/queries";
-  vi.spyOn(queries, "getUser").mockResolvedValue(mockUser);
-  ```
-- Add/update tests for any code changes, even if not requested
-- Fix all type errors and lint issues before submitting
-
-#### Astro Testing
-Astro outputs raw HTML — e2e tests can use build output. Vitest and React Testing Library work for React component tests.
-
-See Astro's [testing guide](https://docs.astro.build/en/guides/testing/).
-
-### End-to-End Testing
-Tracksy e2e built with Playwright.
-
-See [E2E README](e2e/README.md) and [Playwright documentation](https://playwright.dev/docs/intro).
-
-## CI/CD
-- Workflows in `.github/workflows/`
 
 ## Commit Conventions
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
-- `feat(scope): description` - New feature
-- `fix(scope): description` - Bug fix
-- `docs: description` - Documentation changes
-- `style: description` - Code formatting (no logic change)
-- `refactor: description` - Code restructuring
-- `test: description` - Test additions/corrections
-- `chore: description` - Build/tooling changes
 
-Examples:
-```
-feat(charts): add streaming trends visualization
-fix(upload): resolve file parsing timeout
-docs: update setup instructions
-```
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `feat(scope): description` — new feature
+- `fix(scope): description` — bug fix
+- `docs: description` — documentation changes
+- `style: description` — code formatting (no logic change)
+- `refactor: description` — code restructuring
+- `test: description` — test additions/corrections
+- `chore: description` — build/tooling changes
+
+All tests and quality checks must pass before committing.
+
+See sub-project AGENTS.md for format/lint/test/typecheck commands.
 
 ## PR Instructions
-1. Create feature branch from `main`: `git checkout -b feat/your-feature-name`
-2. Focused, atomic commits per conventions
+
+1. Feature branch from `main`: `git checkout -b feat/your-feature-name`
+2. Focused, atomic commits per conventions above
 3. Before submitting, rebase on latest main:
    ```bash
-   git fetch origin
-   git rebase origin/main
+   git fetch origin && git rebase origin/main
    ```
-4. Quality checks:
-   ```bash
-   moon run app:lint
-   moon run app:test
-   moon run app:format-check
-   ```
+4. Quality checks: see sub-project AGENTS.md for format/lint/test/typecheck commands
 5. All tests must pass before merging
 6. Use **rebase and merge** strategy (enforced)
-7. Squash related commits for single logical changes
 
-## Architecture Notes
-- **Data Flow:** User uploads file → `StreamProvider` detects format + parses → DuckDB WASM → Observable Plot/D3.js visualization
-  - Spotify: ZIP or JSON (`Streaming_History_Audio_*.json`)
-  - Deezer: XLSX (`deezer-data_\d{10}.xlsx`), sheet `10_listeningHistory`, parsed via DuckDB Excel extension
-- **StreamProvider pattern:** `app/src/streamProvider/` — extensible adapter for multi-source support. Each provider implements `filePattern`, `readFile()`, `transform()` → canonical `StreamRecord` objects. Register new providers in `index.ts`.
-- **Key Directories:**
-  - `app/src/components/`: React and Astro components
-  - `app/src/pages/`: Astro page routes
-  - `app/src/db/`: DuckDB queries and database logic
-  - `app/src/streamProvider/`: Provider adapters (Spotify, Deezer)
-  - `synthetic-datasets/`: Python test data generation (supports `--provider spotify|deezer`)
+## CI/CD
 
-## Environment Variables
-See `app/.env.example` for required config.
+Workflows in `.github/workflows/`.
 
-## Security Considerations
-- **No server-side data storage** — all processing client-side
-- **No external API calls** with user data
+## Security
+
+- No server-side data storage — all processing client-side
+- No external API calls with user data
 - Review `SECURITY.md` for vulnerability reporting
 - `moon run app:audit` — check dependency vulnerabilities
 
 ## Additional Resources
+
 - [Contributing Guide](CONTRIBUTING.md)
-- [App-specific README](app/README.md)
-- [Datasets README](synthetic-datasets/README.md)
 - [Moon Documentation](https://moonrepo.dev/docs)
-- [Astro Documentation](https://docs.astro.build)
-- [DuckDB WASM](https://duckdb.org/docs/api/wasm)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ See sub-project AGENTS.md for format/lint/test/typecheck commands.
 5. All tests must pass before merging
 6. Use **rebase and merge** strategy (enforced)
 
+PRs use the template at [`.github/pull_request_template.md`](.github/pull_request_template.md). Fill all sections. Issues and PRs use labels defined in [`.github/labels.yml`](.github/labels.yml) — apply the relevant ones.
+
 ## CI/CD
 
 Workflows in `.github/workflows/`.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -1,0 +1,81 @@
+# App — AGENTS.md
+
+Astro + React web app. DuckDB WASM for client-side data processing.
+
+[Root AGENTS.md](../AGENTS.md)
+
+## Dev
+
+```bash
+moon run app:dev            # Start dev server
+moon run app:build          # Type-check + build
+moon run app:preview        # Preview production build
+```
+
+## Code Style
+
+- TypeScript strict mode
+- File naming: kebab-case files, PascalCase components, camelCase functions
+- Components: `.astro` for static content, `.tsx` for interactive React
+- Follow Astro's islands architecture pattern
+- Components: focused, single-purpose; separate business logic from UI
+
+Quality checks:
+
+```bash
+moon run app:format          # Format with Prettier
+moon run app:format-check    # Check formatting
+moon run app:lint            # ESLint
+moon run app:lint-fix        # Auto-fix lint
+moon run app:lint-sql        # SQL lint (sqruff)
+moon run app:lint-fix-sql    # Auto-fix SQL lint
+moon run app:typecheck       # TypeScript type-check
+```
+
+## Testing
+
+```bash
+moon run app:test                          # Run all tests
+moon run app:test-coverage                 # Coverage report
+moon run app:test -- -t "<test name>"      # Focus a specific test
+moon run app:test -- <file path>           # Focus a specific file
+```
+
+All tests must pass before committing. Add/update tests for any code changes.
+
+**IMPORTANT:** Use `vi.spyOn()` not `vi.mock()` (ESLint enforced):
+
+```ts
+// Bad
+vi.mock('../db/queries', () => ({ getUser: vi.fn() }))
+
+// Good
+import * as queries from '../db/queries'
+vi.spyOn(queries, 'getUser').mockResolvedValue(mockUser)
+```
+
+Astro outputs raw HTML — e2e tests can use build output. Vitest and React Testing Library for React component tests. See Astro's [testing guide](https://docs.astro.build/en/guides/testing/).
+
+## Architecture
+
+**Data Flow:** User uploads file → `StreamProvider` detects format + parses → DuckDB WASM → Observable Plot/D3.js visualization
+
+Supported formats:
+
+- Spotify: ZIP or JSON (`Streaming_History_Audio_*.json`)
+- Deezer: XLSX (`deezer-data_\d{10}.xlsx`), sheet `10_listeningHistory`, parsed via DuckDB Excel extension
+
+**StreamProvider pattern:** `src/streamProvider/` — extensible adapter for multi-source support. Each provider implements `filePattern`, `readFile()`, `transform()` → canonical `StreamRecord` objects. Register new providers in `index.ts`.
+
+**Key Directories:**
+
+| Path                  | Purpose                             |
+| --------------------- | ----------------------------------- |
+| `src/components/`     | React and Astro components          |
+| `src/pages/`          | Astro page routes                   |
+| `src/db/`             | DuckDB queries and database logic   |
+| `src/streamProvider/` | Provider adapters (Spotify, Deezer) |
+
+## Environment Variables
+
+See `.env.example` for required config.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -68,19 +68,23 @@ Astro outputs raw HTML — e2e tests can use build output. Vitest and React Test
 
 Supported formats:
 
-- Spotify: ZIP or JSON (`Streaming_History_Audio_*.json`)
-- Deezer: XLSX (`deezer-data_\d{10}.xlsx`), sheet `10_listeningHistory`, parsed via DuckDB Excel extension
+| Provider    | File pattern                            | Notes                                               |
+| ----------- | --------------------------------------- | --------------------------------------------------- |
+| Spotify     | `Streaming_History_Audio_*.json` or ZIP |                                                     |
+| Deezer      | `deezer-data_\d{10}.xlsx`               | Sheet `10_listeningHistory`, DuckDB Excel extension |
+| Apple Music | `Apple Music Play Activity.csv`         |                                                     |
+| Custom      | `tracksy-custom.csv`                    | Tracksy-specific CSV format                         |
 
 **StreamProvider pattern:** `src/streamProvider/` — extensible adapter for multi-source support. Each provider implements `filePattern`, `readFile()`, `transform()` → canonical `StreamRecord` objects. Register new providers in `index.ts`.
 
 **Key Directories:**
 
-| Path                  | Purpose                             |
-| --------------------- | ----------------------------------- |
-| `src/components/`     | React and Astro components          |
-| `src/pages/`          | Astro page routes                   |
-| `src/db/`             | DuckDB queries and database logic   |
-| `src/streamProvider/` | Provider adapters (Spotify, Deezer) |
+| Path                  | Purpose                                                  |
+| --------------------- | -------------------------------------------------------- |
+| `src/components/`     | React and Astro components                               |
+| `src/pages/`          | Astro page routes                                        |
+| `src/db/`             | DuckDB queries and database logic                        |
+| `src/streamProvider/` | Provider adapters (Spotify, Deezer, Apple Music, Custom) |
 
 ## Environment Variables
 

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -12,6 +12,12 @@ moon run app:build          # Type-check + build
 moon run app:preview        # Preview production build
 ```
 
+For raw pnpm commands (adding deps, etc.) — use sparingly:
+
+```bash
+moon run app:pnpm -- add <package>
+```
+
 ## Code Style
 
 - TypeScript strict mode

--- a/blog/AGENTS.md
+++ b/blog/AGENTS.md
@@ -1,0 +1,24 @@
+# Blog — AGENTS.md
+
+Gohugo-based site.
+
+[Root AGENTS.md](../AGENTS.md)
+
+## Commands
+
+```bash
+moon run blog:dev                                          # Dev server (drafts + future + expired)
+moon run blog:build                                        # Production build → public/
+moon run blog:clean                                        # Remove public/
+moon run blog:new-post -- content/posts/my-post.md        # New post from archetype
+```
+
+## Structure
+
+| Path | Purpose |
+|------|---------|
+| `content/` | Markdown posts |
+| `assets/` | Images, CSS |
+| `static/` | Static files served as-is |
+| `themes/` | Hugo themes (git submodule) |
+| `config/` | Hugo configuration |

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -1,0 +1,30 @@
+# E2E — AGENTS.md
+
+End-to-end test suite built with [Playwright](https://playwright.dev).
+
+[Root AGENTS.md](../AGENTS.md)
+
+## Quick Start
+
+```bash
+moon setup
+moon run e2e:install-browsers
+moon run e2e:test-dev
+```
+
+## Commands
+
+- `moon run e2e:test-dev` — run all tests (starts `app:dev` first)
+- `moon run e2e:test-ui` — interactive Playwright UI mode (starts `app:dev` first)
+- `moon run e2e:codegen` — record actions to generate tests
+- `moon run e2e:show-report` — view last test report
+
+## Datasets
+
+Tests run against a fixed synthetic dataset generated with:
+
+```bash
+moon run synthetic-datasets:generate-e2e
+```
+
+1000 records, fixed seed — deterministic test expectations. `e2e:test-dev` runs this automatically as a dep.

--- a/synthetic-datasets/AGENTS.md
+++ b/synthetic-datasets/AGENTS.md
@@ -16,6 +16,12 @@ moon run synthetic-datasets:generate -- --seed 42                   # Determinis
 moon run synthetic-datasets:generate -- --help                      # Full options
 ```
 
+For raw uv commands (adding deps, etc.) — use sparingly:
+
+```bash
+moon run synthetic-datasets:uv -- add <package>
+```
+
 ## Testing and Quality
 
 ```bash

--- a/synthetic-datasets/AGENTS.md
+++ b/synthetic-datasets/AGENTS.md
@@ -1,0 +1,34 @@
+# Synthetic Datasets — AGENTS.md
+
+Python scripts for synthetic music streaming history generation.
+
+[Root AGENTS.md](../AGENTS.md)
+
+## Generate
+
+```bash
+moon run synthetic-datasets:generate -- 100 --provider spotify   # 100 records
+moon run synthetic-datasets:generate -- --seed 42                # Deterministic output
+moon run synthetic-datasets:generate -- --help                   # Full options
+```
+
+## Testing and Quality
+
+```bash
+moon run synthetic-datasets:test          # pytest
+moon run synthetic-datasets:lint          # Ruff lint
+moon run synthetic-datasets:lint-fix      # Auto-fix lint
+moon run synthetic-datasets:format        # Ruff format
+moon run synthetic-datasets:format-check  # Check format
+moon run synthetic-datasets:typecheck     # ty type-check
+```
+
+All checks must pass before committing.
+
+## Structure
+
+| Path | Purpose |
+|------|---------|
+| `synthetic_datasets/` | Core generation library |
+| `tests/` | pytest test suite |
+| `datasets/` | Generated output (gitignored) |

--- a/synthetic-datasets/AGENTS.md
+++ b/synthetic-datasets/AGENTS.md
@@ -6,10 +6,14 @@ Python scripts for synthetic music streaming history generation.
 
 ## Generate
 
+Supported providers: `spotify`, `deezer`, `apple-music` (default: `spotify`).
+
 ```bash
-moon run synthetic-datasets:generate -- 100 --provider spotify   # 100 records
-moon run synthetic-datasets:generate -- --seed 42                # Deterministic output
-moon run synthetic-datasets:generate -- --help                   # Full options
+moon run synthetic-datasets:generate -- 100 --provider spotify      # 100 Spotify records
+moon run synthetic-datasets:generate -- 100 --provider deezer       # 100 Deezer records
+moon run synthetic-datasets:generate -- 100 --provider apple-music  # 100 Apple Music records
+moon run synthetic-datasets:generate -- --seed 42                   # Deterministic output
+moon run synthetic-datasets:generate -- --help                      # Full options
 ```
 
 ## Testing and Quality


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Root `AGENTS.md` was a monolithic file covering all subprojects, making it noisy for agents working in a single subproject.

## 🎹 Proposal

Split into a hierarchy:

- `AGENTS.md`: navigation index (overview, setup, commit conventions, PR instructions, security)
- `app/AGENTS.md`: code style, Vitest testing rules, architecture, pnpm escape hatch
- `synthetic-datasets/AGENTS.md`: all three providers (spotify, deezer, apple-music), pytest/ruff/ty commands, uv escape hatch
- `blog/AGENTS.md`: Hugo commands and structure
- `e2e/AGENTS.md`: Playwright commands and dataset dependencies

`CLAUDE.md` is a symlink to root `AGENTS.md` - no change needed there.

## 🎶 Comments

Modeled after the memory index pattern: root file is a pointer table, subproject files are self-contained.

## 🎤 Test

Load each AGENTS.md in an agent context scoped to a subproject and verify no cross-subproject noise.