### PR TITLE
feat(synthetic-datasets): add --all-providers flag to generate command

### DIFF
--- a/.github/workflows/datasets-generate-synthetic.yml
+++ b/.github/workflows/datasets-generate-synthetic.yml
@@ -34,13 +34,11 @@ jobs:
 
       - name: Generate datasets
         run: |
-          moon run synthetic-datasets:generate -- 1000
-          moon run synthetic-datasets:generate -- 25000
-          moon run synthetic-datasets:generate -- 500000
+          moon run synthetic-datasets:generate -- 1000 --provider spotify
+          moon run synthetic-datasets:generate -- 500000 --provider spotify
           moon run synthetic-datasets:generate -- 1000 --provider deezer
-          moon run synthetic-datasets:generate -- 25000 --provider deezer
           moon run synthetic-datasets:generate -- 500000 --provider deezer
-          moon run synthetic-datasets:generate -- 25000 --provider apple-music
+          moon run synthetic-datasets:generate -- 25000 --all-providers
 
       - name: Clone HF repo and move datasets into it
         env:

--- a/synthetic-datasets/AGENTS.md
+++ b/synthetic-datasets/AGENTS.md
@@ -13,6 +13,7 @@ moon run synthetic-datasets:generate -- 100 --provider spotify      # 100 Spotif
 moon run synthetic-datasets:generate -- 100 --provider deezer       # 100 Deezer records
 moon run synthetic-datasets:generate -- 100 --provider apple-music  # 100 Apple Music records
 moon run synthetic-datasets:generate -- 100 --provider custom       # 100 Custom CSV records
