### PR TITLE
fix(chart): fix Fresh vs Familiar semantics and all-time fallback

### DIFF
--- a/app/src/components/Charts/SimpleCharts/NewVsOld/NewVsOld.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/NewVsOld.test.tsx
@@ -1,10 +1,10 @@
-import { describe, it } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { NewVsOld } from './NewVsOld'
 
 describe('NewVsOld Component', () => {
     it('renders empty state when data is undefined', () => {
-        render(<NewVsOld data={undefined} isLoading={false} />)
+        render(<NewVsOld data={undefined} isLoading={false} year={2025} />)
         screen.getByText('No data for this year')
     })
 
@@ -18,6 +18,7 @@ describe('NewVsOld Component', () => {
                     total: 0,
                 }}
                 isLoading={false}
+                year={2025}
             />
         )
         screen.getByText('No data for this year')
@@ -39,19 +40,6 @@ describe('NewVsOld Component', () => {
         screen.getByText(/5 new artists discovered this year/)
     })
 
-    it('renders with "latest year" label when year is undefined (all time)', async () => {
-        const data = {
-            new_artists_streams: 30,
-            old_artists_streams: 70,
-            new_artists_count: 5,
-            total: 100,
-        }
-
-        render(<NewVsOld data={data} year={undefined} />)
-
-        screen.getByText(/5 new artists discovered in your latest year/)
-    })
-
     it('renders Trend Hunter when new artists dominate', () => {
         render(
             <NewVsOld
@@ -61,6 +49,7 @@ describe('NewVsOld Component', () => {
                     new_artists_count: 10,
                     total: 100,
                 }}
+                year={2025}
             />
         )
         screen.getByText('Trend Hunter')
@@ -75,8 +64,21 @@ describe('NewVsOld Component', () => {
                     new_artists_count: 2,
                     total: 100,
                 }}
+                year={2025}
             />
         )
         screen.getByText('Balanced Taste')
+    })
+
+    it('renders all-time fallback when year is undefined', () => {
+        render(<NewVsOld data={undefined} year={undefined} totalArtists={42} />)
+        screen.getByText('Select a year to see your Fresh vs Familiar split')
+        screen.getByText(/42 artists discovered all time/)
+    })
+
+    it('renders all-time fallback without insight when totalArtists is undefined', () => {
+        render(<NewVsOld data={undefined} year={undefined} />)
+        screen.getByText('Select a year to see your Fresh vs Familiar split')
+        expect(screen.queryByText(/artists discovered all time/)).toBeNull()
     })
 })

--- a/app/src/components/Charts/SimpleCharts/NewVsOld/NewVsOld.test.tsx
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/NewVsOld.test.tsx
@@ -23,7 +23,7 @@ describe('NewVsOld Component', () => {
         screen.getByText('No data for this year')
     })
 
