### PR TITLE
refactor(e2e): use expect.soft for data assertions

### DIFF
--- a/.github/workflows/app-deploy-preview.yml
+++ b/.github/workflows/app-deploy-preview.yml
@@ -9,7 +9,9 @@ on:
       - closed
     paths:
       - "app/**"
+      - "e2e/**"
       - ".github/workflows/app-deploy-preview.yml"
+      - ".github/workflows/e2e.yml"
       - ".moon/toolchains.yml"
   workflow_dispatch:
 

--- a/e2e/tests/main.spec.ts
+++ b/e2e/tests/main.spec.ts
@@ -48,10 +48,10 @@ test('has title and can upload dataset', async ({ page }) => {
         await expect(topTracksCard).toBeVisible()
 
         const firstTopTrack = topTracksCard.getByRole('listitem').filter({ hasText: 'benchmark e-busi' })
-        await expect(firstTopTrack).toBeVisible()
-        await expect(firstTopTrack).toContainText('🥇')
-        await expect(firstTopTrack).toContainText('Teresa King')
-        await expect(firstTopTrack).toContainText('35')
+        await expect.soft(firstTopTrack).toBeVisible()
+        await expect.soft(firstTopTrack).toContainText('🥇')
+        await expect.soft(firstTopTrack).toContainText('Teresa King')
+        await expect.soft(firstTopTrack).toContainText('35')
     })
 
     await test.step('top artists card', async () => {
@@ -61,10 +61,10 @@ test('has title and can upload dataset', async ({ page }) => {
         await expect(topArtistsCard).toBeVisible()
 
         const secondTopArtist = topArtistsCard.getByRole('listitem').filter({ hasText: 'Michelle Marshall' })
-        await expect(secondTopArtist).toBeVisible()
-        await expect(secondTopArtist).toContainText('🥈')
-        await expect(secondTopArtist).toContainText('2h')
-        await expect(secondTopArtist).toContainText('32')
+        await expect.soft(secondTopArtist).toBeVisible()
+        await expect.soft(secondTopArtist).toContainText('🥈')
+        await expect.soft(secondTopArtist).toContainText('2h')
+        await expect.soft(secondTopArtist).toContainText('32')
     })
 
     await test.step('top albums card', async () => {
@@ -74,10 +74,10 @@ test('has title and can upload dataset', async ({ page }) => {
         await expect(topAlbumsCard).toBeVisible()
 
         const fifthTopAlbum = topAlbumsCard.getByRole('listitem').filter({ hasText: 'Compatible recipro' })
-        await expect(fifthTopAlbum).toBeVisible()
-        await expect(fifthTopAlbum).toContainText('5️⃣')
-        await expect(fifthTopAlbum).toContainText('Ryan Collins')
-        await expect(fifthTopAlbum).toContainText('18')
+        await expect.soft(fifthTopAlbum).toBeVisible()
+        await expect.soft(fifthTopAlbum).toContainText('5️⃣')
+        await expect.soft(fifthTopAlbum).toContainText('Ryan Collins')
+        await expect.soft(fifthTopAlbum).toContainText('18')
     })
 
     await test.step('listening activity section', async () => {
@@ -89,9 +89,9 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /Focus Mode/ }),
         })
         await expect(focusModeCard).toBeVisible()
-        await expect(focusModeCard.getByRole('listitem').filter({ hasText: 'Top 5' })).toContainText('39.6%')
-        await expect(focusModeCard.getByRole('listitem').filter({ hasText: 'Top 10' })).toContainText('64.3%')
-        await expect(focusModeCard.getByRole('listitem').filter({ hasText: 'Top 20' })).toContainText('87.1%')
+        await expect.soft(focusModeCard.getByRole('listitem').filter({ hasText: 'Top 5' })).toContainText('39.6%')
+        await expect.soft(focusModeCard.getByRole('listitem').filter({ hasText: 'Top 10' })).toContainText('64.3%')
+        await expect.soft(focusModeCard.getByRole('listitem').filter({ hasText: 'Top 20' })).toContainText('87.1%')
     })
 
     await test.step('artist loyalty card', async () => {
@@ -99,12 +99,12 @@ test('has title and can upload dataset', async ({ page }) => {
             .locator('.group')
             .filter({ has: page.getByRole('heading', { name: /Artist Loyalty/ }) })
         await expect(loyaltyCard).toBeVisible()
-        await expect(loyaltyCard.getByText('Balanced Regular43 artists')).toBeVisible()
-        await expect(loyaltyCard.getByText('1 stream3%')).toBeVisible()
-        await expect(loyaltyCard.getByText('2-10 streams21%')).toBeVisible()
-        await expect(loyaltyCard.getByText('11-100 streams76%')).toBeVisible()
-        await expect(loyaltyCard.getByText('101-1000 streams0%')).toBeVisible()
-        await expect(loyaltyCard.getByText('1000+ streams0%')).toBeVisible()
+        await expect.soft(loyaltyCard.getByText('Balanced Regular43 artists')).toBeVisible()
+        await expect.soft(loyaltyCard.getByText('1 stream3%')).toBeVisible()
+        await expect.soft(loyaltyCard.getByText('2-10 streams21%')).toBeVisible()
+        await expect.soft(loyaltyCard.getByText('11-100 streams76%')).toBeVisible()
+        await expect.soft(loyaltyCard.getByText('101-1000 streams0%')).toBeVisible()
+        await expect.soft(loyaltyCard.getByText('1000+ streams0%')).toBeVisible()
     })
 
     await test.step('daily vibes card', async () => {
@@ -112,11 +112,11 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /Daily Vibes/ }),
         })
         await expect(dailyVibesCard).toBeVisible()
