### PR TITLE
style(e2e): add prettier and reformat all files

### DIFF
--- a/.github/workflows/e2e-format.yml
+++ b/.github/workflows/e2e-format.yml
@@ -1,0 +1,32 @@
+name: E2E Format Check
+
+on:
+  pull_request:
+    paths:
+      - "e2e/**"
+      - ".github/workflows/e2e-format.yml"
+      - ".moon/toolchains.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  format-check:
+    name: Check format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install moon
+        uses: moonrepo/setup-toolchain@v0
+        with:
+          auto-install: false
+
+      - name: Setup toolchains
+        run: moon setup
+
+      - name: Check format
+        run: moon run e2e:format-check

--- a/e2e/.prettierignore
+++ b/e2e/.prettierignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+pnpm-lock.yaml
+package.json
+datasets/

--- a/e2e/.prettierrc.mjs
+++ b/e2e/.prettierrc.mjs
@@ -1,0 +1,17 @@
+/** @type {import("prettier").Config} */
+
+export default {
+    trailingComma: 'es5',
+    tabWidth: 4,
+    semi: false,
+    singleQuote: true,
+
+    overrides: [
+        {
+            files: '*.astro',
+            options: {
+                parser: 'astro',
+            },
+        },
+    ],
+}

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -19,6 +19,13 @@ moon run e2e:test-dev
 - `moon run e2e:codegen` — record actions to generate tests
 - `moon run e2e:show-report` — view last test report
 
+Quality checks:
+
+```bash
+moon run e2e:format          # Format with Prettier
+moon run e2e:format-check    # Check formatting
+```
+
 ## Datasets
 
 Tests run against a fixed synthetic dataset generated with:

--- a/e2e/moon.yml
+++ b/e2e/moon.yml
@@ -1,27 +1,31 @@
 language: javascript
 tasks:
-  test:
-    command: playwright test
-    deps:
-      - synthetic-datasets:generate-e2e
-  test-dev:
-    command: playwright test
-    deps:
-      - app:dev
-      - synthetic-datasets:generate-e2e
-    preset: server
-  test-ui:
-    command: playwright test --ui
-    deps:
-      - app:dev
-      - synthetic-datasets:generate-e2e
-    preset: server
-  codegen:
-    command: playwright codegen
-    preset: server
-  show-report:
-    command: playwright show-report
-    preset: server
-  install-browsers:
-    command: playwright install --with-deps
+    test:
+        command: playwright test
+        deps:
+            - synthetic-datasets:generate-e2e
+    test-dev:
+        command: playwright test
+        deps:
+            - app:dev
+            - synthetic-datasets:generate-e2e
+        preset: server
+    test-ui:
+        command: playwright test --ui
+        deps:
+            - app:dev
+            - synthetic-datasets:generate-e2e
+        preset: server
+    codegen:
+        command: playwright codegen
+        preset: server
+    show-report:
+        command: playwright show-report
+        preset: server
+    install-browsers:
+        command: playwright install --with-deps
+    format:
+        command: prettier --write .
+    format-check:
+        command: prettier --check .
 layer: application

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,6 +4,7 @@
   "description": "End-to-end tests for Tracksy",
   "devDependencies": {
     "@playwright/test": "^1.57.0",
+    "prettier": "^3.8.3",
     "@types/node": "^24.10.4",
     "typescript": "^5.9.3"
   },

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,44 +1,44 @@
-import { defineConfig, devices } from "@playwright/test";
+import { defineConfig, devices } from '@playwright/test'
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: "./tests",
-  /* Run tests in files in parallel */
-  fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
-  use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.URL || "http://localhost:4321",
+    testDir: './tests',
+    /* Run tests in files in parallel */
+    fullyParallel: true,
+    /* Fail the build on CI if you accidentally left test.only in the source code. */
+    forbidOnly: !!process.env.CI,
+    /* Retry on CI only */
+    retries: process.env.CI ? 2 : 0,
+    /* Opt out of parallel tests on CI. */
+    workers: process.env.CI ? 1 : undefined,
+    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+    reporter: 'html',
+    /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+    use: {
+        /* Base URL to use in actions like `await page.goto('/')`. */
+        baseURL: process.env.URL || 'http://localhost:4321',
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: "on-first-retry",
-  },
-
-  /* Configure projects for major browsers */
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+        /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+        trace: 'on-first-retry',
     },
 
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
+    /* Configure projects for major browsers */
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
 
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
-  ],
-});
+        {
+            name: 'firefox',
+            use: { ...devices['Desktop Firefox'] },
+        },
+
+        {
+            name: 'webkit',
+            use: { ...devices['Desktop Safari'] },
+        },
+    ],
+})

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/node':
         specifier: ^24.10.4
         version: 24.10.4
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -41,6 +44,11 @@ packages:
   playwright@1.57.0:
     resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
     engines: {node: '>=18'}
