### PR TITLE
docs: remove Apple Music from roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ More details in the [CONTRIBUTING.md development section](CONTRIBUTING.md#develo
 Tracksy is under active development. On the horizon:
 
 - More visualizations and a simplified view for non-technical users
-- Support for additional data sources (Apple Music, Funkwhale, etc.)
+- Support for additional data sources (Funkwhale, etc.)
 
 See [open issues](https://github.com/Gudsfile/tracksy/issues) for the full list.
 


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The roadmap listed Apple Music as a future data source, but it is already supported (experimentally).

## 🎹 Proposal

Remove Apple Music from the roadmap item to avoid misleading visitors.

## 🎶 Comments

Apple Music remains marked as experimental in the usage section.

## 🎤 Test

Read the roadmap section in README.md.