### PR TITLE
fix(synthetic-datasets): use num_records as deezer filename suffix

### DIFF
--- a/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.test.ts
+++ b/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.test.ts
@@ -50,6 +50,9 @@ describe('DeezerStreamProvider', () => {
             'deezer-data_1234567890.xlsx',
             'deezer-data_0000000000.xlsx',
             'DEEZER-DATA_9999999999.xlsx',
+            'deezer-data_250.xlsx',
+            'deezer-data_123.xlsx',
+            'deezer-data_12345678901.xlsx',
         ])(
             'should return true for %s as it matches Deezer filename pattern',
             (filename) => {
@@ -61,8 +64,6 @@ describe('DeezerStreamProvider', () => {
         )
 
         it.each([
-            'deezer-data_123.xlsx',
-            'deezer-data_12345678901.xlsx',
             'deezer_data_1234567890.xlsx',
             'Streaming_History_Audio_2024.json',
             'deezer-data_1234567890.json',

--- a/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.ts
+++ b/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.ts
@@ -10,7 +10,7 @@ export class DeezerStreamProvider extends StreamProvider<DeezerRawStreamRecord> 
     name = 'deezer'
     displayName = 'Deezer'
     acceptedFormats = 'XLSX'
-    filePattern = /^deezer-data_\d{10}\.xlsx$/i
+    filePattern = /^deezer-data_\d+\.xlsx$/i
     fileContentType =
         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 

--- a/synthetic-datasets/synthetic_datasets/writers/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/writers/deezer.py
@@ -26,12 +26,11 @@ COLUMNS = [
 class DeezerWriter:
     def __init__(self, output_dir: Path, reference_date: datetime) -> None:
         folder = output_dir / "deezer"
-        self.xlsx_path_template: str = str(folder) + "/deezer-data_{timestamp}.xlsx"
+        self.xlsx_path_template: str = str(folder) + "/deezer-data_{num_records}.xlsx"
         self.reference_date = reference_date
 
     def write(self, records: list[DeezerStreaming]) -> None:
-        timestamp = int(self.reference_date.timestamp())
-        xlsx_path = Path(self.xlsx_path_template.format(timestamp=timestamp))
+        xlsx_path = Path(self.xlsx_path_template.format(num_records=len(records)))
         with _console.status("🖍️ Writing xlsx..."):
             write_xlsx(xlsx_path, records, self.reference_date)
         print(f"🖍️ Write xlsx: [green]success[/green] {xlsx_path.absolute()} ({len(records)} records)")

--- a/synthetic-datasets/tests/writers/test_deezer.py
+++ b/synthetic-datasets/tests/writers/test_deezer.py
@@ -61,6 +61,5 @@ def test_deezer_writer_write_calls_helper(mock_write_xlsx, tmp_path, deezer_stre
     writer.write(records)
     # then
     assert mock_write_xlsx.called
-    expected_timestamp = int(reference_date.timestamp())
-    expected_path = Path(tmp_path) / "deezer" / f"deezer-data_{expected_timestamp}.xlsx"
+    expected_path = Path(tmp_path) / "deezer" / f"deezer-data_{len(records)}.xlsx"
     assert mock_write_xlsx.call_args.args == (expected_path, records, reference_date)


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).

## 🔇 Problem

Deezer output file was named `deezer-data_{timestamp}.xlsx` using the reference date's Unix timestamp. Each regeneration with a new reference date produced a distinct filename, accumulating new files on HuggingFace instead of overwriting the previous one.

## 🎹 Proposal

Replace the timestamp suffix with the record count (`num_records`), matching the approach already used for Spotify (`Streaming_History_Audio_2006_{num_records}.json`). Same generation config now produces the same filename, so HuggingFace uploads overwrite rather than append.

## 🎶 Comments

The timestamp was derived from `reference_date`, not `datetime.now()`, so it was already deterministic for a fixed config but it changes whenever the reference date changes. Record count is a more stable identity for a given dataset size.

> [!NOTE]
> Using the line number required relaxing the filePattern to accept any digit count (`\d{10}` -> `\d+`)

## 🎤 Test

```bash
# Generate twice with same config, confirm single file in output/deezer/
moon run --force synthetic-datasets:generate -- 100 --provider deezer
moon run --force synthetic-datasets:generate -- 100 --provider deezer
ls output/deezer/  # should show one file, not two
moon run --force synthetic-datasets:generate -- 1000 --provider deezer
ls output/deezer/  # should show two files

moon run synthetic-datasets:test
```

The file is correctly loaded into the app.