+    hasBin: true
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
     hasBin: true
 
   typescript@5.9.3:
@@ -71,6 +79,8 @@ snapshots:
       playwright-core: 1.57.0
     optionalDependencies:
       fsevents: 2.3.2
+
+  prettier@3.8.3: {}
 
   typescript@5.9.3: {}
 

--- a/e2e/tests/main.spec.ts
+++ b/e2e/tests/main.spec.ts
@@ -1,132 +1,236 @@
 // FIXME: download the dataset from hugging face and use it instead of the zip file https://github.com/Gudsfile/tracksy/issues/242
 
-import { test, expect } from "@playwright/test";
-import * as path from "path";
+import { test, expect } from '@playwright/test'
+import * as path from 'path'
 
-test("has title and can upload dataset", async ({ page }) => {
-  await page.goto(process.env.TEST_PATH || "/tracksy");
+test('has title and can upload dataset', async ({ page }) => {
+    await page.goto(process.env.TEST_PATH || '/tracksy')
 
-  // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/Tracksy/);
+    // Expect a title "to contain" a substring.
+    await expect(page).toHaveTitle(/Tracksy/)
 
-  // Expect anchor under h1 with text "Tracksy" to be visible
-  await expect(page.locator("h1").getByRole("link", { name: "Tracksy" })).toBeVisible();
+    // Expect anchor under h1 with text "Tracksy" to be visible
+    await expect(
+        page.locator('h1').getByRole('link', { name: 'Tracksy' })
+    ).toBeVisible()
 
-  // Upload the zip file
-  // Note: We use relative path from the test file to the dataset
-  const fileInput = page.locator('input[type="file"]');
-  await fileInput.setInputFiles(path.join(__dirname, "../datasets/spotify/streamings_1000.zip"));
+    // Upload the zip file
+    // Note: We use relative path from the test file to the dataset
+    const fileInput = page.locator('input[type="file"]')
+    await fileInput.setInputFiles(
+        path.join(__dirname, '../datasets/spotify/streamings_1000.zip')
+    )
 
-  // Simple view assertions
-  const simpleViewTab = page.getByRole("tab", { name: /✨ Simple/ });
-  await expect(simpleViewTab).toBeVisible();
+    // Simple view assertions
+    const simpleViewTab = page.getByRole('tab', { name: /✨ Simple/ })
+    await expect(simpleViewTab).toBeVisible()
 
-  // Assert it is active (selected)
-  await expect(simpleViewTab).toHaveAttribute("aria-selected", "true");
+    // Assert it is active (selected)
+    await expect(simpleViewTab).toHaveAttribute('aria-selected', 'true')
 
-  // Select 2025 in the year sidebar
-  const year2025Button = page
-    .getByRole("navigation", { name: "Filter by year" })
-    .getByRole("button", { name: "2025", exact: true });
-  await year2025Button.click();
-  await expect(year2025Button).toHaveAttribute("aria-pressed", "true");
+    // Select 2025 in the year sidebar
+    const year2025Button = page
+        .getByRole('navigation', { name: 'Filter by year' })
+        .getByRole('button', { name: '2025', exact: true })
+    await year2025Button.click()
+    await expect(year2025Button).toHaveAttribute('aria-pressed', 'true')
 
-  /* Top Tracks Card */
-  const topTracksCard = page.locator(".group").filter({
-    has: page.getByRole("heading", { name: /Top Tracks/ }),
-  });
-  await expect(topTracksCard).toBeVisible();
+    /* Top Tracks Card */
+    const topTracksCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Top Tracks/ }),
+    })
+    await expect(topTracksCard).toBeVisible()
 
