### PR TITLE
test(e2e): scope assertions to card containers and re-enable preview CI

### DIFF
--- a/.github/workflows/app-deploy-preview.yml
+++ b/.github/workflows/app-deploy-preview.yml
@@ -67,16 +67,11 @@ jobs:
           deploy-commit-message: "chore(): deploy Tracksy App Preview for PR #${{ github.event.number }}"
           remove-commit-message: "chore(): remove Tracksy App Preview for PR #${{ github.event.number }}"
 
-  # Temporarily disabled:
-  # - E2E tests are currently broken
-  # - tracked in issue #347
-  # - re-enable once the issue is fixed
-  #
-  # e2e-tests:
-  #   needs: deploy-preview
-  #   if: github.event.action != 'closed'
-  #   uses: ./.github/workflows/e2e.yml
-  #   with:
-  #     baseUrl: ${{ needs.deploy-preview.outputs.preview-url}}
-  #     testPath: /tracksy/pr-preview/pr-${{ github.event.pull_request.number }}
-  #   secrets: inherit
+  e2e-tests:
+    needs: deploy-preview
+    if: github.event.action != 'closed'
+    uses: ./.github/workflows/e2e.yml
+    with:
+      baseUrl: ${{ needs.deploy-preview.outputs.preview-url}}
+      testPath: /tracksy/pr-preview/pr-${{ github.event.pull_request.number }}
+    secrets: inherit

