### PR TITLE
feat(synthetic-datasets): add custom provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Once uploaded, explore your listening habits across four views:
 | [`app/`](app/) | Frontend. DuckDB WASM processes data client-side; nothing reaches a server. |
 | [`blog/`](blog/) | Static blog with architectural decision records. |
 | [`e2e/`](e2e/) | End-to-end test suite built with Playwright. |
-| [`synthetic-datasets/`](synthetic-datasets/) | Generates synthetic Spotify/Deezer streaming histories for testing. |
+| [`synthetic-datasets/`](synthetic-datasets/) | Generates synthetic Spotify/Deezer/Apple Music/Custom streaming histories for testing. |
 
 ## Installation
 

--- a/synthetic-datasets/AGENTS.md
+++ b/synthetic-datasets/AGENTS.md
@@ -6,12 +6,13 @@ Python scripts for synthetic music streaming history generation.
 
 ## Generate
 
-Supported providers: `spotify`, `deezer`, `apple-music` (default: `spotify`).
+Supported providers: `spotify`, `deezer`, `apple-music`, `custom` (default: `spotify`).
 
 ```bash
 moon run synthetic-datasets:generate -- 100 --provider spotify      # 100 Spotify records
 moon run synthetic-datasets:generate -- 100 --provider deezer       # 100 Deezer records
 moon run synthetic-datasets:generate -- 100 --provider apple-music  # 100 Apple Music records
+moon run synthetic-datasets:generate -- 100 --provider custom       # 100 Custom CSV records
 moon run synthetic-datasets:generate -- --seed 42                   # Deterministic output
 moon run synthetic-datasets:generate -- --help                      # Full options
 ```

--- a/synthetic-datasets/synthetic_datasets/app.py
+++ b/synthetic-datasets/synthetic_datasets/app.py
@@ -10,9 +10,11 @@ from rich.panel import Panel
 
 from synthetic_datasets.config import GenerationConfig
 from synthetic_datasets.factories.apple_music import AppleMusicFactory
+from synthetic_datasets.factories.custom import CustomFactory
 from synthetic_datasets.factories.deezer import DeezerFactory
 from synthetic_datasets.factories.spotify import SpotifyFactory
 from synthetic_datasets.writers.apple_music import AppleMusicWriter
+from synthetic_datasets.writers.custom import CustomWriter
 from synthetic_datasets.writers.deezer import DeezerWriter
 from synthetic_datasets.writers.spotify import SpotifyWriter
 
@@ -21,6 +23,7 @@ class Provider(str, Enum):
     spotify = "spotify"
     deezer = "deezer"
     apple_music = "apple-music"
+    custom = "custom"
 
 
 app = typer.Typer(add_completion=False)
@@ -41,6 +44,12 @@ def _spotify(num_records: int, output_dir: Path, config: GenerationConfig) -> No
 def _deezer(num_records: int, output_dir: Path, config: GenerationConfig) -> None:
     factory = DeezerFactory(num_records, config=config)
     writer = DeezerWriter(output_dir=output_dir, reference_date=config.reference_date)
+    writer.write(factory.create_streaming_history())
+
+
+def _custom(num_records: int, output_dir: Path, config: GenerationConfig) -> None:
+    factory = CustomFactory(num_records, config=config)
+    writer = CustomWriter(output_dir=output_dir)
     writer.write(factory.create_streaming_history())
 
 