-  await expect(topTracksCard.getByRole("listitem").filter({ hasText: "Property Simply Break" })).toBeVisible();
-  await expect(topTracksCard.getByRole("listitem").filter({ hasText: "Property Simply Break" })).toContainText("🥇");
-  await expect(topTracksCard.getByRole("listitem").filter({ hasText: "Property Simply Break" })).toContainText("Property Simply Break Could");
-  await expect(topTracksCard.getByRole("listitem").filter({ hasText: "Property Simply Break" })).toContainText("Norma Roberts");
-  await expect(topTracksCard.getByRole("listitem").filter({ hasText: "Property Simply Break" })).toContainText("15");
+    await expect(
+        topTracksCard
+            .getByRole('listitem')
+            .filter({ hasText: 'Property Simply Break' })
+    ).toBeVisible()
+    await expect(
+        topTracksCard
+            .getByRole('listitem')
+            .filter({ hasText: 'Property Simply Break' })
+    ).toContainText('🥇')
+    await expect(
+        topTracksCard
+            .getByRole('listitem')
+            .filter({ hasText: 'Property Simply Break' })
+    ).toContainText('Property Simply Break Could')
+    await expect(
+        topTracksCard
+            .getByRole('listitem')
+            .filter({ hasText: 'Property Simply Break' })
+    ).toContainText('Norma Roberts')
+    await expect(
+        topTracksCard
+            .getByRole('listitem')
+            .filter({ hasText: 'Property Simply Break' })
+    ).toContainText('15')
 
-  /* Top Artists Card */
-  const topArtistsCard = page.locator(".group").filter({
-    has: page.getByRole("heading", { name: /Top Artists/ }),
-  });
-  await expect(topArtistsCard).toBeVisible();
-  await expect(topArtistsCard.getByRole("listitem").filter({ hasText: "Jeffrey Mathis" })).toBeVisible();
-  await expect(topArtistsCard.getByRole("listitem").filter({ hasText: "Jeffrey Mathis" })).toContainText("🥈");
-  await expect(topArtistsCard.getByRole("listitem").filter({ hasText: "Jeffrey Mathis" })).toContainText("21m");
-  await expect(topArtistsCard.getByRole("listitem").filter({ hasText: "Jeffrey Mathis" })).toContainText("8");
+    /* Top Artists Card */
+    const topArtistsCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Top Artists/ }),
+    })
+    await expect(topArtistsCard).toBeVisible()
+    await expect(
+        topArtistsCard
+            .getByRole('listitem')
+            .filter({ hasText: 'Jeffrey Mathis' })
+    ).toBeVisible()
+    await expect(
+        topArtistsCard
+            .getByRole('listitem')
+            .filter({ hasText: 'Jeffrey Mathis' })
+    ).toContainText('🥈')
+    await expect(
+        topArtistsCard
+            .getByRole('listitem')
+            .filter({ hasText: 'Jeffrey Mathis' })
+    ).toContainText('21m')
+    await expect(
+        topArtistsCard
+            .getByRole('listitem')
+            .filter({ hasText: 'Jeffrey Mathis' })
+    ).toContainText('8')
 
-  /* Top Albums Card */
-  const topAlbumsCard = page.locator(".group").filter({
-    has: page.getByRole("heading", { name: /Top Albums/ }),
-  });
-  await expect(topAlbumsCard).toBeVisible();
-  await expect(topAlbumsCard.getByRole("listitem").filter({ hasText: "Hand Growth After" })).toBeVisible();
-  await expect(topAlbumsCard.getByRole("listitem").filter({ hasText: "Hand Growth After" })).toContainText("5️⃣");
-  await expect(topAlbumsCard.getByRole("listitem").filter({ hasText: "Hand Growth After" })).toContainText("Kayla Richardson");
-  await expect(topAlbumsCard.getByRole("listitem").filter({ hasText: "Hand Growth After" })).toContainText("4");
+    /* Top Albums Card */
+    const topAlbumsCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Top Albums/ }),
+    })
+    await expect(topAlbumsCard).toBeVisible()
+    await expect(
+        topAlbumsCard
+            .getByRole('listitem')
+            .filter({ hasText: 'Hand Growth After' })
+    ).toBeVisible()
+    await expect(
+        topAlbumsCard
+            .getByRole('listitem')
+            .filter({ hasText: 'Hand Growth After' })
+    ).toContainText('5️⃣')
+    await expect(
+        topAlbumsCard
+            .getByRole('listitem')
+            .filter({ hasText: 'Hand Growth After' })
+    ).toContainText('Kayla Richardson')
+    await expect(
+        topAlbumsCard
+            .getByRole('listitem')
+            .filter({ hasText: 'Hand Growth After' })
+    ).toContainText('4')
 