--- a/e2e/.prettierrc.mjs
+++ b/e2e/.prettierrc.mjs
@@ -1,6 +1,7 @@
 /** @type {import("prettier").Config} */
 
 export default {
+    printWidth: 120,
     trailingComma: 'es5',
     tabWidth: 4,
     semi: false,

--- a/e2e/tests/main.spec.ts
+++ b/e2e/tests/main.spec.ts
@@ -177,4 +177,17 @@ test('has title and can upload dataset', async ({ page }) => {
     /* Eclectic Day */
     await expect(page.getByRole('heading', { name: /Eclectic Day/ })).toBeVisible()
     await expect(page.getByText('4different artists')).toBeVisible()
+
+    // Switch to Lab view
+    await labView.click()
+    await expect(simpleViewTab).not.toHaveAttribute('aria-selected', 'true')
+    await expect(labView).toHaveAttribute('aria-selected', 'true')
+
+    await expect(page.getByRole('heading', { name: /Stream Timeline/ })).toBeVisible()
+    await expect(page.getByRole('heading', { name: /Stream Variety/ })).toBeVisible()
+    await expect(page.getByRole('heading', { name: /Stream Discovery/ })).toBeVisible()
+
+    await expect(page.getByRole('heading', { name: /Top 10 Race/ })).toBeVisible()
+    await expect(page.getByRole('heading', { name: /Listening Streaks/ })).toBeVisible()
+    await expect(page.getByRole('heading', { name: /Listening Bingo/ })).toBeVisible()
 })

--- a/e2e/tests/main.spec.ts
+++ b/e2e/tests/main.spec.ts
@@ -10,16 +10,12 @@ test('has title and can upload dataset', async ({ page }) => {
     await expect(page).toHaveTitle(/Tracksy/)
 
     // Expect anchor under h1 with text "Tracksy" to be visible
-    await expect(
-        page.locator('h1').getByRole('link', { name: 'Tracksy' })
-    ).toBeVisible()
+    await expect(page.locator('h1').getByRole('link', { name: 'Tracksy' })).toBeVisible()
 
     // Upload the zip file
     // Note: We use relative path from the test file to the dataset
     const fileInput = page.locator('input[type="file"]')
-    await fileInput.setInputFiles(
-        path.join(__dirname, '../datasets/spotify/streamings_1000.zip')
-    )
+    await fileInput.setInputFiles(path.join(__dirname, '../datasets/spotify/streamings_1000.zip'))
 
     // Simple view assertions
     const simpleViewTab = page.getByRole('tab', { name: /✨ Simple/ })
@@ -27,6 +23,19 @@ test('has title and can upload dataset', async ({ page }) => {
 
     // Assert it is active (selected)
     await expect(simpleViewTab).toHaveAttribute('aria-selected', 'true')
+
+    // Assert other tabs
+    const labView = page.getByRole('tab', { name: /🔬 Lab/ })
+    await expect(labView).toBeVisible()
+    await expect(labView).not.toHaveAttribute('aria-selected', 'true')
+
+    const chatView = page.getByRole('tab', { name: /💬 Chat/ })
+    await expect(chatView).toBeVisible()
+    await expect(chatView).not.toHaveAttribute('aria-selected', 'true')
+
+    const queryView = page.getByRole('tab', { name: /⌨️ Query/ })
+    await expect(queryView).toBeVisible()
+    await expect(queryView).not.toHaveAttribute('aria-selected', 'true')
 
     // Select 2025 in the year sidebar
     const year2025Button = page
@@ -41,196 +50,131 @@ test('has title and can upload dataset', async ({ page }) => {
     })
     await expect(topTracksCard).toBeVisible()
 
-    await expect(
-        topTracksCard
-            .getByRole('listitem')
-            .filter({ hasText: 'Property Simply Break' })
-    ).toBeVisible()
-    await expect(
-        topTracksCard
-            .getByRole('listitem')
-            .filter({ hasText: 'Property Simply Break' })
-    ).toContainText('🥇')
-    await expect(
-        topTracksCard
-            .getByRole('listitem')
-            .filter({ hasText: 'Property Simply Break' })
-    ).toContainText('Property Simply Break Could')
-    await expect(
-        topTracksCard
-            .getByRole('listitem')
-            .filter({ hasText: 'Property Simply Break' })
-    ).toContainText('Norma Roberts')
-    await expect(
-        topTracksCard
-            .getByRole('listitem')
-            .filter({ hasText: 'Property Simply Break' })
-    ).toContainText('15')
+    const firstTopTrack = topTracksCard.getByRole('listitem').filter({ hasText: 'benchmark e-busi' })
+    await expect(firstTopTrack).toBeVisible()
+    await expect(firstTopTrack).toContainText('🥇')
+    await expect(firstTopTrack).toContainText('Teresa King')
+    await expect(firstTopTrack).toContainText('35')
 
     /* Top Artists Card */
     const topArtistsCard = page.locator('.group').filter({
         has: page.getByRole('heading', { name: /Top Artists/ }),
     })
     await expect(topArtistsCard).toBeVisible()
-    await expect(
-        topArtistsCard
-            .getByRole('listitem')
-            .filter({ hasText: 'Jeffrey Mathis' })
-    ).toBeVisible()
-    await expect(
-        topArtistsCard
-            .getByRole('listitem')
-            .filter({ hasText: 'Jeffrey Mathis' })
-    ).toContainText('🥈')
-    await expect(
-        topArtistsCard
-            .getByRole('listitem')
-            .filter({ hasText: 'Jeffrey Mathis' })
-    ).toContainText('21m')
-    await expect(
-        topArtistsCard
-            .getByRole('listitem')
-            .filter({ hasText: 'Jeffrey Mathis' })
-    ).toContainText('8')
+
+    const secondTopArtist = topArtistsCard.getByRole('listitem').filter({ hasText: 'Michelle Marshall' })
+    await expect(secondTopArtist).toBeVisible()
+    await expect(secondTopArtist).toContainText('🥈')
+    await expect(secondTopArtist).toContainText('2h')
+    await expect(secondTopArtist).toContainText('32')
 
     /* Top Albums Card */
     const topAlbumsCard = page.locator('.group').filter({
         has: page.getByRole('heading', { name: /Top Albums/ }),
     })
     await expect(topAlbumsCard).toBeVisible()
-    await expect(
-        topAlbumsCard
-            .getByRole('listitem')
-            .filter({ hasText: 'Hand Growth After' })
-    ).toBeVisible()
-    await expect(
-        topAlbumsCard
-            .getByRole('listitem')
-            .filter({ hasText: 'Hand Growth After' })
-    ).toContainText('5️⃣')
-    await expect(
-        topAlbumsCard
-            .getByRole('listitem')
-            .filter({ hasText: 'Hand Growth After' })
-    ).toContainText('Kayla Richardson')
-    await expect(
-        topAlbumsCard
-            .getByRole('listitem')
-            .filter({ hasText: 'Hand Growth After' })
-    ).toContainText('4')
+
+    const fifthTopAlbum = topAlbumsCard.getByRole('listitem').filter({ hasText: 'Compatible recipro' })
+    await expect(fifthTopAlbum).toBeVisible()
+    await expect(fifthTopAlbum).toContainText('5️⃣')
+    await expect(fifthTopAlbum).toContainText('Ryan Collins')
+    await expect(fifthTopAlbum).toContainText('18')
+
+    /* Listening activity */
+    await expect(page.getByRole('heading', { name: /Listening activity/ })).toBeVisible()
 
     /* Focus Mode Card */
-    await expect(
-        page.getByRole('heading', { name: /Focus Mode/ })
-    ).toBeVisible()
-    await expect(
-        page.getByRole('listitem').filter({ hasText: 'Top 5' })
-    ).toContainText('25.0%')
-    await expect(
-        page.getByRole('listitem').filter({ hasText: 'Top 10' })
-    ).toContainText('37.8%')
-    await expect(
-        page.getByRole('listitem').filter({ hasText: 'Top 20' })
-    ).toContainText('55.8%')
+    await expect(page.getByRole('heading', { name: /Focus Mode/ })).toBeVisible()
+    await expect(page.getByRole('listitem').filter({ hasText: 'Top 5' })).toContainText('39.6%')
+    await expect(page.getByRole('listitem').filter({ hasText: 'Top 10' })).toContainText('64.3%')
+    await expect(page.getByRole('listitem').filter({ hasText: 'Top 20' })).toContainText('87.1%')
 
     /* Artist Loyalty Card */
-    const loyaltyCard = page.locator('.group').filter({
-        has: page.getByRole('heading', { name: /Artist Loyalty/ }),
-    })
+    const loyaltyCard = page.locator('.group').filter({ has: page.getByRole('heading', { name: /Artist Loyalty/ }) })
     await expect(loyaltyCard).toBeVisible()
-    await expect(loyaltyCard.getByText('Explorer')).toBeVisible()
-    await expect(loyaltyCard.getByText('1 stream26%')).toBeVisible()
-    await expect(loyaltyCard.getByText('2-10 streams63%')).toBeVisible()
-    await expect(loyaltyCard.getByText('11-100 streams11%')).toBeVisible()
+    await expect(loyaltyCard.getByText('Balanced Regular43 artists')).toBeVisible()
+    await expect(loyaltyCard.getByText('1 stream3%')).toBeVisible()
+    await expect(loyaltyCard.getByText('2-10 streams21%')).toBeVisible()
+    await expect(loyaltyCard.getByText('11-100 streams76%')).toBeVisible()
     await expect(loyaltyCard.getByText('101-1000 streams0%')).toBeVisible()
     await expect(loyaltyCard.getByText('1000+ streams0%')).toBeVisible()
 
     /* Daily Vibes Card */
-    await expect(
-        page.getByRole('heading', { name: /Daily Vibes/ })
-    ).toBeVisible()
-    await expect(
-        page.getByRole('listitem').filter({ hasText: 'Morning' })
-    ).toContainText('39.5%')
-    await expect(
-        page.getByRole('listitem').filter({ hasText: 'Night' })
-    ).toContainText('14.0%')
+    await expect(page.getByRole('heading', { name: /Daily Vibes/ })).toBeVisible()
+    await expect(page.getByText('Morning166 streams')).toBeVisible()
+    await expect(page.getByRole('listitem').filter({ hasText: 'Morning' })).toContainText('49.8%')
+    await expect(page.getByRole('listitem').filter({ hasText: 'Afternoon' })).toContainText('12.9%')
+    await expect(page.getByRole('listitem').filter({ hasText: 'Evening' })).toContainText('25.8%')
+    await expect(page.getByRole('listitem').filter({ hasText: 'Night' })).toContainText('11.4%')
 
     /* Consistency Meter Card */
-    await expect(
-        page.getByRole('heading', { name: /Consistency Meter/ })
-    ).toBeVisible()
-    await expect(page.getByText('Occasional', { exact: true })).toBeVisible()
-    await expect(page.getByText('134 / 365 days')).toBeVisible()
-    await expect(page.getByText('37%')).toBeVisible()
+    await expect(page.getByRole('heading', { name: /Consistency Meter/ })).toBeVisible()
+    await expect(page.getByText('Regular', { exact: true })).toBeVisible()
+    await expect(page.getByText('203 / 365 days')).toBeVisible()
+    await expect(page.getByText('56%')).toBeVisible()
+    await expect(page.getByText('31d')).toBeVisible()
 
     /* Soundtrack Growth */
-    await expect(
-        page.getByRole('heading', { name: /Soundtrack Growth/ })
-    ).toBeVisible()
-    await expect(
-        page.getByRole('listitem').filter({ hasText: 'Total streams' })
-    ).toContainText('746')
-    await expect(
-        page.getByRole('listitem').filter({ hasText: 'This year' })
-    ).toContainText('172')
+    await expect(page.getByRole('heading', { name: /Soundtrack Growth/ })).toBeVisible()
+    await expect(page.getByRole('listitem').filter({ hasText: 'Total streams' })).toContainText('960')
+    await expect(page.getByRole('listitem').filter({ hasText: 'This year' })).toContainText('333')
 
     /* Seasonal Mood Card */
-    await expect(
-        page.getByRole('heading', { name: /Seasonal Mood/ })
-    ).toBeVisible()
-    await expect(page.getByText('Fall54 streams🍂')).toBeVisible()
-    await expect(
-        page.getByRole('listitem').filter({ hasText: 'Winter' })
-    ).toContainText('23.3%')
-    await expect(
-        page.getByRole('listitem').filter({ hasText: 'Summer' })
-    ).toContainText('17.4%')
+    await expect(page.getByRole('heading', { name: /Seasonal Mood/ })).toBeVisible()
+    await expect(page.getByText('Winter99 streams')).toBeVisible()
+    await expect(page.getByRole('listitem').filter({ hasText: 'Winter' })).toContainText('29.7%')
+    await expect(page.getByRole('listitem').filter({ hasText: 'Spring' })).toContainText('28.2%')
+    await expect(page.getByRole('listitem').filter({ hasText: 'Summer' })).toContainText('12.6%')
+    await expect(page.getByRole('listitem').filter({ hasText: 'Fall' })).toContainText('29.4%')
 
     /* Fresh vs Familiar Card */
-    await expect(
-        page.getByRole('heading', { name: /Fresh vs Familiar/ })
-    ).toBeVisible()
-    await expect(
-        page.getByText('9 new artists discovered this year!')
-    ).toBeVisible()
-    await expect(
-        page.getByRole('listitem').filter({ hasText: 'Discoveries' })
-    ).toContainText('11%')
+    await expect(page.getByRole('heading', { name: /Fresh vs Familiar/ })).toBeVisible()
+    await expect(page.getByText('Comfort Listener', { exact: true })).toBeVisible()
+    await expect(page.getByText('6 new artists discovered this year!')).toBeVisible()
+    await expect(page.getByRole('listitem').filter({ hasText: 'Discoveries' })).toContainText('3%')
+    await expect(page.getByRole('listitem').filter({ hasText: 'Favorites' })).toContainText('97%')
 
     /* Skip Mood Card */
     await expect(page.getByRole('heading', { name: /Skip Mood/ })).toBeVisible()
-    await expect(page.getByText('100.0%')).toBeVisible()
-    await expect(
-        page.getByRole('listitem').filter({ hasText: 'Completed' })
-    ).toContainText('172')
+    await expect(page.getByText('Patient', { exact: true })).toBeVisible()
+    await expect(page.getByText('83.2%')).toBeVisible()
+    await expect(page.getByRole('listitem').filter({ hasText: 'Skippped' })).toContainText('56')
+    await expect(page.getByRole('listitem').filter({ hasText: 'Completed' })).toContainText('277')
 
     /* Replay Energy Card */
-    await expect(
-        page.getByRole('heading', { name: /Replay Energy/ })
-    ).toBeVisible()
-    await expect(page.getByText('Variated')).toBeVisible()
-    await expect(
-        page.getByRole('listitem').filter({ hasText: 'Repeat average' })
-    ).toContainText('2.0 times')
+    await expect(page.getByRole('heading', { name: /Replay Style/ })).toBeVisible()
+    await expect(page.getByText('Moderate', { exact: true })).toBeVisible()
+    await expect(page.getByText('12 repeated sequences')).toBeVisible()
+    await expect(page.getByRole('listitem').filter({ hasText: 'Repeat average' })).toContainText('2.0 times')
 
     /* Your Sound Machine Card */
-    await expect(
-        page.getByRole('heading', { name: /Your Sound Machine/ })
-    ).toBeVisible()
-    await expect(page.getByText('Windows')).toHaveCount(2)
-    await expect(page.getByText('70 streams')).toBeVisible()
-    await expect(
-        page.getByRole('listitem').filter({ hasText: 'Windows' })
-    ).toContainText('40.7%')
-    await expect(
-        page.getByRole('listitem').filter({ hasText: 'Others' })
-    ).toContainText('59.3%')
+    await expect(page.getByRole('heading', { name: /Your Sound Machine/ })).toBeVisible()
+    await expect(page.getByText('Android OS72 streams')).toBeVisible()
+    await expect(page.getByRole('listitem').filter({ hasText: 'Android OS' })).toContainText('21.6%')
+    await expect(page.getByRole('listitem').filter({ hasText: 'Windows' })).toContainText('20.7%')
+    await expect(page.getByRole('listitem').filter({ hasText: 'Others' })).toContainText('57.7%')
 
     /* Your Power Day Card */
-    await expect(
-        page.getByRole('heading', { name: /Your Power Day/ })
-    ).toBeVisible()
-    await expect(page.getByText('Tuesday').first()).toBeVisible()
-    await expect(page.getByText('31 streams')).toBeVisible()
+    await expect(page.getByRole('heading', { name: /Your Power Day/ })).toBeVisible()
+    await expect(page.getByText('Wednesday63 streams')).toBeVisible()
+
+    /* Listening sessions */
+    await expect(page.getByRole('heading', { name: /Listening sessions/ })).toBeVisible()
+    await expect(page.getByText('Express8 sessions')).toBeVisible()
+
+    /* Around the Clock */
+    await expect(page.getByRole('heading', { name: /Around the Clock/ })).toBeVisible()
+    await expect(page.getByText('08h62 streams')).toBeVisible()
+
+    /* On a Roll */
+    await expect(page.getByRole('heading', { name: /On a Roll/ })).toBeVisible()
+    await expect(page.getByText('9days in a row')).toBeVisible()
+
+    /* Deep Dive */
+    await expect(page.getByRole('heading', { name: /Deep Dive/ })).toBeVisible()
+    await expect(page.getByText('0h 20minin a day')).toBeVisible()
+
+    /* Eclectic Day */
+    await expect(page.getByRole('heading', { name: /Eclectic Day/ })).toBeVisible()
+    await expect(page.getByText('4different artists')).toBeVisible()
 })

--- a/e2e/tests/main.spec.ts
+++ b/e2e/tests/main.spec.ts
@@ -84,10 +84,13 @@ test('has title and can upload dataset', async ({ page }) => {
     await expect(page.getByRole('heading', { name: /Listening activity/ })).toBeVisible()
 
     /* Focus Mode Card */
-    await expect(page.getByRole('heading', { name: /Focus Mode/ })).toBeVisible()
-    await expect(page.getByRole('listitem').filter({ hasText: 'Top 5' })).toContainText('39.6%')
-    await expect(page.getByRole('listitem').filter({ hasText: 'Top 10' })).toContainText('64.3%')
-    await expect(page.getByRole('listitem').filter({ hasText: 'Top 20' })).toContainText('87.1%')
+    const focusModeCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Focus Mode/ }),
+    })
+    await expect(focusModeCard).toBeVisible()
+    await expect(focusModeCard.getByRole('listitem').filter({ hasText: 'Top 5' })).toContainText('39.6%')
+    await expect(focusModeCard.getByRole('listitem').filter({ hasText: 'Top 10' })).toContainText('64.3%')
+    await expect(focusModeCard.getByRole('listitem').filter({ hasText: 'Top 20' })).toContainText('87.1%')
 
     /* Artist Loyalty Card */
     const loyaltyCard = page.locator('.group').filter({ has: page.getByRole('heading', { name: /Artist Loyalty/ }) })
@@ -100,83 +103,125 @@ test('has title and can upload dataset', async ({ page }) => {
     await expect(loyaltyCard.getByText('1000+ streams0%')).toBeVisible()
 
     /* Daily Vibes Card */
-    await expect(page.getByRole('heading', { name: /Daily Vibes/ })).toBeVisible()
-    await expect(page.getByText('Morning166 streams')).toBeVisible()
-    await expect(page.getByRole('listitem').filter({ hasText: 'Morning' })).toContainText('49.8%')
-    await expect(page.getByRole('listitem').filter({ hasText: 'Afternoon' })).toContainText('12.9%')
-    await expect(page.getByRole('listitem').filter({ hasText: 'Evening' })).toContainText('25.8%')
-    await expect(page.getByRole('listitem').filter({ hasText: 'Night' })).toContainText('11.4%')
+    const dailyVibesCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Daily Vibes/ }),
+    })
+    await expect(dailyVibesCard).toBeVisible()
+    await expect(dailyVibesCard.getByText('Morning166 streams')).toBeVisible()
+    await expect(dailyVibesCard.getByRole('listitem').filter({ hasText: 'Morning' })).toContainText('49.8%')
+    await expect(dailyVibesCard.getByRole('listitem').filter({ hasText: 'Afternoon' })).toContainText('12.9%')
+    await expect(dailyVibesCard.getByRole('listitem').filter({ hasText: 'Evening' })).toContainText('25.8%')
+    await expect(dailyVibesCard.getByRole('listitem').filter({ hasText: 'Night' })).toContainText('11.4%')
 
     /* Consistency Meter Card */
