### PR TITLE
fix(skip-rate): fix typo Skippped -> Skipped

### DIFF
--- a/app/src/components/Charts/SimpleCharts/SkipRate/SkipRate.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/SkipRate/SkipRate.test.tsx
@@ -25,7 +25,7 @@ describe('SkipRate Component', () => {
 
         screen.getByRole('heading', { name: /⏭️Skip Mood/ })
         screen.getByText('80.0% are full listens')
-        screen.getByText('Skippped (20)')
+        screen.getByText('Skipped (20)')
         screen.getByText('Completed (80)')
         screen.getByText(/Patient/)
     })

--- a/app/src/components/Charts/SimpleCharts/SkipRate/SkipRate.tsx
+++ b/app/src/components/Charts/SimpleCharts/SkipRate/SkipRate.tsx
@@ -44,7 +44,7 @@ export const SkipRate: FC<Props> = ({ data, isLoading }) => {
                         role="list"
                     >
                         <li role="listitem">
-                            Skippped ({skipped_listens.toLocaleString()})
+                            Skipped ({skipped_listens.toLocaleString()})
                         </li>
                         <li role="listitem">
                             Completed ({complete_listens.toLocaleString()})

--- a/e2e/tests/main.spec.ts
+++ b/e2e/tests/main.spec.ts
@@ -159,7 +159,7 @@ test('has title and can upload dataset', async ({ page }) => {
     await expect(skipMoodCard).toBeVisible()
     await expect(skipMoodCard.getByText('Patient', { exact: true })).toBeVisible()
     await expect(skipMoodCard.getByText('83.2%')).toBeVisible()
-    await expect(skipMoodCard.getByRole('listitem').filter({ hasText: 'Skippped' })).toContainText('56')
+    await expect(skipMoodCard.getByRole('listitem').filter({ hasText: 'Skipped' })).toContainText('56')
     await expect(skipMoodCard.getByRole('listitem').filter({ hasText: 'Completed' })).toContainText('277')
 
     /* Replay Energy Card */


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

`SkipRate` component displayed "Skippped" (3× p) in the UI, propagated to the unit test and e2e assertion.

## 🎹 Proposal

Fix the typo to "Skipped" in `SkipRate.tsx`, `SkipRate.test.tsx`, and `main.spec.ts`.

## 🎶 Comments

<!-- Additional information, tips or problems encountered. -->

## 🎤 Test

Unit test `renders correctly with data` now asserts `Skipped (20)`. E2e assertion targets `hasText: 'Skipped'`.