-    it('renders correctly with data', async () => {
+    it('renders correctly with a specific year', async () => {
         const data = {
             new_artists_streams: 30,
             old_artists_streams: 70,
@@ -31,12 +31,25 @@ describe('NewVsOld Component', () => {
             total: 100,
         }
 
-        render(<NewVsOld data={data} />)
+        render(<NewVsOld data={data} year={2025} />)
 
         screen.getByRole('heading', { name: /🆕Fresh vs Familiar/ })
         screen.getByText('30%')
         screen.getByText('70%')
-        screen.getByText(/5 new artists discovered/)
+        screen.getByText(/5 new artists discovered this year/)
+    })
+
+    it('renders with "latest year" label when year is undefined (all time)', async () => {
+        const data = {
+            new_artists_streams: 30,
+            old_artists_streams: 70,
+            new_artists_count: 5,
+            total: 100,
+        }
+
+        render(<NewVsOld data={data} year={undefined} />)
+
+        screen.getByText(/5 new artists discovered in your latest year/)
     })
 
     it('renders Trend Hunter when new artists dominate', () => {

--- a/app/src/components/Charts/SimpleCharts/NewVsOld/NewVsOld.tsx
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/NewVsOld.tsx
@@ -31,7 +31,7 @@ export const NewVsOld: FC<Props> = ({ data, isLoading, year }) => {
             title="Fresh vs Familiar"
             emoji="🆕"
             isLoading={isLoading}
-            question="Am I discovering new artists?"
+            question="Do I listen more to new or familiar artists?"
         >
             {!data?.total ? (
                 <ChartCardEmpty />
@@ -48,7 +48,7 @@ export const NewVsOld: FC<Props> = ({ data, isLoading, year }) => {
                                 <div className="text-2xl font-bold text-brand-purple">
                                     {newPct.toFixed(0)}%
                                 </div>
-                                <div>Discoveries</div>
+                                <div>Fresh</div>
                             </div>
                             <div className="text-2xl" role="separator">
                                 |
@@ -57,7 +57,7 @@ export const NewVsOld: FC<Props> = ({ data, isLoading, year }) => {
                                 <div className="text-2xl font-bold text-brand-blue">
                                     {oldPct.toFixed(0)}%
                                 </div>
-                                <div>Favorites</div>
+                                <div>Familiar</div>
                             </div>
                         </div>
                     </div>

--- a/app/src/components/Charts/SimpleCharts/NewVsOld/NewVsOld.tsx
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/NewVsOld.tsx
@@ -9,9 +9,36 @@ type Props = {
     data: NewVsOldResult | undefined
     isLoading?: boolean
     year?: number
+    totalArtists?: number
 }
 
-export const NewVsOld: FC<Props> = ({ data, isLoading, year }) => {
+export const NewVsOld: FC<Props> = ({
+    data,
+    isLoading,
+    year,
+    totalArtists,
+}) => {
+    if (year === undefined) {
+        return (
+            <ChartCard
+                title="Fresh vs Familiar"
+                emoji="🆕"
+                isLoading={isLoading}
+                question="Do I listen more to new or familiar artists?"
+            >
+                <p className="text-sm text-gray-400 dark:text-gray-500 italic text-center py-6">
+                    Select a year to see your Fresh vs Familiar split
+                </p>
+                {totalArtists !== undefined && (
+                    <InsightCard>
+                        {totalArtists.toLocaleString()} artists discovered all
+                        time
+                    </InsightCard>
+                )}
+            </ChartCard>
+        )
+    }
+
     const newPct = data?.total
         ? (data.new_artists_streams / data.total) * 100
         : 0
@@ -75,11 +102,7 @@ export const NewVsOld: FC<Props> = ({ data, isLoading, year }) => {
 
                     <InsightCard>
                         {data.new_artists_count.toLocaleString()} new artists
-                        discovered
-                        {year !== undefined
-                            ? ' this year'
-                            : ' in your latest year'}
-                        !
+                        discovered this year!
                     </InsightCard>
                 </>
             )}

--- a/app/src/components/Charts/SimpleCharts/NewVsOld/NewVsOld.tsx
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/NewVsOld.tsx
@@ -8,9 +8,10 @@ import { InsightCard } from '../shared/InsightCard'
 type Props = {
     data: NewVsOldResult | undefined
     isLoading?: boolean
+    year?: number
 }
 
-export const NewVsOld: FC<Props> = ({ data, isLoading }) => {
+export const NewVsOld: FC<Props> = ({ data, isLoading, year }) => {
     const newPct = data?.total
         ? (data.new_artists_streams / data.total) * 100
         : 0
@@ -74,7 +75,11 @@ export const NewVsOld: FC<Props> = ({ data, isLoading }) => {
 
                     <InsightCard>
                         {data.new_artists_count.toLocaleString()} new artists
-                        discovered this year!
+                        discovered
+                        {year !== undefined
+                            ? ' this year'
+                            : ' in your latest year'}
+                        !
                     </InsightCard>
                 </>
             )}

--- a/app/src/components/Charts/SimpleCharts/NewVsOld/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/index.tsx
@@ -8,5 +8,5 @@ export function NewVsOld({ year }: { year: number | undefined }) {
         year,
     })
 
-    return <NewVsOldView data={data} isLoading={isLoading} />
+    return <NewVsOldView data={data} isLoading={isLoading} year={year} />
 }

--- a/app/src/components/Charts/SimpleCharts/NewVsOld/index.tsx
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/index.tsx
@@ -1,12 +1,36 @@
 import { useDBQueryFirst } from '../../../../hooks/useDBQuery'
-import { queryNewVsOld, type NewVsOldResult } from './query'
+import {
+    queryNewVsOld,
+    queryTotalArtists,
+    type NewVsOldResult,
+    type TotalArtistsResult,
+} from './query'
 import { NewVsOld as NewVsOldView } from './NewVsOld'
 
-export function NewVsOld({ year }: { year: number | undefined }) {
+function NewVsOldLoader({ year }: { year: number }) {
     const { data, isLoading } = useDBQueryFirst<NewVsOldResult>({
         query: queryNewVsOld(year),
         year,
     })
-
     return <NewVsOldView data={data} isLoading={isLoading} year={year} />
+}
+
+function NewVsOldAllTimeFallback() {
+    const { data: totalArtistsData, isLoading } =
+        useDBQueryFirst<TotalArtistsResult>({
+            query: queryTotalArtists(),
+        })
+    return (
+        <NewVsOldView
+            data={undefined}
+            isLoading={isLoading}
+            year={undefined}
+            totalArtists={totalArtistsData?.total_artists}
+        />
+    )
+}
+
+export function NewVsOld({ year }: { year: number | undefined }) {
+    if (year === undefined) return <NewVsOldAllTimeFallback />
+    return <NewVsOldLoader year={year} />
 }

--- a/app/src/components/Charts/SimpleCharts/NewVsOld/query.test.ts
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/query.test.ts
@@ -44,14 +44,4 @@ describe('NewVsOld Query', () => {
         expect(row.old_artists_streams).toBe(1)
         expect(row.total).toBe(1 + 1)
     })
-
-    it('should include all years when year is undefined', async () => {
-        const rows = await testQuery<NewVsOldResult>(
-            conn,
-            queryNewVsOld(undefined)
-        )
-        // All years included; "new" = discovered in the latest year (2026)
-        expect(rows.length).toBe(1)
-        expect(rows[0].total).toBe(5)
-    })
 })

--- a/app/src/components/Charts/SimpleCharts/NewVsOld/query.ts
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/query.ts
@@ -16,7 +16,7 @@ export type TotalArtistsResult = {
     total_artists: number
 }
 
-export function queryNewVsOld(year: number | undefined): string {
+export function queryNewVsOld(year: number): string {
     const yearCondition = buildYearCondition(year)
     const yearForNew = buildYearOrLatest(year)
     return sqlQueryNewVsOld

--- a/app/src/components/Charts/SimpleCharts/NewVsOld/query.ts
+++ b/app/src/components/Charts/SimpleCharts/NewVsOld/query.ts
@@ -12,6 +12,10 @@ export type NewVsOldResult = {
     total: number
 }
 
+export type TotalArtistsResult = {
+    total_artists: number
+}
+
 export function queryNewVsOld(year: number | undefined): string {
     const yearCondition = buildYearCondition(year)
     const yearForNew = buildYearOrLatest(year)
@@ -19,4 +23,8 @@ export function queryNewVsOld(year: number | undefined): string {
         .replaceAll('${table}', TABLE)
         .replaceAll('${year_condition}', yearCondition)
         .replaceAll('${year_for_new}', yearForNew)
+}
+
+export function queryTotalArtists(): string {
+    return `SELECT count(distinct artist_name)::int as total_artists FROM ${TABLE} WHERE artist_name IS NOT NULL`
 }

--- a/e2e/tests/main.spec.ts
+++ b/e2e/tests/main.spec.ts
@@ -162,11 +162,9 @@ test('has title and can upload dataset', async ({ page }) => {
         await expect(freshVsFamiliarCard).toBeVisible()
         await expect.soft(freshVsFamiliarCard.getByText('Comfort Listener', { exact: true })).toBeVisible()
         await expect.soft(freshVsFamiliarCard.getByText('6 new artists discovered this year!')).toBeVisible()
+        await expect.soft(freshVsFamiliarCard.getByRole('listitem').filter({ hasText: 'Fresh' })).toContainText('3%')
         await expect
-            .soft(freshVsFamiliarCard.getByRole('listitem').filter({ hasText: 'Discoveries' }))
-            .toContainText('3%')
-        await expect
-            .soft(freshVsFamiliarCard.getByRole('listitem').filter({ hasText: 'Favorites' }))
+            .soft(freshVsFamiliarCard.getByRole('listitem').filter({ hasText: 'Familiar' }))
             .toContainText('97%')
     })
 


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The Fresh vs Familiar chart had three issues:

- The insight label "X new artists discovered this year!" was hardcoded and did not update when switching to "all time". It always showed the value from the latest year.
- The labels "Discoveries" / "Favorites" were semantically misleading: the chart measures stream share by artist novelty, not acts of discovery or affective preference.
- The question "Am I discovering new artists?" did not match what the chart actually computes.

Additionally, the "all time" mode had no meaningful fallback. The Fresh vs Familiar concept is year-scoped (new = first heard this year) and has no natural equivalent over all time.

## 🎹 Proposal

- Pass `year` down to the view component so the insight text is context-aware.
- Rename labels to "Fresh" / "Familiar", consistent with the chart title.
- Shorten and reword the question to "Do I listen more to new or familiar artists?"
- Add an all-time fallback ("Select a year to see your Fresh vs Familiar split") with a total unique artists insight powered by a separate lightweight query.

## 🎶 Comments

The "all time" total artists count is computed via a dedicated `queryTotalArtists()` query (no year filter), always running alongside the main query. It is only surfaced in the fallback view.

## 🎤 Test

1. Upload a dataset with multiple years.
2. Select a specific year -> chart renders normally with "Fresh" / "Familiar" labels and "X new artists discovered this year!".
3. Switch to "all time" -> fallback message appears with total unique artists count.
4. Switch back to a year -> chart renders again correctly.