-    await expect(page.getByRole('heading', { name: /Consistency Meter/ })).toBeVisible()
-    await expect(page.getByText('Regular', { exact: true })).toBeVisible()
-    await expect(page.getByText('203 / 365 days')).toBeVisible()
-    await expect(page.getByText('56%')).toBeVisible()
-    await expect(page.getByText('31d')).toBeVisible()
+    const consistencyMeterCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Consistency Meter/ }),
+    })
+    await expect(consistencyMeterCard).toBeVisible()
+    await expect(consistencyMeterCard.getByText('Regular', { exact: true })).toBeVisible()
+    await expect(consistencyMeterCard.getByText('203 / 365 days')).toBeVisible()
+    await expect(consistencyMeterCard.getByText('56%')).toBeVisible()
+    await expect(consistencyMeterCard.getByText('31d')).toBeVisible()
 
     /* Soundtrack Growth */
-    await expect(page.getByRole('heading', { name: /Soundtrack Growth/ })).toBeVisible()
-    await expect(page.getByRole('listitem').filter({ hasText: 'Total streams' })).toContainText('960')
-    await expect(page.getByRole('listitem').filter({ hasText: 'This year' })).toContainText('333')
+    const soundtrackGrowthCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Soundtrack Growth/ }),
+    })
+    await expect(soundtrackGrowthCard).toBeVisible()
+    await expect(soundtrackGrowthCard.getByRole('listitem').filter({ hasText: 'Total streams' })).toContainText('960')
+    await expect(soundtrackGrowthCard.getByRole('listitem').filter({ hasText: 'This year' })).toContainText('333')
 
     /* Seasonal Mood Card */
