### PR TITLE
feat(synthetic-datasets): accept multiple --provider values

### DIFF
--- a/.github/workflows/datasets-generate-synthetic.yml
+++ b/.github/workflows/datasets-generate-synthetic.yml
@@ -34,10 +34,8 @@ jobs:
 
       - name: Generate datasets
         run: |
-          moon run synthetic-datasets:generate -- 1000 --provider spotify
-          moon run synthetic-datasets:generate -- 500000 --provider spotify
-          moon run synthetic-datasets:generate -- 1000 --provider deezer
-          moon run synthetic-datasets:generate -- 500000 --provider deezer
+          moon run synthetic-datasets:generate -- 1000 --provider spotify --provider deezer
+          moon run synthetic-datasets:generate -- 500000 --provider spotify --provider deezer
           moon run synthetic-datasets:generate -- 25000 --all-providers
 
       - name: Clone HF repo and move datasets into it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,10 +168,12 @@ Run tasks across the entire monorepo or for specific projects.
 - **Datasets (`synthetic-datasets`)**:
 
     ```bash
-    moon run synthetic-datasets:generate  # Generate new datasets
-    moon run synthetic-datasets:generate-e2e  # Generate predictable dataset for e2e tests
-    moon run synthetic-datasets:generate -- --help  # View available options for generate command
-    moon run synthetic-datasets:test      # Run python tests
+    moon run synthetic-datasets:generate -- 1000 --provider spotify             # Generate Spotify dataset
+    moon run synthetic-datasets:generate -- 1000 --provider spotify --provider deezer  # Multiple providers
+    moon run synthetic-datasets:generate -- 1000 --all-providers                # All providers
+    moon run synthetic-datasets:generate-e2e                                    # Predictable e2e dataset
+    moon run synthetic-datasets:generate -- --help                              # View all options
+    moon run synthetic-datasets:test                                            # Run Python tests
     ```
 
 - **Blog (`blog`)**:

--- a/synthetic-datasets/AGENTS.md
+++ b/synthetic-datasets/AGENTS.md
@@ -9,13 +9,11 @@ Python scripts for synthetic music streaming history generation.
 Supported providers: `spotify`, `deezer`, `apple-music`, `custom` (default: `spotify`).
 
 ```bash
-moon run synthetic-datasets:generate -- 100 --provider spotify      # 100 Spotify records
-moon run synthetic-datasets:generate -- 100 --provider deezer       # 100 Deezer records
-moon run synthetic-datasets:generate -- 100 --provider apple-music  # 100 Apple Music records
-moon run synthetic-datasets:generate -- 100 --provider custom       # 100 Custom CSV records
-moon run synthetic-datasets:generate -- 100 --all-providers         # All providers at once
-moon run synthetic-datasets:generate -- --seed 42                   # Deterministic output
-moon run synthetic-datasets:generate -- --help                      # Full options
+moon run synthetic-datasets:generate -- 100 --provider spotify                     # single provider
+moon run synthetic-datasets:generate -- 100 --provider spotify --provider deezer   # multiple providers
+moon run synthetic-datasets:generate -- 100 --all-providers                        # all providers
+moon run synthetic-datasets:generate -- --seed 42                                  # deterministic output
+moon run synthetic-datasets:generate -- --help                                     # full options + valid values
 ```
 
 For raw uv commands (adding deps, etc.) — use sparingly:

--- a/synthetic-datasets/README.md
+++ b/synthetic-datasets/README.md
@@ -13,6 +13,8 @@ Run the generator locally with:
 ```bash
 moon setup
 moon run synthetic-datasets:generate -- 1000 --provider spotify
+moon run synthetic-datasets:generate -- 1000 --provider spotify --provider deezer  # multiple providers at once
+moon run synthetic-datasets:generate -- 1000 --all-providers                       # all providers at once
 ```
 
 Find generated datasets in the `datasets` folder. Load the output file in the Tracksy app and inspect charts.

--- a/synthetic-datasets/synthetic_datasets/app.py
+++ b/synthetic-datasets/synthetic_datasets/app.py
@@ -77,6 +77,8 @@ Examples:
 
   generate 1000 --seed 42
 