@@ -90,6 +99,8 @@ def generate(
             _apple_music(num_records, output_dir, config)
         case Provider.spotify:
             _spotify(num_records, output_dir, config)
+        case Provider.custom:
+            _custom(num_records, output_dir, config)
 
     elapsed = time.perf_counter() - start
     print(Panel(f"Completed in [bold]{elapsed:.2f}s[/bold]", title="✨ Result", style="green"))

--- a/synthetic-datasets/synthetic_datasets/factories/custom.py
+++ b/synthetic-datasets/synthetic_datasets/factories/custom.py
@@ -1,0 +1,68 @@
+import re
+from dataclasses import dataclass
+
+from rich import print
+
+from ..config import GenerationConfig
+from ..models.base import BaseEvent
+from ..models.custom import CustomStreaming
+from .base import BaseFactory
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(text: str) -> str:
+    return _SLUG_RE.sub("-", text.lower()).strip("-")
+
+
+@dataclass
+class _CustomTrack:
+    track_uri: str
+    title: str
+    artist: str
+    album: str
+    duration_ms: int
+
+
+class CustomFactory(BaseFactory[CustomStreaming]):
+    def __init__(self, num_records: int, config: GenerationConfig) -> None:
+        super().__init__(num_records, config)
+
+        print("🎵 Enriching Custom catalog...")
+        self._custom_catalog: list[_CustomTrack] = [
+            _CustomTrack(
+                track_uri=f"custom:{_slugify(t.artist)}:{_slugify(t.title)}",
+                title=t.title,
+                artist=t.artist,
+                album=t.album,
+                duration_ms=t.duration_ms,
+            )
+            for t in self._catalog
+        ]
+
+        num_platforms = 5
+        print("💻 Generating platforms...")
+        self.platforms = [
+            self.faker.random_element(
+                [
+                    self.faker.android_platform_token(),
+                    self.faker.ios_platform_token(),
+                    self.faker.linux_platform_token(),
+                    self.faker.mac_platform_token(),
+                    self.faker.windows_platform_token(),
+                ]
+            )
+            for _ in range(num_platforms)
+        ]
+
+    def _map_event(self, event: BaseEvent) -> CustomStreaming:
+        track = self._custom_catalog[event.track_index]
+        return CustomStreaming(
+            ts=event.timestamp,
+            track_name=track.title,
+            artist_name=track.artist,
+            album_name=track.album,
+            ms_played=int(track.duration_ms * event.duration_ratio),
+            track_uri=track.track_uri,
+            platform=self.rng.choice(self.platforms),
+        )

--- a/synthetic-datasets/synthetic_datasets/models/custom.py
+++ b/synthetic-datasets/synthetic_datasets/models/custom.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+
+from pydantic import BaseModel, PastDatetime, field_serializer
+
+
+class CustomStreaming(BaseModel):
+    ts: PastDatetime
+    track_name: str
+    artist_name: str
+    album_name: str
+    ms_played: int
+    track_uri: str
+    platform: str
+
+    @field_serializer("ts")
+    def serialize_ts(self, ts: datetime) -> str:
+        return ts.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/synthetic-datasets/synthetic_datasets/writers/custom.py
+++ b/synthetic-datasets/synthetic_datasets/writers/custom.py
@@ -1,0 +1,45 @@
+import csv
+from pathlib import Path
+
+from rich import get_console, print
+from rich.progress import track
+
+from ..models.custom import CustomStreaming
+
+_console = get_console()
+
+FILE_NAME = "tracksy-custom.csv"
+COLUMNS = [
+    "ts",
+    "track_name",
+    "artist_name",
+    "album_name",
+    "ms_played",
+    "track_uri",
+    "platform",
+]
+
+
+class CustomWriter:
+    def __init__(self, output_dir: Path) -> None:
+        self.output_path = output_dir / "custom" / FILE_NAME
+
+    def write(self, records: list[CustomStreaming]) -> None:
+        with _console.status("🖍️ Writing csv..."):
+            self.output_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.output_path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(f, fieldnames=COLUMNS)
+                writer.writeheader()
+                for record in track(records, description=f"📦 Writing {self.output_path.name}"):
+                    writer.writerow(
+                        {
+                            "ts": record.ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                            "track_name": record.track_name,
+                            "artist_name": record.artist_name,
+                            "album_name": record.album_name,
+                            "ms_played": str(record.ms_played),
+                            "track_uri": record.track_uri,
+                            "platform": record.platform,
+                        }
+                    )
+        print(f"🖍️ Write csv: [green]success[/green] {self.output_path.absolute()} ({len(records)} records)")

--- a/synthetic-datasets/tests/conftest.py
+++ b/synthetic-datasets/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 
 from synthetic_datasets.config import GenerationConfig
 from synthetic_datasets.models.apple_music import AppleMusicRecord
+from synthetic_datasets.models.custom import CustomStreaming
 from synthetic_datasets.models.deezer import DeezerStreaming
 from synthetic_datasets.models.spotify import ReasonEndEnum, ReasonStartEnum, Streaming
 
@@ -55,6 +56,19 @@ def apple_music_record():
         play_duration_ms=213_000,
         device_type="IPHONE",
         container_origin_type=None,
+    )
+
+
+@pytest.fixture
+def custom_streaming_record():
+    return CustomStreaming(
+        ts=datetime.fromisoformat("2024-03-15T14:30:00"),
+        track_name="NeS - Post-it",
+        artist_name="Veridis Project",
+        album_name="Veridis Remix",
+        ms_played=213_000,
+        track_uri="custom:veridis-project:nes-post-it",
+        platform="web",
     )
 
 