-    await expect(page.getByRole('heading', { name: /Seasonal Mood/ })).toBeVisible()
-    await expect(page.getByText('Winter99 streams')).toBeVisible()
-    await expect(page.getByRole('listitem').filter({ hasText: 'Winter' })).toContainText('29.7%')
-    await expect(page.getByRole('listitem').filter({ hasText: 'Spring' })).toContainText('28.2%')
-    await expect(page.getByRole('listitem').filter({ hasText: 'Summer' })).toContainText('12.6%')
-    await expect(page.getByRole('listitem').filter({ hasText: 'Fall' })).toContainText('29.4%')
+    const seasonalMoodCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Seasonal Mood/ }),
+    })
+    await expect(seasonalMoodCard).toBeVisible()
+    await expect(seasonalMoodCard.getByText('Winter99 streams')).toBeVisible()
+    await expect(seasonalMoodCard.getByRole('listitem').filter({ hasText: 'Winter' })).toContainText('29.7%')
+    await expect(seasonalMoodCard.getByRole('listitem').filter({ hasText: 'Spring' })).toContainText('28.2%')
+    await expect(seasonalMoodCard.getByRole('listitem').filter({ hasText: 'Summer' })).toContainText('12.6%')
+    await expect(seasonalMoodCard.getByRole('listitem').filter({ hasText: 'Fall' })).toContainText('29.4%')
 
     /* Fresh vs Familiar Card */