-  /* Focus Mode Card */
-  await expect(page.getByRole("heading", { name: /Focus Mode/ })).toBeVisible();
-  await expect(page.getByRole("listitem").filter({ hasText: "Top 5" })).toContainText("25.0%");
-  await expect(page.getByRole("listitem").filter({ hasText: "Top 10" })).toContainText("37.8%");
-  await expect(page.getByRole("listitem").filter({ hasText: "Top 20" })).toContainText("55.8%");
+    /* Focus Mode Card */
+    await expect(
+        page.getByRole('heading', { name: /Focus Mode/ })
+    ).toBeVisible()
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'Top 5' })
+    ).toContainText('25.0%')
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'Top 10' })
+    ).toContainText('37.8%')
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'Top 20' })
+    ).toContainText('55.8%')
 
-  /* Artist Loyalty Card */
-  const loyaltyCard = page.locator(".group").filter({
-    has: page.getByRole("heading", { name: /Artist Loyalty/ }),
-  });
-  await expect(loyaltyCard).toBeVisible();
-  await expect(loyaltyCard.getByText("Explorer")).toBeVisible();
-  await expect(loyaltyCard.getByText("1 stream26%")).toBeVisible();
-  await expect(loyaltyCard.getByText("2-10 streams63%")).toBeVisible();
-  await expect(loyaltyCard.getByText("11-100 streams11%")).toBeVisible();
-  await expect(loyaltyCard.getByText("101-1000 streams0%")).toBeVisible();
-  await expect(loyaltyCard.getByText("1000+ streams0%")).toBeVisible();
+    /* Artist Loyalty Card */
+    const loyaltyCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Artist Loyalty/ }),
+    })
+    await expect(loyaltyCard).toBeVisible()
+    await expect(loyaltyCard.getByText('Explorer')).toBeVisible()
+    await expect(loyaltyCard.getByText('1 stream26%')).toBeVisible()
+    await expect(loyaltyCard.getByText('2-10 streams63%')).toBeVisible()
+    await expect(loyaltyCard.getByText('11-100 streams11%')).toBeVisible()
+    await expect(loyaltyCard.getByText('101-1000 streams0%')).toBeVisible()
+    await expect(loyaltyCard.getByText('1000+ streams0%')).toBeVisible()
 
-  /* Daily Vibes Card */
-  await expect(page.getByRole("heading", { name: /Daily Vibes/ })).toBeVisible();
-  await expect(page.getByRole("listitem").filter({ hasText: "Morning" })).toContainText("39.5%");
-  await expect(page.getByRole("listitem").filter({ hasText: "Night" })).toContainText("14.0%");
+    /* Daily Vibes Card */
+    await expect(
+        page.getByRole('heading', { name: /Daily Vibes/ })
+    ).toBeVisible()
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'Morning' })
+    ).toContainText('39.5%')
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'Night' })
+    ).toContainText('14.0%')
 
-  /* Consistency Meter Card */
-  await expect(page.getByRole("heading", { name: /Consistency Meter/ })).toBeVisible();
-  await expect(page.getByText("Occasional", { exact: true })).toBeVisible();
-  await expect(page.getByText("134 / 365 days")).toBeVisible();
-  await expect(page.getByText("37%")).toBeVisible();
+    /* Consistency Meter Card */
+    await expect(
+        page.getByRole('heading', { name: /Consistency Meter/ })
+    ).toBeVisible()
+    await expect(page.getByText('Occasional', { exact: true })).toBeVisible()
+    await expect(page.getByText('134 / 365 days')).toBeVisible()
+    await expect(page.getByText('37%')).toBeVisible()
 
-  /* Soundtrack Growth */
-  await expect(page.getByRole("heading", { name: /Soundtrack Growth/ })).toBeVisible();
-  await expect(page.getByRole("listitem").filter({ hasText: "Total streams" })).toContainText("746");
-  await expect(page.getByRole("listitem").filter({ hasText: "This year" })).toContainText("172");
+    /* Soundtrack Growth */
+    await expect(
+        page.getByRole('heading', { name: /Soundtrack Growth/ })
+    ).toBeVisible()
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'Total streams' })
+    ).toContainText('746')
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'This year' })
+    ).toContainText('172')
 
-  /* Seasonal Mood Card */
-  await expect(page.getByRole("heading", { name: /Seasonal Mood/ })).toBeVisible();
-  await expect(page.getByText('Fall54 streams🍂')).toBeVisible();
-  await expect(page.getByRole("listitem").filter({ hasText: "Winter" })).toContainText("23.3%");
-  await expect(page.getByRole("listitem").filter({ hasText: "Summer" })).toContainText("17.4%");
+    /* Seasonal Mood Card */
+    await expect(
+        page.getByRole('heading', { name: /Seasonal Mood/ })
+    ).toBeVisible()
+    await expect(page.getByText('Fall54 streams🍂')).toBeVisible()
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'Winter' })
+    ).toContainText('23.3%')
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'Summer' })
+    ).toContainText('17.4%')
 