--- a/synthetic-datasets/tests/factories/test_custom.py
+++ b/synthetic-datasets/tests/factories/test_custom.py
@@ -1,0 +1,67 @@
+import re
+from dataclasses import replace
+
+import pytest
+
+from synthetic_datasets.factories.custom import CustomFactory
+from synthetic_datasets.models.custom import CustomStreaming
+
+TRACK_URI_PATTERN = re.compile(r"^custom:[a-z0-9-]+:[a-z0-9-]+$")
+
+
+@pytest.mark.parametrize("num_records", range(0, 100, 3))
+def test_create_streaming_history(num_records, default_generation_config):
+    factory = CustomFactory(num_records=num_records, config=default_generation_config)
+    streamings = factory.create_streaming_history()
+    assert len(streamings) == num_records
+    for streaming in streamings:
+        assert isinstance(streaming, CustomStreaming)
+
+
+def test_track_uri_format(default_generation_config):
+    factory = CustomFactory(num_records=100, config=default_generation_config)
+    streamings = factory.create_streaming_history()
+    for streaming in streamings:
+        assert TRACK_URI_PATTERN.match(streaming.track_uri), f"Invalid track_uri: {streaming.track_uri}"
+
+
+def test_ms_played_non_negative(default_generation_config):
+    factory = CustomFactory(num_records=100, config=default_generation_config)
+    streamings = factory.create_streaming_history()
+    for streaming in streamings:
+        assert streaming.ms_played > 0
+
+
+def test_platform_non_empty(default_generation_config):
+    factory = CustomFactory(num_records=100, config=default_generation_config)
+    streamings = factory.create_streaming_history()
+    for streaming in streamings:
+        assert streaming.platform != ""
+
+
+def test_same_seed_produces_identical_results(default_generation_config):
+    num_records = 100
+    factory1 = CustomFactory(num_records, default_generation_config)
+    streamings1 = factory1.create_streaming_history()
+    factory2 = CustomFactory(num_records, default_generation_config)
+    streamings2 = factory2.create_streaming_history()
+    assert streamings1 == streamings2
+
+
+def test_different_seeds_produce_different_results(default_generation_config):
+    num_records = 50
+    config1 = replace(default_generation_config, seed=123)
+    config2 = replace(default_generation_config, seed=456)
+    factory1 = CustomFactory(num_records, config1)
+    streamings1 = factory1.create_streaming_history()
+    factory2 = CustomFactory(num_records, config2)
+    streamings2 = factory2.create_streaming_history()
+    assert streamings1 != streamings2
+
+
+@pytest.mark.parametrize("seed", [0, 1, 42, 999, 12345])
+def test_various_seeds_work(seed, default_generation_config):
+    config = replace(default_generation_config, seed=seed)
+    factory = CustomFactory(100, config)
+    streamings = factory.create_streaming_history()
+    assert len(streamings) == 100