+  generate 1000 --provider spotify --provider deezer
+
   generate 1000 --all-providers
 """
 )
@@ -95,35 +97,42 @@ def generate(
         typer.Option(help="Overwrite reference date in ISO format (e.g., 2026-02-08 or 2026-02-08T14:30:00)"),
     ] = None,
     provider: Annotated[
-        Provider | None,
-        typer.Option(help="Streaming provider to generate data for"),
-    ] = None,
+        list[Provider],
+        typer.Option(help="Streaming provider to generate data for (repeatable)"),
+    ] = [],
     all_providers: Annotated[
         bool,
         typer.Option("--all-providers", help="Generate datasets for all providers"),
     ] = False,
 ) -> None:
     """Generate synthetic streaming datasets."""
-    if all_providers and provider is not None:
+    if all_providers and provider:
         raise typer.BadParameter("Cannot use --all-providers with --provider")
 
     start = time.perf_counter()
     config = GenerationConfig.create(seed=seed, reference_date=reference_date)
 
+    provider_fns = {
+        Provider.spotify: _spotify,
+        Provider.deezer: _deezer,
+        Provider.apple_music: _apple_music,
+        Provider.jellyfin: _jellyfin,
+        Provider.custom: _custom,
+    }
+
     if all_providers:
-        provider_fns = {
-            Provider.spotify: _spotify,
-            Provider.deezer: _deezer,
-            Provider.apple_music: _apple_music,
-            Provider.jellyfin: _jellyfin,
-            Provider.custom: _custom,
-        }
+        providers_to_run: list[Provider] = list(Provider)
+    elif provider:
+        providers_to_run = provider
+    else:
+        providers_to_run = []
+
+    if providers_to_run:
         errors: list[tuple[Provider, Exception]] = []
-        for prov in Provider:
-            fn = provider_fns[prov]
+        for prov in providers_to_run:
             print(Rule(f"[bold]{prov.value}[/bold]"))
             try:
-                fn(num_records, output_dir, config)
+                provider_fns[prov](num_records, output_dir, config)
             except Exception as e:
                 errors.append((prov, e))
         if errors:
@@ -131,17 +140,7 @@ def generate(
                 print(f"[red]Error generating {prov.value}: {e}[/red]")
             raise typer.Exit(code=1)
     else:
-        match provider or Provider.spotify:
-            case Provider.deezer:
-                _deezer(num_records, output_dir, config)
-            case Provider.apple_music:
-                _apple_music(num_records, output_dir, config)
-            case Provider.spotify:
-                _spotify(num_records, output_dir, config)
-            case Provider.jellyfin:
-                _jellyfin(num_records, output_dir, config)
-            case Provider.custom:
-                _custom(num_records, output_dir, config)
+        _spotify(num_records, output_dir, config)
 
     elapsed = time.perf_counter() - start
     print(Panel(f"Completed in [bold]{elapsed:.2f}s[/bold]", title="✨ Result", style="green"))

--- a/synthetic-datasets/tests/test_app.py
+++ b/synthetic-datasets/tests/test_app.py
@@ -136,3 +136,48 @@ def test_help_mentions_all_providers():
     result = runner.invoke(app, ["--help"], env={"TERM": "dumb"})
     assert result.exit_code == 0
     assert "all-providers" in result.output
+
+
+def test_generate_multiple_providers(tmp_path):
+    result = runner.invoke(
+        app,
+        ["100", "--seed", "42", "--provider", "spotify", "--provider", "deezer", "-o", str(tmp_path)],
+    )
+    assert result.exit_code == 0
+    assert (tmp_path / "spotify").exists()
+    assert (tmp_path / "deezer").exists()
+
+
+@patch("synthetic_datasets.app._deezer")
+@patch("synthetic_datasets.app._spotify")
+def test_multiple_providers_continues_on_failure(mock_spotify, mock_deezer, tmp_path):
+    mock_spotify.side_effect = RuntimeError("spotify failed")
+    result = runner.invoke(
+        app,
+        ["100", "--seed", "42", "--provider", "spotify", "--provider", "deezer", "-o", str(tmp_path)],
+        env={"TERM": "dumb"},
+    )
+    assert result.exit_code != 0
+    assert "Error generating spotify" in result.output
+    mock_deezer.assert_called_once()
+
+
+def test_multiple_providers_conflict_with_all_providers(tmp_path):
+    result = runner.invoke(
+        app,
+        [
+            "100",
+            "--seed",
+            "42",
+            "--all-providers",
+            "--provider",
+            "spotify",
+            "--provider",
+            "deezer",
+            "-o",
+            str(tmp_path),
+        ],
+        env={"TERM": "dumb"},
+    )
+    assert result.exit_code == 2
+    assert "Cannot use --all-providers with --provider" in result.output


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

`--all-providers` runs all providers at once, but there was no way to run a specific subset (e.g. Spotify + Deezer only) without invoking the CLI twice.

Closes #504.

## 🎹 Proposal

`--provider` is now repeatable: `--provider spotify --provider deezer` runs both providers sequentially with the same `GenerationConfig` (same seed and reference date) and the same continue-on-error behavior as `--all-providers`. Using `--all-providers` together with `--provider` remains an error.

The CI generate workflow is updated to use the new flag where applicable.

## 🎶 Comments

Typer maps `list[Provider]` to a Click `multiple=True` option. The `provider_fns` dict is kept inside the function body so patches applied in tests are picked up at call time.

## 🎤 Test

```bash
# single provider (unchanged)
moon run synthetic-datasets:generate -- 100 --provider deezer

# multiple providers
moon run synthetic-datasets:generate -- 100 --provider spotify --provider deezer

# conflict still errors
moon run synthetic-datasets:generate -- 100 --all-providers --provider spotify
```

```bash
moon run synthetic-datasets:test
```