-    await expect(page.getByRole('heading', { name: /Fresh vs Familiar/ })).toBeVisible()
-    await expect(page.getByText('Comfort Listener', { exact: true })).toBeVisible()
-    await expect(page.getByText('6 new artists discovered this year!')).toBeVisible()
-    await expect(page.getByRole('listitem').filter({ hasText: 'Discoveries' })).toContainText('3%')
-    await expect(page.getByRole('listitem').filter({ hasText: 'Favorites' })).toContainText('97%')
+    const freshVsFamiliarCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Fresh vs Familiar/ }),
+    })
+    await expect(freshVsFamiliarCard).toBeVisible()
+    await expect(freshVsFamiliarCard.getByText('Comfort Listener', { exact: true })).toBeVisible()
+    await expect(freshVsFamiliarCard.getByText('6 new artists discovered this year!')).toBeVisible()
+    await expect(freshVsFamiliarCard.getByRole('listitem').filter({ hasText: 'Discoveries' })).toContainText('3%')
+    await expect(freshVsFamiliarCard.getByRole('listitem').filter({ hasText: 'Favorites' })).toContainText('97%')
 
     /* Skip Mood Card */
-    await expect(page.getByRole('heading', { name: /Skip Mood/ })).toBeVisible()
-    await expect(page.getByText('Patient', { exact: true })).toBeVisible()
-    await expect(page.getByText('83.2%')).toBeVisible()
-    await expect(page.getByRole('listitem').filter({ hasText: 'Skippped' })).toContainText('56')
-    await expect(page.getByRole('listitem').filter({ hasText: 'Completed' })).toContainText('277')
+    const skipMoodCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Skip Mood/ }),
+    })
+    await expect(skipMoodCard).toBeVisible()
+    await expect(skipMoodCard.getByText('Patient', { exact: true })).toBeVisible()
+    await expect(skipMoodCard.getByText('83.2%')).toBeVisible()
+    await expect(skipMoodCard.getByRole('listitem').filter({ hasText: 'Skippped' })).toContainText('56')
+    await expect(skipMoodCard.getByRole('listitem').filter({ hasText: 'Completed' })).toContainText('277')
 
     /* Replay Energy Card */