--- a/synthetic-datasets/tests/models/test_custom.py
+++ b/synthetic-datasets/tests/models/test_custom.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+
+import pytest
+
+from synthetic_datasets.models.custom import CustomStreaming
+
+
+@pytest.fixture
+def record():
+    return CustomStreaming(
+        ts=datetime.fromisoformat("2024-03-15T14:30:00"),
+        track_name="NeS - Post-it",
+        artist_name="Veridis Project",
+        album_name="Veridis Remix",
+        ms_played=213000,
+        track_uri="custom:veridis-project:nes-post-it",
+        platform="web",
+    )
+
+
+def test_valid_construction(record):
+    assert record.track_name == "NeS - Post-it"
+    assert record.artist_name == "Veridis Project"
+    assert record.album_name == "Veridis Remix"
+    assert record.ms_played == 213000
+    assert record.track_uri == "custom:veridis-project:nes-post-it"
+    assert record.platform == "web"
+
+
+def test_ts_serialization_z_suffix(record):
+    serialized = record.serialize_ts(record.ts)
+    assert serialized == "2024-03-15T14:30:00Z"
+
+
+def test_ts_serialization_format(record):
+    serialized = record.serialize_ts(record.ts)
+    assert serialized.endswith("Z")
+    datetime.strptime(serialized, "%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_ms_played_is_int(record):
+    assert isinstance(record.ms_played, int)

--- a/synthetic-datasets/tests/test_app.py
+++ b/synthetic-datasets/tests/test_app.py
@@ -51,6 +51,12 @@ def test_generate_apple_music(tmp_path):
     assert (tmp_path / "apple_music").exists()
 
 
+def test_generate_custom(tmp_path):
+    result = runner.invoke(app, ["100", "--seed", "42", "--provider", "custom", "-o", str(tmp_path)])
+    assert result.exit_code == 0
+    assert (tmp_path / "custom").exists()
+
+
 @patch("synthetic_datasets.app._spotify")
 @patch("synthetic_datasets.app.GenerationConfig.create")
 @mark.parametrize(

--- a/synthetic-datasets/tests/writers/test_custom.py
+++ b/synthetic-datasets/tests/writers/test_custom.py
@@ -1,0 +1,66 @@
+import csv
+from datetime import datetime
+
+from synthetic_datasets.writers.custom import COLUMNS, CustomWriter
+
+
+def test_write_creates_file(tmp_path, custom_streaming_record):
+    writer = CustomWriter(output_dir=tmp_path)
+    writer.write([custom_streaming_record])
+    assert writer.output_path.exists()
+
+
+def test_output_filename(tmp_path, custom_streaming_record):
+    writer = CustomWriter(output_dir=tmp_path)
+    writer.write([custom_streaming_record])
+    assert writer.output_path.name == "tracksy-custom.csv"
+    assert writer.output_path.parent.name == "custom"
+
+
+def test_write_csv_headers(tmp_path, custom_streaming_record):
+    writer = CustomWriter(output_dir=tmp_path)
+    writer.write([custom_streaming_record])
+    with open(writer.output_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        assert reader.fieldnames == COLUMNS
+
+
+def test_write_csv_row_count(tmp_path, custom_streaming_record):
+    writer = CustomWriter(output_dir=tmp_path)
+    records = [custom_streaming_record] * 5
+    writer.write(records)
+    with open(writer.output_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        assert len(list(reader)) == 5
+
+
+def test_write_creates_output_directory(tmp_path, custom_streaming_record):
+    nested_dir = tmp_path / "nested" / "output"
+    writer = CustomWriter(output_dir=nested_dir)
+    writer.write([custom_streaming_record])
+    assert writer.output_path.exists()
+
+
+def test_write_csv_ts_format(tmp_path, custom_streaming_record):
+    writer = CustomWriter(output_dir=tmp_path)
+    writer.write([custom_streaming_record])
+    with open(writer.output_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        row = next(reader)
+    ts_str = row["ts"]
+    assert ts_str.endswith("Z")
+    datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_write_csv_record_values(tmp_path, custom_streaming_record):
+    writer = CustomWriter(output_dir=tmp_path)
+    writer.write([custom_streaming_record])
+    with open(writer.output_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        row = next(reader)
+    assert row["track_name"] == custom_streaming_record.track_name
+    assert row["artist_name"] == custom_streaming_record.artist_name
+    assert row["album_name"] == custom_streaming_record.album_name
+    assert row["ms_played"] == str(custom_streaming_record.ms_played)
+    assert row["track_uri"] == custom_streaming_record.track_uri
+    assert row["platform"] == custom_streaming_record.platform


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The synthetic datasets generator had no support for the `tracksy-custom.csv` format, making it impossible to quickly generate test data for the Custom upload flow or add automated coverage for `CustomStreamProvider`.

Closes #466

## 🎹 Proposal

Add `--provider custom` to the generator following the existing model/factory/writer pattern.

- `CustomStreaming`: Pydantic model with `ts` (serialized as `2026-01-15T14:30:00Z`), `track_name`, `artist_name`, `album_name`, `ms_played`, `track_uri`, `platform`
- `CustomFactory`: builds a catalog with pre-computed `track_uri = custom:<artist-slug>:<track-slug>`, copies Spotify's Faker OS platform tokens
- `CustomWriter`: writes `output_dir/custom/tracksy-custom.csv` via stdlib `csv`
- Full test parity: model, factory, and writer test files

## 🎶 Comments

`generate-e2e` and e2e tests are out of scope — this PR unblocks them as a follow-up.

## 🎤 Test

```bash
moon run synthetic-datasets:generate -- 100 --provider custom
# → datasets/custom/tracksy-custom.csv
```

Upload the generated file to the app to verify the Custom provider flow end-to-end.