-        await expect(dailyVibesCard.getByText('Morning166 streams')).toBeVisible()
-        await expect(dailyVibesCard.getByRole('listitem').filter({ hasText: 'Morning' })).toContainText('49.8%')
-        await expect(dailyVibesCard.getByRole('listitem').filter({ hasText: 'Afternoon' })).toContainText('12.9%')
-        await expect(dailyVibesCard.getByRole('listitem').filter({ hasText: 'Evening' })).toContainText('25.8%')
-        await expect(dailyVibesCard.getByRole('listitem').filter({ hasText: 'Night' })).toContainText('11.4%')
+        await expect.soft(dailyVibesCard.getByText('Morning166 streams')).toBeVisible()
+        await expect.soft(dailyVibesCard.getByRole('listitem').filter({ hasText: 'Morning' })).toContainText('49.8%')
+        await expect.soft(dailyVibesCard.getByRole('listitem').filter({ hasText: 'Afternoon' })).toContainText('12.9%')
+        await expect.soft(dailyVibesCard.getByRole('listitem').filter({ hasText: 'Evening' })).toContainText('25.8%')
+        await expect.soft(dailyVibesCard.getByRole('listitem').filter({ hasText: 'Night' })).toContainText('11.4%')
     })
 
     await test.step('consistency meter card', async () => {
@@ -124,10 +124,10 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /Consistency Meter/ }),
         })
         await expect(consistencyMeterCard).toBeVisible()
-        await expect(consistencyMeterCard.getByText('Regular', { exact: true })).toBeVisible()
-        await expect(consistencyMeterCard.getByText('203 / 365 days')).toBeVisible()
-        await expect(consistencyMeterCard.getByText('56%')).toBeVisible()
-        await expect(consistencyMeterCard.getByText('31d')).toBeVisible()
+        await expect.soft(consistencyMeterCard.getByText('Regular', { exact: true })).toBeVisible()
+        await expect.soft(consistencyMeterCard.getByText('203 / 365 days')).toBeVisible()
+        await expect.soft(consistencyMeterCard.getByText('56%')).toBeVisible()
+        await expect.soft(consistencyMeterCard.getByText('31d')).toBeVisible()
     })
 
     await test.step('soundtrack growth card', async () => {
@@ -135,10 +135,12 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /Soundtrack Growth/ }),
         })
         await expect(soundtrackGrowthCard).toBeVisible()
-        await expect(soundtrackGrowthCard.getByRole('listitem').filter({ hasText: 'Total streams' })).toContainText(
-            '960'
-        )
-        await expect(soundtrackGrowthCard.getByRole('listitem').filter({ hasText: 'This year' })).toContainText('333')
+        await expect
+            .soft(soundtrackGrowthCard.getByRole('listitem').filter({ hasText: 'Total streams' }))
+            .toContainText('960')
+        await expect
+            .soft(soundtrackGrowthCard.getByRole('listitem').filter({ hasText: 'This year' }))
+            .toContainText('333')
     })
 
     await test.step('seasonal mood card', async () => {
@@ -146,11 +148,11 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /Seasonal Mood/ }),
         })
         await expect(seasonalMoodCard).toBeVisible()
