### PR TITLE
feat(providers): add JellyFin Playback Reporting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Or bring your own data:
 
 </details>
 
-
 <details>
 <summary>Apple Music (experimental)</summary>
 <br>
@@ -73,6 +72,21 @@ Or bring your own data:
 3. Download and extract the ZIP you receive by email
 4. Inside the archive, navigate to `Apple Music Activity/` and find `Apple Music Play Activity.csv`.
 5. If the data is in a nested ZIP (e.g. `Apple_Media_Services.zip`), upload the outer ZIP directly, Tracksy extracts it automatically.
+
+</details>
+
+<details>
+<summary>JellyFin</summary>
+<br>
+
+**Requires the [Playback Reporting plugin](https://github.com/jellyfin/jellyfin-plugin-playbackreporting).**
+
+1. In JellyFin, go to "_Dashboard_" > "_Plugins_" and install "Playback Reporting" if not already installed
+2. After some listening activity has been recorded, go to "_Dashboard_" > "_Playback Report_"
+3. Click "_Export as CSV_" to download `playback_report.csv`
+
+> [!NOTE]
+> Artist and album names are not included in the plugin export. Charts based on artist or album will not be populated for JellyFin data.
 
 </details>
 

--- a/app/src/streamProvider/JellyFinStreamProvider/JellyFinStreamProvider.test.ts
+++ b/app/src/streamProvider/JellyFinStreamProvider/JellyFinStreamProvider.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { JellyFinStreamProvider } from './JellyFinStreamProvider'
+import type { JellyFinRawRecord } from './types'
+import type { StreamRecord } from '../types'
+
+function mockFile(
+    buffer: ArrayBuffer,
+    name: string,
+    options: { type: string }
+) {
+    return {
+        name,
+        arrayBuffer: async () => buffer,
+        type: options.type,
+        size: buffer.byteLength,
+    } as unknown as File
+}
+
+const CSV_TYPE = 'text/csv'
+
+const RAW_AUDIO: JellyFinRawRecord = {
+    DateCreated: '2024-03-15 14:30:00',
+    UserId: 'user-abc-123',
+    ItemId: 'item-def-456',
+    ItemType: 'Audio',
+    ItemName: 'Never Gonna Give You Up',
+    PlaybackMethod: 'DirectPlay',
+    ClientName: 'Jellyfin Web',
+    DeviceName: 'Chrome',
+    PlayDuration: '213',
+}
+
+const RAW_MOVIE: JellyFinRawRecord = {
+    ...RAW_AUDIO,
+    ItemType: 'Movie',
+    ItemName: 'Some Movie',
+}
+
+describe('JellyFinStreamProvider', () => {
+    const provider = new JellyFinStreamProvider()
+
+    it('should return correct metadata', () => {
+        expect(provider.name).toBe('jellyfin')
+        expect(provider.displayName).toBe('JellyFin')
+        expect(provider.fileContentType).toBe(CSV_TYPE)
+        expect(provider.filePattern).toBeInstanceOf(RegExp)
+        expect(provider.acceptedFormats).toBe('CSV')
+    })
+
+    describe('validateFile', () => {
+        it.each(['playback_report.csv', 'PLAYBACK_REPORT.CSV'])(
+            'should return true for %s',
+            (filename) => {
+                const file = mockFile(new ArrayBuffer(0), filename, {
+                    type: CSV_TYPE,
+                })
+                expect(provider.validateFile(file)).toBe(true)
+            }
+        )
+
+        it.each(['report.csv', 'playback.csv', 'playback_report.json'])(
+            'should return false for %s',
+            (filename) => {
+                const file = mockFile(new ArrayBuffer(0), filename, {
+                    type: CSV_TYPE,
+                })
+                expect(provider.validateFile(file)).toBe(false)
+            }
+        )
+    })
+
+    describe('transform', () => {
+        it('should map Audio record to StreamRecord', () => {
+            const result = provider.transform([RAW_AUDIO])
+            const expected: StreamRecord = {
+                track_uri: 'jellyfin:item-def-456',
+                track_name: 'Never Gonna Give You Up',
+                artist_name: '',
+                album_name: '',
+                ts: '2024-03-15T14:30:00Z',
+                ms_played: 213000,
+                platform: 'Jellyfin Web',
+            }
+            expect(result).toHaveLength(1)
+            expect(result[0]).toEqual(expected)
+        })
+
+        it('should filter out non-Audio rows', () => {
+            const result = provider.transform([RAW_AUDIO, RAW_MOVIE])
+            expect(result).toHaveLength(1)
+            expect(result[0].track_name).toBe('Never Gonna Give You Up')
+        })
+
+        it('should convert DateCreated to ISO 8601', () => {
+            const result = provider.transform([RAW_AUDIO])
+            expect(result[0].ts).toBe('2024-03-15T14:30:00Z')
+        })
+
+        it('should multiply PlayDuration seconds by 1000', () => {
+            const result = provider.transform([RAW_AUDIO])
+            expect(result[0].ms_played).toBe(213000)
+        })
+
+        it('should handle PlayDuration as number from DuckDB', () => {
+            const raw = { ...RAW_AUDIO, PlayDuration: 180 }
+            const result = provider.transform([raw])
+            expect(result[0].ms_played).toBe(180000)
+        })
+
+        it('should set ms_played to 0 for negative PlayDuration (Swiftfin bug)', () => {
+            const raw = { ...RAW_AUDIO, PlayDuration: '-2147483648' }
+            const result = provider.transform([raw])
+            expect(result[0].ms_played).toBe(0)
+        })
+
+        it('should set ms_played to 0 for zero PlayDuration', () => {
+            const raw = { ...RAW_AUDIO, PlayDuration: '0' }
+            const result = provider.transform([raw])
+            expect(result[0].ms_played).toBe(0)
+        })
+
+        it('should set artist_name and album_name to empty strings', () => {
+            const result = provider.transform([RAW_AUDIO])
+            expect(result[0].artist_name).toBe('')
+            expect(result[0].album_name).toBe('')
+        })
+
+        it('should use ClientName as platform', () => {
+            const result = provider.transform([RAW_AUDIO])
+            expect(result[0].platform).toBe('Jellyfin Web')
+        })
+
+        it('should prefix ItemId with jellyfin: in track_uri', () => {
+            const result = provider.transform([RAW_AUDIO])
+            expect(result[0].track_uri).toBe('jellyfin:item-def-456')
+        })
+    })
+
+    describe('readFile', () => {
+        beforeEach(() => {
+            vi.restoreAllMocks()
+        })
+
+        it('should call getDB and query the CSV', async () => {
+            const mockConn = {
+                query: vi.fn().mockResolvedValue({
+                    toArray: () => [{ toJSON: () => RAW_AUDIO }],
+                }),
+            }
+            const mockDB = {
+                registerFileBuffer: vi.fn().mockResolvedValue(undefined),
+                dropFile: vi.fn().mockResolvedValue(undefined),
+            }
+
+            const getDBModule = await import('../../db/getDB')
+            vi.spyOn(getDBModule, 'getDB').mockResolvedValue({
+                db: mockDB as never,
+                conn: mockConn as never,
+            })
+
+            const file = mockFile(new ArrayBuffer(8), 'playback_report.csv', {
+                type: CSV_TYPE,
+            })
+            const result = await provider.readFile(file)
+
+            expect(mockDB.registerFileBuffer).toHaveBeenCalledWith(
+                '_jellyfin_tmp.csv',
+                expect.any(Uint8Array)
+            )
+            expect(mockConn.query).toHaveBeenCalledWith(
+                expect.stringContaining('_jellyfin_tmp.csv')
+            )
+            expect(mockDB.dropFile).toHaveBeenCalledWith('_jellyfin_tmp.csv')
+            expect(result).toEqual([RAW_AUDIO])
+        })
+
+        it('should drop the temp file even when query throws', async () => {
+            const mockConn = {
+                query: vi.fn().mockRejectedValue(new Error('CSV error')),
+            }
+            const mockDB = {
+                registerFileBuffer: vi.fn().mockResolvedValue(undefined),
+                dropFile: vi.fn().mockResolvedValue(undefined),
+            }
+
+            const getDBModule = await import('../../db/getDB')
+            vi.spyOn(getDBModule, 'getDB').mockResolvedValue({
+                db: mockDB as never,
+                conn: mockConn as never,
+            })
+
+            const file = mockFile(new ArrayBuffer(8), 'playback_report.csv', {
+                type: CSV_TYPE,
+            })
+            await expect(provider.readFile(file)).rejects.toThrow()
+            expect(mockDB.dropFile).toHaveBeenCalledWith('_jellyfin_tmp.csv')
+        })
+    })
+
+    describe('processFile integration', () => {
+        beforeEach(() => {
+            vi.restoreAllMocks()
+        })
+
+        it('should filter out records shorter than 30 seconds', async () => {
+            const shortRecord = { ...RAW_AUDIO, PlayDuration: '29' }
+            const longRecord = { ...RAW_AUDIO, PlayDuration: '180' }
+
+            const mockConn = {
+                query: vi.fn().mockResolvedValue({
+                    toArray: () =>
+                        [shortRecord, longRecord].map((r) => ({
+                            toJSON: () => r,
+                        })),
+                }),
+            }
+            const mockDB = {
+                registerFileBuffer: vi.fn().mockResolvedValue(undefined),
+                dropFile: vi.fn().mockResolvedValue(undefined),
+            }
+
+            const getDBModule = await import('../../db/getDB')
+            vi.spyOn(getDBModule, 'getDB').mockResolvedValue({
+                db: mockDB as never,
+                conn: mockConn as never,
+            })
+
+            const file = mockFile(new ArrayBuffer(8), 'playback_report.csv', {
+                type: CSV_TYPE,
+            })
+            const result = await provider.processFile(file)
+
+            expect(result).toHaveLength(1)
+            expect(result[0].ms_played).toBe(180000)
+        })
+    })
+})

--- a/app/src/streamProvider/JellyFinStreamProvider/JellyFinStreamProvider.ts
+++ b/app/src/streamProvider/JellyFinStreamProvider/JellyFinStreamProvider.ts
@@ -11,6 +11,7 @@ export class JellyFinStreamProvider extends StreamProvider<JellyFinRawRecord> {
     readonly acceptedFormats = 'CSV'
     readonly filePattern = /^playback_report\.csv$/i
     readonly fileContentType = 'text/csv'
+    readonly experimental = true
 
     async readFile(file: File): Promise<JellyFinRawRecord[]> {
         const buffer = await file.arrayBuffer()

--- a/app/src/streamProvider/JellyFinStreamProvider/JellyFinStreamProvider.ts
+++ b/app/src/streamProvider/JellyFinStreamProvider/JellyFinStreamProvider.ts
@@ -43,7 +43,10 @@ export class JellyFinStreamProvider extends StreamProvider<JellyFinRawRecord> {
                     ts:
                         r.DateCreated instanceof Date
                             ? r.DateCreated.toISOString()
-                            : String(r.DateCreated).replace(' ', 'T') + 'Z',
+                            : typeof r.DateCreated === 'number' ||
+                                typeof r.DateCreated === 'bigint'
+                              ? new Date(Number(r.DateCreated)).toISOString()
+                              : String(r.DateCreated).replace(' ', 'T') + 'Z',
                     ms_played: seconds > 0 ? seconds * 1000 : 0,
                     platform: r.ClientName,
                 }

--- a/app/src/streamProvider/JellyFinStreamProvider/JellyFinStreamProvider.ts
+++ b/app/src/streamProvider/JellyFinStreamProvider/JellyFinStreamProvider.ts
@@ -1,0 +1,48 @@
+import { getDB } from '../../db/getDB'
+import { StreamProvider } from '../StreamProvider'
+import type { StreamRecord } from '../types'
+import type { JellyFinRawRecord } from './types'
+
+const TMP_FILE_NAME = '_jellyfin_tmp.csv'
+
+export class JellyFinStreamProvider extends StreamProvider<JellyFinRawRecord> {
+    readonly name = 'jellyfin'
+    readonly displayName = 'JellyFin'
+    readonly acceptedFormats = 'CSV'
+    readonly filePattern = /^playback_report\.csv$/i
+    readonly fileContentType = 'text/csv'
+
+    async readFile(file: File): Promise<JellyFinRawRecord[]> {
+        const buffer = await file.arrayBuffer()
+        const { db, conn } = await getDB()
+
+        await db.registerFileBuffer(TMP_FILE_NAME, new Uint8Array(buffer))
+        try {
+            const result = await conn.query(
+                `SELECT * FROM read_csv('${TMP_FILE_NAME}', header=true)`
+            )
+            return result
+                .toArray()
+                .map((row) => row.toJSON() as JellyFinRawRecord)
+        } finally {
+            await db.dropFile(TMP_FILE_NAME)
+        }
+    }
+
+    transform(rawData: JellyFinRawRecord[]): StreamRecord[] {
+        return rawData
+            .filter((r) => r.ItemType === 'Audio')
+            .map((r) => {
+                const seconds = Number(r.PlayDuration)
+                return {
+                    track_uri: `jellyfin:${r.ItemId}`,
+                    track_name: r.ItemName,
+                    artist_name: '',
+                    album_name: '',
+                    ts: r.DateCreated.replace(' ', 'T') + 'Z',
+                    ms_played: seconds > 0 ? seconds * 1000 : 0,
+                    platform: r.ClientName,
+                }
+            })
+    }
+}

--- a/app/src/streamProvider/JellyFinStreamProvider/JellyFinStreamProvider.ts
+++ b/app/src/streamProvider/JellyFinStreamProvider/JellyFinStreamProvider.ts
@@ -40,7 +40,10 @@ export class JellyFinStreamProvider extends StreamProvider<JellyFinRawRecord> {
                     track_name: r.ItemName,
                     artist_name: '',
                     album_name: '',
-                    ts: r.DateCreated.replace(' ', 'T') + 'Z',
+                    ts:
+                        r.DateCreated instanceof Date
+                            ? r.DateCreated.toISOString()
+                            : String(r.DateCreated).replace(' ', 'T') + 'Z',
                     ms_played: seconds > 0 ? seconds * 1000 : 0,
                     platform: r.ClientName,
                 }

--- a/app/src/streamProvider/JellyFinStreamProvider/index.ts
+++ b/app/src/streamProvider/JellyFinStreamProvider/index.ts
@@ -1,0 +1,1 @@
+export { JellyFinStreamProvider } from './JellyFinStreamProvider'

--- a/app/src/streamProvider/JellyFinStreamProvider/types.ts
+++ b/app/src/streamProvider/JellyFinStreamProvider/types.ts
@@ -1,5 +1,5 @@
 export interface JellyFinRawRecord {
-    DateCreated: Date | string // DuckDB parses TIMESTAMP columns as Date objects
+    DateCreated: Date | string | number | bigint // DuckDB may return TIMESTAMP as Date, bigint (µs), or string
     UserId: string
     ItemId: string
     ItemType: string // "Audio" | "Movie" | "Episode" | ...

--- a/app/src/streamProvider/JellyFinStreamProvider/types.ts
+++ b/app/src/streamProvider/JellyFinStreamProvider/types.ts
@@ -1,0 +1,11 @@
+export interface JellyFinRawRecord {
+    DateCreated: string // "YYYY-MM-DD HH:MM:SS"
+    UserId: string
+    ItemId: string
+    ItemType: string // "Audio" | "Movie" | "Episode" | ...
+    ItemName: string
+    PlaybackMethod: string
+    ClientName: string
+    DeviceName: string
+    PlayDuration: string | number // seconds; DuckDB may return as number; can be negative (bug)
+}

--- a/app/src/streamProvider/JellyFinStreamProvider/types.ts
+++ b/app/src/streamProvider/JellyFinStreamProvider/types.ts
@@ -1,5 +1,5 @@
 export interface JellyFinRawRecord {
-    DateCreated: string // "YYYY-MM-DD HH:MM:SS"
+    DateCreated: Date | string // DuckDB parses TIMESTAMP columns as Date objects
     UserId: string
     ItemId: string
     ItemType: string // "Audio" | "Movie" | "Episode" | ...

--- a/app/src/streamProvider/index.test.ts
+++ b/app/src/streamProvider/index.test.ts
@@ -38,59 +38,68 @@ describe('StreamProvider Factory', () => {
 
             expect(streamProvider).not.toBeUndefined()
             expect(streamProvider?.name).toBe('custom')
+
+            it('should detect JellyFin files', () => {
+                const file = new File([], 'playback_report.csv')
+                const streamProvider = detectProvider(file)
+
+                expect(streamProvider).not.toBeUndefined()
+                expect(streamProvider?.name).toBe('jellyfin')
+            })
+
+            it('should return undefined for unknown file formats', () => {
+                const file = new File([], 'unknown_format.json')
+                const streamProvider = detectProvider(file)
+
+                expect(streamProvider).toBeUndefined()
+            })
         })
 
-        it('should return undefined for unknown file formats', () => {
-            const file = new File([], 'unknown_format.json')
-            const streamProvider = detectProvider(file)
+        describe('getSupportedProviderNames', () => {
+            it('returns a non-empty array of display names', () => {
+                const names = getSupportedProviderNames()
+                expect(names.length).toBeGreaterThan(0)
+                expect(
+                    names.every((n) => typeof n === 'string' && n.length > 0)
+                ).toBe(true)
+            })
 
-            expect(streamProvider).toBeUndefined()
-        })
-    })
-
-    describe('getSupportedProviderNames', () => {
-        it('returns a non-empty array of display names', () => {
-            const names = getSupportedProviderNames()
-            expect(names.length).toBeGreaterThan(0)
-            expect(
-                names.every((n) => typeof n === 'string' && n.length > 0)
-            ).toBe(true)
-        })
-
-        it('returns one entry per registered provider with format hint', () => {
-            const names = getSupportedProviderNames()
-            expect(names.length).toBe(3)
-            expect(names).toContain('Spotify (ZIP/JSON)')
-            expect(names).toContain('Deezer (XLSX)')
-            expect(names).toContain('Custom (CSV)')
-            expect(names).not.toContain('Apple Music (ZIP/CSV)')
-        })
-    })
-
-    describe('isFileSupported', () => {
-        it('should return true for supported files', () => {
-            const file = new File([], 'Streaming_History_Audio_2024.json')
-            expect(isFileSupported(file)).toBe(true)
+            it('returns one entry per registered provider with format hint', () => {
+                const names = getSupportedProviderNames()
+                expect(names.length).toBe(3)
+                expect(names).toContain('Spotify (ZIP/JSON)')
+                expect(names).toContain('Deezer (XLSX)')
+                expect(names).toContain('Custom (CSV)')
+                expect(names).not.toContain('Apple Music (ZIP/CSV)')
+                expect(names).toContain('JellyFin (CSV)')
+            })
         })
 
-        it('should return false for unsupported files', () => {
-            const file = new File([], 'unsupported.json')
-            expect(isFileSupported(file)).toBe(false)
-        })
-    })
+        describe('isFileSupported', () => {
+            it('should return true for supported files', () => {
+                const file = new File([], 'Streaming_History_Audio_2024.json')
+                expect(isFileSupported(file)).toBe(true)
+            })
 
-    describe('isAllowedFileContentType', () => {
-        it.each([
-            'application/json',
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-            'text/csv',
-        ])(
-            'should return true if the file content type %s is allowed',
-            (contentType) => {
-                const file = new File([], 'filename', { type: contentType })
-                expect(isAllowedFileContentType(file)).toBe(true)
-            }
-        )
+            it('should return false for unsupported files', () => {
+                const file = new File([], 'unsupported.json')
+                expect(isFileSupported(file)).toBe(false)
+            })
+        })
+
+        describe('isAllowedFileContentType', () => {
+            it.each([
+                'application/json',
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'text/csv',
+            ])(
+                'should return true if the file content type %s is allowed',
+                (contentType) => {
+                    const file = new File([], 'filename', { type: contentType })
+                    expect(isAllowedFileContentType(file)).toBe(true)
+                }
+            )
+        })
 
         it.each([
             'image/png',

--- a/app/src/streamProvider/index.test.ts
+++ b/app/src/streamProvider/index.test.ts
@@ -38,21 +38,21 @@ describe('StreamProvider Factory', () => {
 
             expect(streamProvider).not.toBeUndefined()
             expect(streamProvider?.name).toBe('custom')
+        })
 
-            it('should detect JellyFin files', () => {
-                const file = new File([], 'playback_report.csv')
-                const streamProvider = detectProvider(file)
+        it('should detect JellyFin files', () => {
+            const file = new File([], 'playback_report.csv')
+            const streamProvider = detectProvider(file)
 
-                expect(streamProvider).not.toBeUndefined()
-                expect(streamProvider?.name).toBe('jellyfin')
-            })
+            expect(streamProvider).not.toBeUndefined()
+            expect(streamProvider?.name).toBe('jellyfin')
+        })
 
-            it('should return undefined for unknown file formats', () => {
-                const file = new File([], 'unknown_format.json')
-                const streamProvider = detectProvider(file)
+        it('should return undefined for unknown file formats', () => {
+            const file = new File([], 'unknown_format.json')
+            const streamProvider = detectProvider(file)
 
-                expect(streamProvider).toBeUndefined()
-            })
+            expect(streamProvider).toBeUndefined()
         })
 
         describe('getSupportedProviderNames', () => {
@@ -71,7 +71,7 @@ describe('StreamProvider Factory', () => {
                 expect(names).toContain('Deezer (XLSX)')
                 expect(names).toContain('Custom (CSV)')
                 expect(names).not.toContain('Apple Music (ZIP/CSV)')
-                expect(names).toContain('JellyFin (CSV)')
+                expect(names).not.toContain('JellyFin (CSV)')
             })
         })
 

--- a/app/src/streamProvider/index.ts
+++ b/app/src/streamProvider/index.ts
@@ -1,6 +1,7 @@
 import { AppleMusicStreamProvider } from './AppleMusicStreamProvider/AppleMusicStreamProvider'
 import { CustomStreamProvider } from './CustomStreamProvider/CustomStreamProvider'
 import { DeezerStreamProvider } from './DeezerStreamProvider/DeezerStreamProvider'
+import { JellyFinStreamProvider } from './JellyFinStreamProvider/JellyFinStreamProvider'
 import type { StreamProvider } from './StreamProvider'
 import { SpotifyStreamProvider } from './SpotifyStreamProvider/SpotifyStreamProvider'
 
@@ -9,6 +10,7 @@ const STREAM_PROVIDERS: StreamProvider[] = [
     new DeezerStreamProvider(),
     new AppleMusicStreamProvider(),
     new CustomStreamProvider(),
+    new JellyFinStreamProvider(),
 ]
 
 export const STREAM_PROVIDERS_CONTENT_TYPES = STREAM_PROVIDERS.map(

--- a/synthetic-datasets/synthetic_datasets/app.py
+++ b/synthetic-datasets/synthetic_datasets/app.py
@@ -13,10 +13,12 @@ from synthetic_datasets.config import GenerationConfig
 from synthetic_datasets.factories.apple_music import AppleMusicFactory
 from synthetic_datasets.factories.custom import CustomFactory
 from synthetic_datasets.factories.deezer import DeezerFactory
+from synthetic_datasets.factories.jellyfin import JellyFinFactory
 from synthetic_datasets.factories.spotify import SpotifyFactory
 from synthetic_datasets.writers.apple_music import AppleMusicWriter
 from synthetic_datasets.writers.custom import CustomWriter
 from synthetic_datasets.writers.deezer import DeezerWriter
+from synthetic_datasets.writers.jellyfin import JellyFinWriter
 from synthetic_datasets.writers.spotify import SpotifyWriter
 
 
@@ -24,6 +26,7 @@ class Provider(str, Enum):
     spotify = "spotify"
     deezer = "deezer"
     apple_music = "apple-music"
+    jellyfin = "jellyfin"
     custom = "custom"
 
 
@@ -45,6 +48,12 @@ def _spotify(num_records: int, output_dir: Path, config: GenerationConfig) -> No
 def _deezer(num_records: int, output_dir: Path, config: GenerationConfig) -> None:
     factory = DeezerFactory(num_records, config=config)
     writer = DeezerWriter(output_dir=output_dir, reference_date=config.reference_date)
+    writer.write(factory.create_streaming_history())
+
+
+def _jellyfin(num_records: int, output_dir: Path, config: GenerationConfig) -> None:
+    factory = JellyFinFactory(num_records, config=config)
+    writer = JellyFinWriter(output_dir=output_dir, reference_date=config.reference_date)
     writer.write(factory.create_streaming_history())
 
 
@@ -106,6 +115,7 @@ def generate(
             Provider.spotify: _spotify,
             Provider.deezer: _deezer,
             Provider.apple_music: _apple_music,
+            Provider.jellyfin: _jellyfin,
             Provider.custom: _custom,
         }
         errors: list[tuple[Provider, Exception]] = []
@@ -128,6 +138,8 @@ def generate(
                 _apple_music(num_records, output_dir, config)
             case Provider.spotify:
                 _spotify(num_records, output_dir, config)
+            case Provider.jellyfin:
+                _jellyfin(num_records, output_dir, config)
             case Provider.custom:
                 _custom(num_records, output_dir, config)
 

--- a/synthetic-datasets/synthetic_datasets/factories/jellyfin.py
+++ b/synthetic-datasets/synthetic_datasets/factories/jellyfin.py
@@ -1,0 +1,41 @@
+import uuid
+
+from ..config import GenerationConfig
+from ..models.base import BaseEvent
+from ..models.jellyfin import JellyFinRecord
+from .base import BaseFactory
+
+NON_AUDIO_ITEM_TYPES = ["Movie", "Episode"]
+CLIENT_NAMES = ["Jellyfin Web", "Jellyfin Android", "Jellyfin iOS", "Infuse", "Swiftfin"]
+
+
+class JellyFinFactory(BaseFactory[JellyFinRecord]):
+    def __init__(self, num_records: int, config: GenerationConfig) -> None:
+        super().__init__(num_records, config)
+        self.user_id = uuid.UUID(int=self.rng.getrandbits(128)).hex
+        self._item_ids = [uuid.UUID(int=self.rng.getrandbits(128)).hex for _ in self._catalog]
+
+    def _map_event(self, event: BaseEvent) -> JellyFinRecord:
+        if self.rng.random() < 0.10:
+            item_type = self.rng.choice(NON_AUDIO_ITEM_TYPES)
+            item_name = self.faker.bs()
+            play_duration = self.rng.randint(1800, 7200)
+            item_id = uuid.UUID(int=self.rng.getrandbits(128)).hex
+        else:
+            track = self._catalog[event.track_index]
+            item_type = "Audio"
+            item_name = track.title
+            play_duration = max(1, int(event.duration_ratio * track.duration_ms / 1000))
+            item_id = self._item_ids[event.track_index]
+
+        return JellyFinRecord(
+            date_created=event.timestamp,
+            user_id=self.user_id,
+            item_id=item_id,
+            item_type=item_type,
+            item_name=item_name,
+            playback_method="DirectPlay" if self.rng.random() < 0.70 else "Transcode",
+            client_name=self.rng.choice(CLIENT_NAMES),
+            device_name=self.faker.user_agent(),
+            play_duration=play_duration,
+        )

--- a/synthetic-datasets/synthetic_datasets/models/jellyfin.py
+++ b/synthetic-datasets/synthetic_datasets/models/jellyfin.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+from pydantic import BaseModel, PastDatetime, field_serializer
+
+
+class JellyFinRecord(BaseModel):
+    date_created: PastDatetime
+    user_id: str  # UUID hex
+    item_id: str  # UUID hex
+    item_type: str = "Audio"
+    item_name: str
+    playback_method: str
+    client_name: str
+    device_name: str
+    play_duration: int  # seconds
+
+    @field_serializer("date_created")
+    def serialize_date_created(self, date_created: datetime) -> str:
+        return date_created.strftime("%Y-%m-%d %H:%M:%S")

--- a/synthetic-datasets/synthetic_datasets/writers/jellyfin.py
+++ b/synthetic-datasets/synthetic_datasets/writers/jellyfin.py
@@ -1,0 +1,47 @@
+import csv
+from datetime import datetime
+from pathlib import Path
+
+from rich import print
+from rich.progress import track
+
+from ..models.jellyfin import JellyFinRecord
+
+COLUMNS = [
+    "DateCreated",
+    "UserId",
+    "ItemId",
+    "ItemType",
+    "ItemName",
+    "PlaybackMethod",
+    "ClientName",
+    "DeviceName",
+    "PlayDuration",
+]
+
+
+class JellyFinWriter:
+    def __init__(self, output_dir: Path, reference_date: datetime) -> None:
+        self.output_path = output_dir / "jellyfin" / "playback_report.csv"
+        self.reference_date = reference_date
+
+    def write(self, records: list[JellyFinRecord]) -> None:
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.output_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=COLUMNS)
+            writer.writeheader()
+            for record in track(records, description=f"📦 Writing {self.output_path.name}"):
+                writer.writerow(
+                    {
+                        "DateCreated": record.serialize_date_created(record.date_created),
+                        "UserId": record.user_id,
+                        "ItemId": record.item_id,
+                        "ItemType": record.item_type,
+                        "ItemName": record.item_name,
+                        "PlaybackMethod": record.playback_method,
+                        "ClientName": record.client_name,
+                        "DeviceName": record.device_name,
+                        "PlayDuration": str(record.play_duration),
+                    }
+                )
+        print(f"📦 Write csv: [green]success[/green] {self.output_path.absolute()} ({len(records)} records)")

--- a/synthetic-datasets/tests/conftest.py
+++ b/synthetic-datasets/tests/conftest.py
@@ -7,6 +7,7 @@ from synthetic_datasets.config import GenerationConfig
 from synthetic_datasets.models.apple_music import AppleMusicRecord
 from synthetic_datasets.models.custom import CustomStreaming
 from synthetic_datasets.models.deezer import DeezerStreaming
+from synthetic_datasets.models.jellyfin import JellyFinRecord
 from synthetic_datasets.models.spotify import ReasonEndEnum, ReasonStartEnum, Streaming
 
 
@@ -69,6 +70,21 @@ def custom_streaming_record():
         ms_played=213_000,
         track_uri="custom:veridis-project:nes-post-it",
         platform="web",
+    )
+
+
+@pytest.fixture
+def jellyfin_record():
+    return JellyFinRecord(
+        date_created=datetime.fromisoformat("2024-03-15T14:30:00"),
+        user_id="abcdef1234567890abcdef1234567890",
+        item_id="fedcba0987654321fedcba0987654321",
+        item_type="Audio",
+        item_name="Never Gonna Give You Up",
+        playback_method="DirectPlay",
+        client_name="Jellyfin Web",
+        device_name="Chrome/123",
+        play_duration=213,
     )
 
 

--- a/synthetic-datasets/tests/factories/test_jellyfin.py
+++ b/synthetic-datasets/tests/factories/test_jellyfin.py
@@ -1,0 +1,101 @@
+from dataclasses import replace
+
+import pytest
+
+from synthetic_datasets.factories.jellyfin import JellyFinFactory
+from synthetic_datasets.models.jellyfin import JellyFinRecord
+
+
+@pytest.mark.parametrize("num_records", range(0, 100, 3))
+def test_create_streaming_history(num_records, default_generation_config):
+    # given
+    factory = JellyFinFactory(num_records=num_records, config=default_generation_config)
+    # when
+    records = factory.create_streaming_history()
+    # then
+    assert len(records) == num_records
+    for record in records:
+        assert isinstance(record, JellyFinRecord)
+
+
+def test_same_seed_produces_identical_results(default_generation_config):
+    # given
+    num_records = 100
+    # when
+    factory1 = JellyFinFactory(num_records, default_generation_config)
+    records1 = factory1.create_streaming_history()
+
+    factory2 = JellyFinFactory(num_records, default_generation_config)
+    records2 = factory2.create_streaming_history()
+    # then
+    assert len(records1) == len(records2)
+    assert records1 == records2
+
+
+def test_different_seeds_produce_different_results(default_generation_config):
+    # given
+    num_records = 50
+    config1 = replace(default_generation_config, seed=123)
+    config2 = replace(default_generation_config, seed=456)
+    # when
+    factory1 = JellyFinFactory(num_records, config1)
+    records1 = factory1.create_streaming_history()
+
+    factory2 = JellyFinFactory(num_records, config2)
+    records2 = factory2.create_streaming_history()
+    # then
+    assert records1 != records2
+
+
+@pytest.mark.parametrize("seed", [0, 1, 42, 999, 12345])
+def test_various_seeds_work(seed, default_generation_config):
+    # given
+    config = replace(default_generation_config, seed=seed)
+    # when
+    factory = JellyFinFactory(100, config)
+    records = factory.create_streaming_history()
+    # then
+    assert len(records) == 100
+
+
+def test_non_audio_records_are_present(default_generation_config):
+    # given — generate enough records so ~10% non-Audio should appear
+    factory = JellyFinFactory(num_records=500, config=default_generation_config)
+    # when
+    records = factory.create_streaming_history()
+    # then
+    non_audio = [r for r in records if r.item_type != "Audio"]
+    assert len(non_audio) > 0, "Expected some non-Audio records (~10%), but found none"
+
+
+def test_records_have_valid_item_types(default_generation_config):
+    # given
+    valid_types = {"Audio", "Movie", "Episode"}
+    factory = JellyFinFactory(num_records=200, config=default_generation_config)
+    # when
+    records = factory.create_streaming_history()
+    # then
+    for record in records:
+        assert record.item_type in valid_types
+
+
+def test_records_have_valid_playback_methods(default_generation_config):
+    # given
+    valid_methods = {"DirectPlay", "Transcode"}
+    factory = JellyFinFactory(num_records=200, config=default_generation_config)
+    # when
+    records = factory.create_streaming_history()
+    # then
+    for record in records:
+        assert record.playback_method in valid_methods
+
+
+def test_records_have_valid_client_names(default_generation_config):
+    # given
+    valid_clients = {"Jellyfin Web", "Jellyfin Android", "Jellyfin iOS", "Infuse", "Swiftfin"}
+    factory = JellyFinFactory(num_records=200, config=default_generation_config)
+    # when
+    records = factory.create_streaming_history()
+    # then
+    for record in records:
+        assert record.client_name in valid_clients

--- a/synthetic-datasets/tests/writers/test_jellyfin.py
+++ b/synthetic-datasets/tests/writers/test_jellyfin.py
@@ -1,0 +1,94 @@
+import csv
+from datetime import datetime
+
+from synthetic_datasets.writers.jellyfin import COLUMNS, JellyFinWriter
+
+
+def test_write_creates_file(tmp_path, jellyfin_record):
+    # given
+    reference_date = datetime(2026, 2, 8)
+    writer = JellyFinWriter(output_dir=tmp_path, reference_date=reference_date)
+    # when
+    writer.write([jellyfin_record])
+    # then
+    assert writer.output_path.exists()
+
+
+def test_write_csv_headers(tmp_path, jellyfin_record):
+    # given
+    reference_date = datetime(2026, 2, 8)
+    writer = JellyFinWriter(output_dir=tmp_path, reference_date=reference_date)
+    # when
+    writer.write([jellyfin_record])
+    # then
+    with open(writer.output_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        assert reader.fieldnames == COLUMNS
+
+
+def test_write_csv_row_count(tmp_path, jellyfin_record):
+    # given
+    reference_date = datetime(2026, 2, 8)
+    writer = JellyFinWriter(output_dir=tmp_path, reference_date=reference_date)
+    num_records = 5
+    records = [jellyfin_record] * num_records
+    # when
+    writer.write(records)
+    # then
+    with open(writer.output_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    assert len(rows) == num_records
+
+
+def test_write_csv_date_format(tmp_path, jellyfin_record):
+    # given
+    reference_date = datetime(2026, 2, 8)
+    writer = JellyFinWriter(output_dir=tmp_path, reference_date=reference_date)
+    # when
+    writer.write([jellyfin_record])
+    # then
+    with open(writer.output_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        row = next(reader)
+    # Expected format: "YYYY-MM-DD HH:MM:SS"
+    date_str = row["DateCreated"]
+    parsed = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
+    assert parsed is not None
+
+
+def test_write_creates_output_directory(tmp_path, jellyfin_record):
+    # given
+    nested_dir = tmp_path / "nested" / "output"
+    writer = JellyFinWriter(output_dir=nested_dir, reference_date=datetime(2026, 2, 8))
+    # when
+    writer.write([jellyfin_record])
+    # then
+    assert writer.output_path.exists()
+
+
+def test_write_csv_output_path_is_playback_report(tmp_path, jellyfin_record):
+    # given
+    writer = JellyFinWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    # then
+    assert writer.output_path.name == "playback_report.csv"
+    assert writer.output_path.parent.name == "jellyfin"
+
+
+def test_write_csv_record_values(tmp_path, jellyfin_record):
+    # given
+    writer = JellyFinWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    # when
+    writer.write([jellyfin_record])
+    # then
+    with open(writer.output_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        row = next(reader)
+    assert row["UserId"] == jellyfin_record.user_id
+    assert row["ItemId"] == jellyfin_record.item_id
+    assert row["ItemType"] == jellyfin_record.item_type
+    assert row["ItemName"] == jellyfin_record.item_name
+    assert row["PlaybackMethod"] == jellyfin_record.playback_method
+    assert row["ClientName"] == jellyfin_record.client_name
+    assert row["DeviceName"] == jellyfin_record.device_name
+    assert row["PlayDuration"] == str(jellyfin_record.play_duration)


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

JellyFin Playback Reporting is a self-hosted streaming service with a plugin that exports playback history as CSV. Users of Tracksy who self-host JellyFin should be able to analyze their listening data.

Closes #197 and #196 

## 🎹 Proposal

Adds end-to-end JellyFin support:

**App (`app/`):** New `JellyFinStreamProvider` that parses the `playback_report.csv` exported by the JellyFin Playback Reporting plugin. Filters to `ItemType = Audio` rows and maps them to the canonical `StreamRecord` format. Registered alongside the existing Spotify/Deezer/Apple Music providers.

**Synthetic datasets (`synthetic-datasets/`):** `JellyFinFactory` generates realistic playback history using the `BaseFactory` infrastructure (personas, chapters, catalog). Produces a mix of Audio (~90%) and non-Audio items (Movie/Episode, ~10%) to exercise the app-side filter. `JellyFinWriter` outputs `jellyfin/playback_report.csv` in the same format as the real plugin export. Wired into the CLI as `--provider jellyfin` and included in `--all-providers`.

## 🎶 Comments

The factory follows the same pattern as `DeezerFactory` and `SpotifyFactory`. Each track gets a stable `item_id` across plays (realistic), while non-Audio items get fresh UUIDs (they are not catalog entries).

## 🎤 Test

```bash
# Generate synthetic JellyFin dataset
moon run synthetic-datasets:generate -- 500 --provider jellyfin --seed 42

# Upload datasets/jellyfin/playback_report.csv to the app
moon run app:dev

# Run all tests
moon run :test
```