-  /* Fresh vs Familiar Card */
-  await expect(page.getByRole("heading", { name: /Fresh vs Familiar/ })).toBeVisible();
-  await expect(page.getByText("9 new artists discovered this year!")).toBeVisible();
-  await expect(page.getByRole("listitem").filter({ hasText: "Discoveries" })).toContainText("11%");
+    /* Fresh vs Familiar Card */
+    await expect(
+        page.getByRole('heading', { name: /Fresh vs Familiar/ })
+    ).toBeVisible()
+    await expect(
+        page.getByText('9 new artists discovered this year!')
+    ).toBeVisible()
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'Discoveries' })
+    ).toContainText('11%')
 
-  /* Skip Mood Card */
-  await expect(page.getByRole("heading", { name: /Skip Mood/ })).toBeVisible();
-  await expect(page.getByText("100.0%")).toBeVisible();
-  await expect(page.getByRole("listitem").filter({ hasText: "Completed" })).toContainText("172");
+    /* Skip Mood Card */
+    await expect(page.getByRole('heading', { name: /Skip Mood/ })).toBeVisible()
+    await expect(page.getByText('100.0%')).toBeVisible()
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'Completed' })
+    ).toContainText('172')
 
-  /* Replay Energy Card */
-  await expect(page.getByRole("heading", { name: /Replay Energy/ })).toBeVisible();
-  await expect(page.getByText("Variated")).toBeVisible();
-  await expect(page.getByRole("listitem").filter({ hasText: "Repeat average" })).toContainText("2.0 times");
+    /* Replay Energy Card */
+    await expect(
+        page.getByRole('heading', { name: /Replay Energy/ })
+    ).toBeVisible()
+    await expect(page.getByText('Variated')).toBeVisible()
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'Repeat average' })
+    ).toContainText('2.0 times')
 
-  /* Your Sound Machine Card */
-  await expect(page.getByRole("heading", { name: /Your Sound Machine/ })).toBeVisible();
-  await expect(page.getByText("Windows")).toHaveCount(2);
-  await expect(page.getByText('70 streams')).toBeVisible();
-  await expect(page.getByRole("listitem").filter({ hasText: "Windows" })).toContainText("40.7%");
-  await expect(page.getByRole("listitem").filter({ hasText: "Others" })).toContainText("59.3%");
+    /* Your Sound Machine Card */
+    await expect(
+        page.getByRole('heading', { name: /Your Sound Machine/ })
+    ).toBeVisible()
+    await expect(page.getByText('Windows')).toHaveCount(2)
+    await expect(page.getByText('70 streams')).toBeVisible()
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'Windows' })
+    ).toContainText('40.7%')
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'Others' })
+    ).toContainText('59.3%')
 
-  /* Your Power Day Card */
-  await expect(page.getByRole("heading", { name: /Your Power Day/ })).toBeVisible();
-  await expect(page.getByText("Tuesday").first()).toBeVisible();
-  await expect(page.getByText("31 streams")).toBeVisible();
-});
+    /* Your Power Day Card */
+    await expect(
+        page.getByRole('heading', { name: /Your Power Day/ })
+    ).toBeVisible()
+    await expect(page.getByText('Tuesday').first()).toBeVisible()
+    await expect(page.getByText('31 streams')).toBeVisible()
+})

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,20 +1,16 @@
 {
-  "compilerOptions": {
-    "target": "es2020",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noImplicitAny": true,
-    "strict": true,
-    "sourceMap": true,
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": [
-        "node_modules/*"
-      ]
-    }
-  },
-  "include": [
-    "**/*.ts"
-  ]
+    "compilerOptions": {
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "noImplicitAny": true,
+        "strict": true,
+        "sourceMap": true,
+        "outDir": "dist",
+        "baseUrl": ".",
+        "paths": {
+            "*": ["node_modules/*"]
+        }
+    },
+    "include": ["**/*.ts"]
 }


### PR DESCRIPTION
Add .prettierrc.mjs and .prettierignore, format/format-check moon tasks, and apply formatting across all e2e files.

## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

<!-- The need or intention covered by this Pull Request. -->

## 🎹 Proposal

<!-- Approach in plain language. No commit lists, no "X files changed", no "X tests added". Describe what changed and why, not how the work was organized. -->

## 🎶 Comments

<!-- Additional information, tips or problems encountered. -->

## 🎤 Test

<!-- Instructions for reproducing the problem and how you tested the fix. -->