-        await expect(seasonalMoodCard.getByText('Winter99 streams')).toBeVisible()
-        await expect(seasonalMoodCard.getByRole('listitem').filter({ hasText: 'Winter' })).toContainText('29.7%')
-        await expect(seasonalMoodCard.getByRole('listitem').filter({ hasText: 'Spring' })).toContainText('28.2%')
-        await expect(seasonalMoodCard.getByRole('listitem').filter({ hasText: 'Summer' })).toContainText('12.6%')
-        await expect(seasonalMoodCard.getByRole('listitem').filter({ hasText: 'Fall' })).toContainText('29.4%')
+        await expect.soft(seasonalMoodCard.getByText('Winter99 streams')).toBeVisible()
+        await expect.soft(seasonalMoodCard.getByRole('listitem').filter({ hasText: 'Winter' })).toContainText('29.7%')
+        await expect.soft(seasonalMoodCard.getByRole('listitem').filter({ hasText: 'Spring' })).toContainText('28.2%')
+        await expect.soft(seasonalMoodCard.getByRole('listitem').filter({ hasText: 'Summer' })).toContainText('12.6%')
+        await expect.soft(seasonalMoodCard.getByRole('listitem').filter({ hasText: 'Fall' })).toContainText('29.4%')
     })
 
     await test.step('fresh vs familiar card', async () => {
@@ -158,10 +160,14 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /Fresh vs Familiar/ }),
         })
         await expect(freshVsFamiliarCard).toBeVisible()
-        await expect(freshVsFamiliarCard.getByText('Comfort Listener', { exact: true })).toBeVisible()
-        await expect(freshVsFamiliarCard.getByText('6 new artists discovered this year!')).toBeVisible()
-        await expect(freshVsFamiliarCard.getByRole('listitem').filter({ hasText: 'Discoveries' })).toContainText('3%')
-        await expect(freshVsFamiliarCard.getByRole('listitem').filter({ hasText: 'Favorites' })).toContainText('97%')
+        await expect.soft(freshVsFamiliarCard.getByText('Comfort Listener', { exact: true })).toBeVisible()
+        await expect.soft(freshVsFamiliarCard.getByText('6 new artists discovered this year!')).toBeVisible()
+        await expect
+            .soft(freshVsFamiliarCard.getByRole('listitem').filter({ hasText: 'Discoveries' }))
+            .toContainText('3%')
+        await expect
+            .soft(freshVsFamiliarCard.getByRole('listitem').filter({ hasText: 'Favorites' }))
+            .toContainText('97%')
     })
 
     await test.step('skip mood card', async () => {
@@ -169,10 +175,10 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /Skip Mood/ }),
         })
         await expect(skipMoodCard).toBeVisible()
-        await expect(skipMoodCard.getByText('Patient', { exact: true })).toBeVisible()
-        await expect(skipMoodCard.getByText('83.2%')).toBeVisible()
-        await expect(skipMoodCard.getByRole('listitem').filter({ hasText: 'Skipped' })).toContainText('56')
-        await expect(skipMoodCard.getByRole('listitem').filter({ hasText: 'Completed' })).toContainText('277')
+        await expect.soft(skipMoodCard.getByText('Patient', { exact: true })).toBeVisible()
+        await expect.soft(skipMoodCard.getByText('83.2%')).toBeVisible()
+        await expect.soft(skipMoodCard.getByRole('listitem').filter({ hasText: 'Skipped' })).toContainText('56')
+        await expect.soft(skipMoodCard.getByRole('listitem').filter({ hasText: 'Completed' })).toContainText('277')
     })
 
     await test.step('replay style card', async () => {
@@ -180,11 +186,11 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /Replay Style/ }),
         })
         await expect(replayStyleCard).toBeVisible()
-        await expect(replayStyleCard.getByText('Moderate', { exact: true })).toBeVisible()
-        await expect(replayStyleCard.getByText('12 repeated sequences')).toBeVisible()
-        await expect(replayStyleCard.getByRole('listitem').filter({ hasText: 'Repeat average' })).toContainText(
-            '2.0 times'
-        )
+        await expect.soft(replayStyleCard.getByText('Moderate', { exact: true })).toBeVisible()
+        await expect.soft(replayStyleCard.getByText('12 repeated sequences')).toBeVisible()
+        await expect
+            .soft(replayStyleCard.getByRole('listitem').filter({ hasText: 'Repeat average' }))
+            .toContainText('2.0 times')
     })
 
     await test.step('your sound machine card', async () => {
@@ -192,10 +198,12 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /Your Sound Machine/ }),
         })
         await expect(soundMachineCard).toBeVisible()
-        await expect(soundMachineCard.getByText('Android OS72 streams')).toBeVisible()
-        await expect(soundMachineCard.getByRole('listitem').filter({ hasText: 'Android OS' })).toContainText('21.6%')
-        await expect(soundMachineCard.getByRole('listitem').filter({ hasText: 'Windows' })).toContainText('20.7%')
-        await expect(soundMachineCard.getByRole('listitem').filter({ hasText: 'Others' })).toContainText('57.7%')
+        await expect.soft(soundMachineCard.getByText('Android OS72 streams')).toBeVisible()
+        await expect
+            .soft(soundMachineCard.getByRole('listitem').filter({ hasText: 'Android OS' }))
+            .toContainText('21.6%')
+        await expect.soft(soundMachineCard.getByRole('listitem').filter({ hasText: 'Windows' })).toContainText('20.7%')
+        await expect.soft(soundMachineCard.getByRole('listitem').filter({ hasText: 'Others' })).toContainText('57.7%')
     })
 
     await test.step('your power day card', async () => {
@@ -203,7 +211,7 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /Your Power Day/ }),
         })
         await expect(powerDayCard).toBeVisible()