-    await expect(page.getByRole('heading', { name: /Replay Style/ })).toBeVisible()
-    await expect(page.getByText('Moderate', { exact: true })).toBeVisible()
-    await expect(page.getByText('12 repeated sequences')).toBeVisible()
-    await expect(page.getByRole('listitem').filter({ hasText: 'Repeat average' })).toContainText('2.0 times')
+    const replayStyleCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Replay Style/ }),
+    })
+    await expect(replayStyleCard).toBeVisible()
+    await expect(replayStyleCard.getByText('Moderate', { exact: true })).toBeVisible()
+    await expect(replayStyleCard.getByText('12 repeated sequences')).toBeVisible()
+    await expect(replayStyleCard.getByRole('listitem').filter({ hasText: 'Repeat average' })).toContainText('2.0 times')
 
     /* Your Sound Machine Card */
-    await expect(page.getByRole('heading', { name: /Your Sound Machine/ })).toBeVisible()
-    await expect(page.getByText('Android OS72 streams')).toBeVisible()
-    await expect(page.getByRole('listitem').filter({ hasText: 'Android OS' })).toContainText('21.6%')
-    await expect(page.getByRole('listitem').filter({ hasText: 'Windows' })).toContainText('20.7%')
-    await expect(page.getByRole('listitem').filter({ hasText: 'Others' })).toContainText('57.7%')
+    const soundMachineCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Your Sound Machine/ }),
+    })
+    await expect(soundMachineCard).toBeVisible()
+    await expect(soundMachineCard.getByText('Android OS72 streams')).toBeVisible()
+    await expect(soundMachineCard.getByRole('listitem').filter({ hasText: 'Android OS' })).toContainText('21.6%')
+    await expect(soundMachineCard.getByRole('listitem').filter({ hasText: 'Windows' })).toContainText('20.7%')
+    await expect(soundMachineCard.getByRole('listitem').filter({ hasText: 'Others' })).toContainText('57.7%')
 
     /* Your Power Day Card */