+moon run synthetic-datasets:generate -- 100 --all-providers         # All providers at once
 moon run synthetic-datasets:generate -- --seed 42                   # Deterministic output
 moon run synthetic-datasets:generate -- --help                      # Full options
 ```

--- a/synthetic-datasets/synthetic_datasets/app.py
+++ b/synthetic-datasets/synthetic_datasets/app.py
@@ -7,6 +7,7 @@ from typing import Annotated
 import typer
 from rich import print
 from rich.panel import Panel
+from rich.rule import Rule
 
 from synthetic_datasets.config import GenerationConfig
 from synthetic_datasets.factories.apple_music import AppleMusicFactory
@@ -108,7 +109,9 @@ def generate(
             Provider.custom: _custom,
         }
         errors: list[tuple[Provider, Exception]] = []
-        for prov, fn in handlers:
+        for prov in Provider:
+            fn = provider_fns[prov]
+            print(Rule(f"[bold]{prov.value}[/bold]"))
             try:
                 fn(num_records, output_dir, config)
             except Exception as e:

--- a/synthetic-datasets/synthetic_datasets/app.py
+++ b/synthetic-datasets/synthetic_datasets/app.py
@@ -66,6 +66,8 @@ Examples:
   generate 1000
 
   generate 1000 --seed 42
+
+  generate 1000 --all-providers
 """
 )
 def generate(
@@ -83,24 +85,48 @@ def generate(
         typer.Option(help="Overwrite reference date in ISO format (e.g., 2026-02-08 or 2026-02-08T14:30:00)"),
     ] = None,
     provider: Annotated[
-        Provider,
+        Provider | None,
         typer.Option(help="Streaming provider to generate data for"),
-    ] = Provider.spotify,
+    ] = None,
+    all_providers: Annotated[
+        bool,
+        typer.Option("--all-providers", help="Generate datasets for all providers"),
+    ] = False,
 ) -> None:
     """Generate synthetic streaming datasets."""
-    start = time.perf_counter()
+    if all_providers and provider is not None:
+        raise typer.BadParameter("Cannot use --all-providers with --provider")
 
+    start = time.perf_counter()
     config = GenerationConfig.create(seed=seed, reference_date=reference_date)
 
-    match provider:
-        case Provider.deezer:
-            _deezer(num_records, output_dir, config)
-        case Provider.apple_music:
-            _apple_music(num_records, output_dir, config)
-        case Provider.spotify:
-            _spotify(num_records, output_dir, config)
-        case Provider.custom:
-            _custom(num_records, output_dir, config)
+    if all_providers:
+        provider_fns = {
+            Provider.spotify: _spotify,
+            Provider.deezer: _deezer,
+            Provider.apple_music: _apple_music,
+            Provider.custom: _custom,
+        }
+        errors: list[tuple[Provider, Exception]] = []
+        for prov, fn in handlers:
+            try:
+                fn(num_records, output_dir, config)
+            except Exception as e:
+                errors.append((prov, e))
+        if errors:
+            for prov, e in errors:
+                print(f"[red]Error generating {prov.value}: {e}[/red]")
+            raise typer.Exit(code=1)
+    else:
+        match provider or Provider.spotify:
+            case Provider.deezer:
+                _deezer(num_records, output_dir, config)
+            case Provider.apple_music:
+                _apple_music(num_records, output_dir, config)
+            case Provider.spotify:
+                _spotify(num_records, output_dir, config)
+            case Provider.custom:
+                _custom(num_records, output_dir, config)
 
     elapsed = time.perf_counter() - start
     print(Panel(f"Completed in [bold]{elapsed:.2f}s[/bold]", title="✨ Result", style="green"))

--- a/synthetic-datasets/tests/test_app.py
+++ b/synthetic-datasets/tests/test_app.py
@@ -97,3 +97,40 @@ def test_log_config_output(tmp_path):
     assert "42" in result.output
     assert "provided" in result.output
     assert "derived from seed" in result.output
+
+
+def test_all_providers_generates_all_outputs(tmp_path):
+    result = runner.invoke(app, ["100", "--seed", "42", "--all-providers", "-o", str(tmp_path)])
+    assert result.exit_code == 0
+    assert (tmp_path / "spotify").exists()
+    assert (tmp_path / "deezer").exists()
+    assert (tmp_path / "apple_music").exists()
+    assert (tmp_path / "custom").exists()
+
+
+def test_all_providers_conflicts_with_provider(tmp_path):
+    result = runner.invoke(
+        app, ["100", "--seed", "42", "--all-providers", "--provider", "spotify", "-o", str(tmp_path)]
+    )
+    assert result.exit_code == 2
+    assert "Cannot use --all-providers with --provider" in result.output
+
+
+@patch("synthetic_datasets.app._spotify")
+@patch("synthetic_datasets.app._apple_music")
+@patch("synthetic_datasets.app._deezer")
+@patch("synthetic_datasets.app._custom")
+def test_all_providers_continues_on_failure(mock_custom, mock_deezer, mock_apple, mock_spotify, tmp_path):
+    mock_spotify.side_effect = RuntimeError("spotify failed")
+    result = runner.invoke(app, ["100", "--seed", "42", "--all-providers", "-o", str(tmp_path)])
+    assert result.exit_code != 0
+    assert "Error generating spotify" in result.output
+    mock_deezer.assert_called_once()
+    mock_apple.assert_called_once()
+    mock_custom.assert_called_once()
+
+
+def test_help_mentions_all_providers():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "all-providers" in result.output

--- a/synthetic-datasets/tests/test_app.py
+++ b/synthetic-datasets/tests/test_app.py
@@ -110,7 +110,9 @@ def test_all_providers_generates_all_outputs(tmp_path):
 
 def test_all_providers_conflicts_with_provider(tmp_path):
     result = runner.invoke(
-        app, ["100", "--seed", "42", "--all-providers", "--provider", "spotify", "-o", str(tmp_path)]
+        app,
+        ["100", "--seed", "42", "--all-providers", "--provider", "spotify", "-o", str(tmp_path)],
+        env={"TERM": "dumb"},
     )
     assert result.exit_code == 2
     assert "Cannot use --all-providers with --provider" in result.output
@@ -131,6 +133,6 @@ def test_all_providers_continues_on_failure(mock_custom, mock_deezer, mock_apple
 
 
 def test_help_mentions_all_providers():
-    result = runner.invoke(app, ["--help"])
+    result = runner.invoke(app, ["--help"], env={"TERM": "dumb"})
     assert result.exit_code == 0
     assert "all-providers" in result.output


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Generating datasets for all providers required running the CLI three times with different `--provider` values, which was inconvenient for demo data and e2e test setup.

Closes #465

## 🎹 Proposal

Add `--all-providers` boolean flag to `generate`. When set, runs all four providers (spotify, deezer, apple-music, custom) sequentially with a shared `GenerationConfig` (same seed and reference date). Each provider's output goes to its existing subdirectory under `--output-dir`.

Errors are collected across all runs — if one provider fails, the others continue. Errors are reported at the end and the command exits nonzero. A `Rule` separator is printed between each provider's output for readability.

Using `--all-providers` together with `--provider` is a conflict and exits with an error.

## 🎶 Comments

The `provider` parameter type changed from `Provider = Provider.spotify` to `Provider | None = None` to cleanly detect explicit `--provider` usage and error on conflict. Default single-provider behavior (no flag → spotify) is unchanged.

## 🎤 Test

```bash
# Generate all providers
moon run synthetic-datasets:generate -- 100 --seed 42 --all-providers

# Verify outputs
ls datasets/spotify datasets/deezer datasets/apple_music datasets/custom

# Conflict detection
moon run synthetic-datasets:generate -- 100 --all-providers --provider spotify
# → error, exit 2
```