-        await expect(powerDayCard.getByText('Wednesday63 streams')).toBeVisible()
+        await expect.soft(powerDayCard.getByText('Wednesday63 streams')).toBeVisible()
     })
 
     await test.step('listening sessions card', async () => {
@@ -211,7 +219,7 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /Listening sessions/ }),
         })
         await expect(listeningSessionsCard).toBeVisible()
-        await expect(listeningSessionsCard.getByText('Express8 sessions')).toBeVisible()
+        await expect.soft(listeningSessionsCard.getByText('Express8 sessions')).toBeVisible()
     })
 
     await test.step('around the clock card', async () => {
@@ -219,7 +227,7 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /Around the Clock/ }),
         })
         await expect(aroundTheClockCard).toBeVisible()
-        await expect(aroundTheClockCard.getByText('08h62 streams')).toBeVisible()
+        await expect.soft(aroundTheClockCard.getByText('08h62 streams')).toBeVisible()
     })
 
     await test.step('on a roll card', async () => {
@@ -227,7 +235,7 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /On a Roll/ }),
         })
         await expect(onARollCard).toBeVisible()
-        await expect(onARollCard.getByText('9days in a row')).toBeVisible()
+        await expect.soft(onARollCard.getByText('9days in a row')).toBeVisible()
     })
 
     await test.step('deep dive card', async () => {
@@ -235,7 +243,7 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /Deep Dive/ }),
         })
         await expect(deepDiveCard).toBeVisible()
-        await expect(deepDiveCard.getByText('0h 20minin a day')).toBeVisible()
+        await expect.soft(deepDiveCard.getByText('0h 20minin a day')).toBeVisible()
     })
 
     await test.step('eclectic day card', async () => {
@@ -243,7 +251,7 @@ test('has title and can upload dataset', async ({ page }) => {
             has: page.getByRole('heading', { name: /Eclectic Day/ }),
         })
         await expect(eclecticDayCard).toBeVisible()
-        await expect(eclecticDayCard.getByText('4different artists')).toBeVisible()
+        await expect.soft(eclecticDayCard.getByText('4different artists')).toBeVisible()
     })
 
     await test.step('lab view', async () => {
@@ -251,11 +259,11 @@ test('has title and can upload dataset', async ({ page }) => {
         await expect(simpleViewTab).not.toHaveAttribute('aria-selected', 'true')
         await expect(labView).toHaveAttribute('aria-selected', 'true')
 
-        await expect(page.getByRole('heading', { name: /Stream Timeline/ })).toBeVisible()
-        await expect(page.getByRole('heading', { name: /Stream Variety/ })).toBeVisible()
-        await expect(page.getByRole('heading', { name: /Stream Discovery/ })).toBeVisible()
-        await expect(page.getByRole('heading', { name: /Top 10 Race/ })).toBeVisible()
-        await expect(page.getByRole('heading', { name: /Listening Streaks/ })).toBeVisible()
-        await expect(page.getByRole('heading', { name: /Listening Bingo/ })).toBeVisible()
+        await expect.soft(page.getByRole('heading', { name: /Stream Timeline/ })).toBeVisible()
+        await expect.soft(page.getByRole('heading', { name: /Stream Variety/ })).toBeVisible()
+        await expect.soft(page.getByRole('heading', { name: /Stream Discovery/ })).toBeVisible()
+        await expect.soft(page.getByRole('heading', { name: /Top 10 Race/ })).toBeVisible()
+        await expect.soft(page.getByRole('heading', { name: /Listening Streaks/ })).toBeVisible()
+        await expect.soft(page.getByRole('heading', { name: /Listening Bingo/ })).toBeVisible()
     })
 })


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

A single failing data assertion stopped the rest of the test. When multiple values are wrong (e.g. after a dataset change), only the first failure was visible.

## 🎹 Proposal

Hard assertions (`expect`) on card visibility and navigation actions, if a card is missing or a click fails, continuing is pointless. Soft assertions (`expect.soft`) on all data values so every failure in a run is reported at once.

## 🎶 Comments

<!-- Additional information, tips or problems encountered. -->

## 🎤 Test

<!-- Instructions for reproducing the problem and how you tested the fix. -->