-    await expect(page.getByRole('heading', { name: /Your Power Day/ })).toBeVisible()
-    await expect(page.getByText('Wednesday63 streams')).toBeVisible()
+    const powerDayCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Your Power Day/ }),
+    })
+    await expect(powerDayCard).toBeVisible()
+    await expect(powerDayCard.getByText('Wednesday63 streams')).toBeVisible()
 
     /* Listening sessions */
-    await expect(page.getByRole('heading', { name: /Listening sessions/ })).toBeVisible()
-    await expect(page.getByText('Express8 sessions')).toBeVisible()
+    const listeningSessionsCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Listening sessions/ }),
+    })
+    await expect(listeningSessionsCard).toBeVisible()
+    await expect(listeningSessionsCard.getByText('Express8 sessions')).toBeVisible()
 
     /* Around the Clock */
-    await expect(page.getByRole('heading', { name: /Around the Clock/ })).toBeVisible()
-    await expect(page.getByText('08h62 streams')).toBeVisible()
+    const aroundTheClockCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Around the Clock/ }),
+    })
+    await expect(aroundTheClockCard).toBeVisible()
+    await expect(aroundTheClockCard.getByText('08h62 streams')).toBeVisible()
 
     /* On a Roll */
-    await expect(page.getByRole('heading', { name: /On a Roll/ })).toBeVisible()
-    await expect(page.getByText('9days in a row')).toBeVisible()
+    const onARollCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /On a Roll/ }),
+    })
+    await expect(onARollCard).toBeVisible()
+    await expect(onARollCard.getByText('9days in a row')).toBeVisible()
 
     /* Deep Dive */
-    await expect(page.getByRole('heading', { name: /Deep Dive/ })).toBeVisible()
-    await expect(page.getByText('0h 20minin a day')).toBeVisible()
+    const deepDiveCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Deep Dive/ }),
+    })
+    await expect(deepDiveCard).toBeVisible()
+    await expect(deepDiveCard.getByText('0h 20minin a day')).toBeVisible()
 
     /* Eclectic Day */
-    await expect(page.getByRole('heading', { name: /Eclectic Day/ })).toBeVisible()
-    await expect(page.getByText('4different artists')).toBeVisible()
+    const eclecticDayCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: /Eclectic Day/ }),
+    })
+    await expect(eclecticDayCard).toBeVisible()
+    await expect(eclecticDayCard.getByText('4different artists')).toBeVisible()
 
     // Switch to Lab view
     await labView.click()


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

E2E assertions were no longer up to date after changes in the generation of test data (which broke determinism). 

E2E assertions on Simple View cards were scoped to the full page, which risked false positives if the same text appeared in multiple cards. E2E tests were also disabled on preview deployments.

## 🎹 Proposal

Update assertions.

Scoped all card-level assertions to their parent `.group` container via `.locator('.group').filter({ has: heading })`, matching the pattern already used for Top Tracks, Top Artists, Top Albums, and Artist Loyalty cards. Re-enabled the E2E job in the preview deployment workflow.

## 🎶 Comments

## 🎤 Test
