### PR TITLE
feat(db): timezone-aware timestamps via DuckDB view

### DIFF
--- a/app/src/db/precompute.test.ts
+++ b/app/src/db/precompute.test.ts
@@ -9,10 +9,21 @@ function mockConn() {
 }
 
 describe('precomputeDerivedTables', () => {
-    it('executes at least 8 queries (4 DROP + 4 CREATE)', async () => {
+    it('executes at least 9 queries (1 CREATE VIEW + 4 DROP + 4 CREATE)', async () => {
         const conn = mockConn()
         await precomputeDerivedTables(conn)
-        expect(conn.query).toHaveBeenCalledTimes(8)
+        expect(conn.query).toHaveBeenCalledTimes(9)
+    })
+
+    it('creates the timezone view before derived tables', async () => {
+        const conn = mockConn()
+        await precomputeDerivedTables(conn)
+
+        const calls: string[] = (
+            conn.query as ReturnType<typeof vi.fn>
+        ).mock.calls.map((c: string[]) => c[0].trim())
+
+        expect(calls[0]).toMatch(/CREATE OR REPLACE VIEW music_streams/)
     })
 
     it('drops all derived tables before creating them', async () => {
@@ -23,10 +34,10 @@ describe('precomputeDerivedTables', () => {
             conn.query as ReturnType<typeof vi.fn>
         ).mock.calls.map((c: string[]) => c[0].trim())
 
-        expect(calls[0]).toBe('DROP TABLE IF EXISTS daily_stream_counts')
-        expect(calls[2]).toBe('DROP TABLE IF EXISTS artist_first_year')
-        expect(calls[4]).toBe('DROP TABLE IF EXISTS stream_sessions')
-        expect(calls[6]).toBe('DROP TABLE IF EXISTS summarize_cache')
+        expect(calls[1]).toBe('DROP TABLE IF EXISTS daily_stream_counts')
+        expect(calls[3]).toBe('DROP TABLE IF EXISTS artist_first_year')
+        expect(calls[5]).toBe('DROP TABLE IF EXISTS stream_sessions')
+        expect(calls[7]).toBe('DROP TABLE IF EXISTS summarize_cache')
     })
 
     it('creates daily_stream_counts, artist_first_year, stream_sessions, summarize_cache', async () => {

--- a/app/src/db/precompute.ts
+++ b/app/src/db/precompute.ts
@@ -1,5 +1,6 @@
 import type { AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
 import {
+    RAW_TABLE,
     TABLE,
     DAILY_STREAM_COUNTS_TABLE,
     ARTIST_FIRST_YEAR_TABLE,
@@ -19,8 +20,12 @@ const DERIVED_TABLES = [
 ] as const
 
 export async function precomputeDerivedTables(
-    conn: AsyncDuckDBConnection
+    conn: AsyncDuckDBConnection,
+    tz: string = Intl.DateTimeFormat().resolvedOptions().timeZone
 ): Promise<void> {
+    await conn.query(
+        `CREATE OR REPLACE VIEW ${TABLE} AS SELECT * EXCLUDE (ts), (ts::TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE '${tz}') AS ts FROM ${RAW_TABLE}`
+    )
     for (const [name, sql] of DERIVED_TABLES) {
         await conn.query(`DROP TABLE IF EXISTS ${name}`)
         await conn.query(

--- a/app/src/db/queries/constants.ts
+++ b/app/src/db/queries/constants.ts
@@ -1,3 +1,4 @@
+export const RAW_TABLE = 'music_streams_raw'
 export const TABLE = 'music_streams'
 
 export const DAILY_STREAM_COUNTS_TABLE = 'daily_stream_counts'

--- a/app/src/db/queries/constants.ts
+++ b/app/src/db/queries/constants.ts
@@ -1,7 +1,5 @@
 export const TABLE = 'music_streams'
 
-export const DROP_TABLE_QUERY = `DROP TABLE IF EXISTS ${TABLE}`
-
 export const DAILY_STREAM_COUNTS_TABLE = 'daily_stream_counts'
 export const ARTIST_FIRST_YEAR_TABLE = 'artist_first_year'
 export const STREAM_SESSIONS_TABLE = 'stream_sessions'

--- a/app/src/db/queries/insertFilesInDatabase.test.ts
+++ b/app/src/db/queries/insertFilesInDatabase.test.ts
@@ -6,7 +6,7 @@ import * as adapters from '../../streamProvider'
 import * as precompute from '../precompute'
 import * as dataSignal from '../dataSignal'
 
-import { TABLE } from './constants'
+import { RAW_TABLE, TABLE } from './constants'
 
 import { mockDB, mockStreamProviderWithSpy } from './__tests__/test-utils'
 
@@ -177,14 +177,17 @@ describe('insertFilesInDatabase', () => {
             expect(processFileSpy1).toHaveBeenCalledTimes(1)
             expect(processFileSpy2).toHaveBeenCalledTimes(1)
 
-            expect(connectionMock.query).toHaveBeenCalledTimes(1)
+            expect(connectionMock.query).toHaveBeenCalledTimes(2)
             expect(connectionMock.query).toHaveBeenCalledWith(
-                `DROP TABLE IF EXISTS ${TABLE}`
+                `DROP VIEW IF EXISTS ${TABLE}`
+            )
+            expect(connectionMock.query).toHaveBeenCalledWith(
+                `DROP TABLE IF EXISTS ${RAW_TABLE}`
             )
             expect(connectionMock.insertArrowTable).toHaveBeenCalledTimes(1)
 
             expect(consoleSpy.debug).toHaveBeenCalledWith(
-                `Table ${TABLE} created with 2 records.`
+                `Table ${RAW_TABLE} created with 2 records.`
             )
         })
     })
@@ -257,9 +260,12 @@ describe('insertFilesInDatabase', () => {
 
             expect(detectProviderSpy).toHaveBeenCalledTimes(2)
 
-            expect(connectionMock.query).toHaveBeenCalledTimes(1)
+            expect(connectionMock.query).toHaveBeenCalledTimes(2)
             expect(connectionMock.query).toHaveBeenCalledWith(
-                `DROP TABLE IF EXISTS ${TABLE}`
+                `DROP VIEW IF EXISTS ${TABLE}`
+            )
+            expect(connectionMock.query).toHaveBeenCalledWith(
+                `DROP TABLE IF EXISTS ${RAW_TABLE}`
             )
             expect(connectionMock.insertArrowTable).toHaveBeenCalledTimes(1)
 

--- a/app/src/db/queries/insertFilesInDatabase.ts
+++ b/app/src/db/queries/insertFilesInDatabase.ts
@@ -1,5 +1,5 @@
 import { getDB } from '../getDB'
-import { TABLE, DROP_TABLE_QUERY } from './constants'
+import { TABLE } from './constants'
 import { tableFromJSON } from 'apache-arrow'
 import { detectProvider } from '../../streamProvider'
 import type { StreamRecord } from '../../streamProvider/types'
@@ -45,7 +45,7 @@ export async function insertFilesInDatabase(files: FileList) {
 
     const { conn } = await getDB()
 
-    await conn.query(DROP_TABLE_QUERY)
+    await conn.query(`DROP TABLE IF EXISTS ${TABLE}`)
     console.debug(`Table ${TABLE} dropped.`)
 
     await conn.insertArrowTable(arrowTableContent, {

--- a/app/src/db/queries/insertFilesInDatabase.ts
+++ b/app/src/db/queries/insertFilesInDatabase.ts
@@ -1,5 +1,5 @@
 import { getDB } from '../getDB'
-import { TABLE } from './constants'
+import { RAW_TABLE, TABLE } from './constants'
 import { tableFromJSON } from 'apache-arrow'
 import { detectProvider } from '../../streamProvider'
 import type { StreamRecord } from '../../streamProvider/types'
@@ -45,15 +45,16 @@ export async function insertFilesInDatabase(files: FileList) {
 
     const { conn } = await getDB()
 
-    await conn.query(`DROP TABLE IF EXISTS ${TABLE}`)
-    console.debug(`Table ${TABLE} dropped.`)
+    await conn.query(`DROP VIEW IF EXISTS ${TABLE}`)
+    await conn.query(`DROP TABLE IF EXISTS ${RAW_TABLE}`)
+    console.debug(`Table ${RAW_TABLE} dropped.`)
 
     await conn.insertArrowTable(arrowTableContent, {
-        name: TABLE,
+        name: RAW_TABLE,
         create: true,
     })
     console.debug(
-        `Table ${TABLE} created with ${allStreamRecords.length} records.`
+        `Table ${RAW_TABLE} created with ${allStreamRecords.length} records.`
     )
 
     await precomputeDerivedTables(conn)

--- a/app/src/db/queries/insertUrlInDatabase.test.ts
+++ b/app/src/db/queries/insertUrlInDatabase.test.ts
@@ -8,7 +8,7 @@ import * as dataSignal from '../dataSignal'
 import { mockDB, mockStreamProviderWithSpy } from './__tests__/test-utils'
 
 import type { StreamRecord } from '../../streamProvider/types'
-import { TABLE } from './constants'
+import { RAW_TABLE, TABLE } from './constants'
 
 describe('insertUrlInDatabase', () => {
     beforeEach(() => {
@@ -120,7 +120,10 @@ describe('insertUrlInDatabase', () => {
             await insertUrlInDatabase(url)
 
             expect(connectionMock.query).toHaveBeenCalledWith(
-                `DROP TABLE IF EXISTS ${TABLE}`
+                `DROP VIEW IF EXISTS ${TABLE}`
+            )
+            expect(connectionMock.query).toHaveBeenCalledWith(
+                `DROP TABLE IF EXISTS ${RAW_TABLE}`
             )
             expect(connectionMock.insertArrowTable).toHaveBeenCalledTimes(1)
         })
@@ -158,7 +161,10 @@ describe('insertUrlInDatabase', () => {
 
             expect(processFileSpy).toHaveBeenCalledTimes(1)
             expect(connectionMock.query).toHaveBeenCalledWith(
-                `DROP TABLE IF EXISTS ${TABLE}`
+                `DROP VIEW IF EXISTS ${TABLE}`
+            )
+            expect(connectionMock.query).toHaveBeenCalledWith(
+                `DROP TABLE IF EXISTS ${RAW_TABLE}`
             )
             expect(connectionMock.insertArrowTable).toHaveBeenCalledTimes(1)
         })

--- a/app/src/db/queries/insertUrlInDatabase.ts
+++ b/app/src/db/queries/insertUrlInDatabase.ts
@@ -1,5 +1,5 @@
 import { getDB } from '../getDB'
-import { TABLE, DROP_TABLE_QUERY } from './constants'
+import { TABLE } from './constants'
 import { tableFromJSON } from 'apache-arrow'
 import { detectProvider } from '../../streamProvider'
 import { precomputeDerivedTables } from '../precompute'
@@ -29,7 +29,7 @@ export async function insertUrlInDatabase(jsonUrl: URL) {
     const arrowTableContent = tableFromJSON(records)
 
     const { conn } = await getDB()
-    await conn.query(DROP_TABLE_QUERY)
+    await conn.query(`DROP TABLE IF EXISTS ${TABLE}`)
     await conn.insertArrowTable(arrowTableContent, {
         name: TABLE,
         create: true,

--- a/app/src/db/queries/insertUrlInDatabase.ts
+++ b/app/src/db/queries/insertUrlInDatabase.ts
@@ -1,5 +1,5 @@
 import { getDB } from '../getDB'
-import { TABLE } from './constants'
+import { RAW_TABLE, TABLE } from './constants'
 import { tableFromJSON } from 'apache-arrow'
 import { detectProvider } from '../../streamProvider'
 import { precomputeDerivedTables } from '../precompute'
@@ -29,9 +29,10 @@ export async function insertUrlInDatabase(jsonUrl: URL) {
     const arrowTableContent = tableFromJSON(records)
 
     const { conn } = await getDB()
-    await conn.query(`DROP TABLE IF EXISTS ${TABLE}`)
+    await conn.query(`DROP VIEW IF EXISTS ${TABLE}`)
+    await conn.query(`DROP TABLE IF EXISTS ${RAW_TABLE}`)
     await conn.insertArrowTable(arrowTableContent, {
-        name: TABLE,
+        name: RAW_TABLE,
         create: true,
     })
 

--- a/app/src/llm/prompt.ts
+++ b/app/src/llm/prompt.ts
@@ -89,7 +89,7 @@ export const FEW_SHOTS: FewShot[] = [
             params: {},
             title: 'Top artists',
             explanation: 'Artists ranked by total stream count.',
-            sql: 'SELECT artist_name, COUNT(*)::DOUBLE AS count_streams, SUM(ms_played)::DOUBLE AS ms_played FROM music_streams WHERE artist_name IS NOT NULL GROUP BY artist_name ORDER BY count_streams DESC LIMIT 5',
+            sql: `SELECT artist_name, COUNT(*)::DOUBLE AS count_streams, SUM(ms_played)::DOUBLE AS ms_played FROM ${TABLE} WHERE artist_name IS NOT NULL GROUP BY artist_name ORDER BY count_streams DESC LIMIT 5`,
         }),
     },
     {
@@ -99,7 +99,7 @@ export const FEW_SHOTS: FewShot[] = [
             params: { year: CURRENT_YEAR },
             title: `Top artists ${CURRENT_YEAR}`,
             explanation: `Artists ranked by total stream count in ${CURRENT_YEAR}.`,
-            sql: `SELECT artist_name, COUNT(*)::DOUBLE AS count_streams, SUM(ms_played)::DOUBLE AS ms_played FROM music_streams WHERE artist_name IS NOT NULL AND EXTRACT(year FROM ts) = ${CURRENT_YEAR} GROUP BY artist_name ORDER BY count_streams DESC LIMIT 5`,
+            sql: `SELECT artist_name, COUNT(*)::DOUBLE AS count_streams, SUM(ms_played)::DOUBLE AS ms_played FROM ${TABLE} WHERE artist_name IS NOT NULL AND EXTRACT(year FROM ts) = ${CURRENT_YEAR} GROUP BY artist_name ORDER BY count_streams DESC LIMIT 5`,
         }),
     },
     {
@@ -109,7 +109,7 @@ export const FEW_SHOTS: FewShot[] = [
             params: { year: CURRENT_YEAR - 1 },
             title: `Top tracks ${CURRENT_YEAR - 1}`,
             explanation: `Most-played tracks during ${CURRENT_YEAR - 1}.`,
-            sql: `SELECT track_name, artist_name, COUNT(*)::DOUBLE AS count_streams FROM music_streams WHERE EXTRACT(year FROM ts) = ${CURRENT_YEAR - 1} AND track_name IS NOT NULL GROUP BY track_name, artist_name ORDER BY count_streams DESC LIMIT 5`,
+            sql: `SELECT track_name, artist_name, COUNT(*)::DOUBLE AS count_streams FROM ${TABLE} WHERE EXTRACT(year FROM ts) = ${CURRENT_YEAR - 1} AND track_name IS NOT NULL GROUP BY track_name, artist_name ORDER BY count_streams DESC LIMIT 5`,
         }),
     },
     {
@@ -119,7 +119,7 @@ export const FEW_SHOTS: FewShot[] = [
             params: { year: 2023, limit: 10 },
             title: 'Top 10 tracks in 2023',
             explanation: 'Most-played tracks during 2023.',
-            sql: 'SELECT track_name, artist_name, COUNT(*)::DOUBLE AS count_streams FROM music_streams WHERE EXTRACT(year FROM ts) = 2023 AND track_name IS NOT NULL GROUP BY track_name, artist_name ORDER BY count_streams DESC LIMIT 10',
+            sql: `SELECT track_name, artist_name, COUNT(*)::DOUBLE AS count_streams FROM ${TABLE} WHERE EXTRACT(year FROM ts) = 2023 AND track_name IS NOT NULL GROUP BY track_name, artist_name ORDER BY count_streams DESC LIMIT 10`,
         }),
     },
     {
@@ -129,7 +129,7 @@ export const FEW_SHOTS: FewShot[] = [
             params: { year: CURRENT_YEAR },
             title: 'Listening calendar',
             explanation: 'Daily listening intensity across the calendar year.',
-            sql: `SELECT ts::date AS day, COUNT(*)::DOUBLE AS stream_count FROM music_streams WHERE EXTRACT(year FROM ts) = ${CURRENT_YEAR} GROUP BY ts::date ORDER BY day`,
+            sql: `SELECT ts::date AS day, COUNT(*)::DOUBLE AS stream_count FROM ${TABLE} WHERE EXTRACT(year FROM ts) = ${CURRENT_YEAR} GROUP BY ts::date ORDER BY day`,
         }),
     },
     {
@@ -139,7 +139,7 @@ export const FEW_SHOTS: FewShot[] = [
             params: { year: 2022 },
             title: 'Streams per month — 2022',
             explanation: 'Monthly stream counts for the year 2022.',
-            sql: "SELECT DATE_TRUNC('month', ts) AS month, COUNT(*)::DOUBLE AS count_streams, SUM(ms_played)::DOUBLE AS ms_played FROM music_streams WHERE EXTRACT(year FROM ts) = 2022 GROUP BY month ORDER BY month",
+            sql: `SELECT DATE_TRUNC('month', ts) AS month, COUNT(*)::DOUBLE AS count_streams, SUM(ms_played)::DOUBLE AS ms_played FROM ${TABLE} WHERE EXTRACT(year FROM ts) = 2022 GROUP BY month ORDER BY month`,
         }),
     },
     {
@@ -150,7 +150,7 @@ export const FEW_SHOTS: FewShot[] = [
             title: 'Minutes listened per platform',
             explanation:
                 'Total minutes of playback grouped by reported platform.',
-            sql: 'SELECT platform, SUM(ms_played) / 60000.0 AS minutes FROM music_streams WHERE platform IS NOT NULL GROUP BY platform ORDER BY minutes DESC',
+            sql: `SELECT platform, SUM(ms_played) / 60000.0 AS minutes FROM ${TABLE} WHERE platform IS NOT NULL GROUP BY platform ORDER BY minutes DESC`,
         }),
     },
     {
@@ -160,7 +160,7 @@ export const FEW_SHOTS: FewShot[] = [
             params: {},
             title: 'Skip rate',
             explanation: 'Share of streams that were skipped vs completed.',
-            sql: 'SELECT COUNT(*) FILTER (WHERE ms_played < 30000)::DOUBLE AS skipped_listens, COUNT(*) FILTER (WHERE ms_played >= 30000)::DOUBLE AS complete_listens FROM music_streams',
+            sql: `SELECT COUNT(*) FILTER (WHERE ms_played < 30000)::DOUBLE AS skipped_listens, COUNT(*) FILTER (WHERE ms_played >= 30000)::DOUBLE AS complete_listens FROM ${TABLE}`,
         }),
     },
     {
@@ -170,7 +170,7 @@ export const FEW_SHOTS: FewShot[] = [
             params: {},
             title: 'Listening evolution',
             explanation: 'Total stream count per year across all years.',
-            sql: 'SELECT year(ts::date)::integer AS stream_year, COUNT(*)::DOUBLE AS stream_count, SUM(ms_played)::DOUBLE AS ms_played FROM music_streams GROUP BY year(ts::date) ORDER BY year(ts::date)',
+            sql: `SELECT year(ts::date)::integer AS stream_year, COUNT(*)::DOUBLE AS stream_count, SUM(ms_played)::DOUBLE AS ms_played FROM ${TABLE} GROUP BY year(ts::date) ORDER BY year(ts::date)`,
         }),
     },
     {
@@ -181,7 +181,7 @@ export const FEW_SHOTS: FewShot[] = [
             title: 'Listening streaks',
             explanation:
                 'Longest and most recent consecutive listening day streaks.',
-            sql: 'SELECT COUNT(*)::integer AS streaks, MIN(ts::date) AS start_ts, MAX(ts::date) AS end_ts FROM music_streams GROUP BY ts::date ORDER BY streaks DESC LIMIT 1',
+            sql: `SELECT COUNT(*)::integer AS streaks, MIN(ts::date) AS start_ts, MAX(ts::date) AS end_ts FROM ${TABLE} GROUP BY ts::date ORDER BY streaks DESC LIMIT 1`,
         }),
     },
     {
@@ -192,7 +192,7 @@ export const FEW_SHOTS: FewShot[] = [
             title: 'Principal platform',
             explanation:
                 'Distribution of listening across platforms and devices.',
-            sql: 'SELECT platform, COUNT(*)::DOUBLE AS stream_count FROM music_streams WHERE platform IS NOT NULL GROUP BY platform ORDER BY stream_count DESC LIMIT 5',
+            sql: `SELECT platform, COUNT(*)::DOUBLE AS stream_count FROM ${TABLE} WHERE platform IS NOT NULL GROUP BY platform ORDER BY stream_count DESC LIMIT 5`,
         }),
     },
 ]

--- a/blog/content/decisions/timezone-aware-timestamps.md
+++ b/blog/content/decisions/timezone-aware-timestamps.md
@@ -1,0 +1,103 @@
+---
+date: 2026-06-11
+draft: true
+title: "Timezone-Aware Timestamps for Streaming Data"
+---
+
+## Context and Problem Statement
+
+Spotify exports streaming history with timestamps (`ts`) in UTC, losing the user's local timezone offset in the process. Time-sensitive visualisations — hourly listening distribution, session analysis, morning/evening/night favourite artists — are computed against UTC time, which may differ from the user's actual local time by several hours. A user in UTC+2 who listened at 1:00 AM local time has a `ts` value of 23:00 the previous day in UTC, causing that stream to be attributed to the wrong date and hour.
+
+No field in the exported dataset can reliably reconstruct the original offset: `country` maps to multiple timezones and is distorted by VPN usage; `ip_addr` requires embedding and maintaining an IP-to-timezone database, which conflicts with the project's privacy-first, no-external-dependency principle.
+
+## Considered Options
+
+### Option 1: Infer timezone from the `country` field
+
+Map each stream's `country` value to a timezone using a bundled country→TZ mapping.
+
+**Pros:**
+
+- Uses data already present in the dataset
+- Covers the common case of a user who rarely travels
+
+**Cons:**
+
+- Many countries span multiple timezones (USA, Russia, Brazil, Australia…)
+- VPN usage distorts the country value
+- Requires bundling and maintaining a mapping table
+
+### Option 2: Infer timezone from the `ip_addr` field
+
+Use a bundled IP geolocation database to map each stream's IP address to a timezone.
+
+**Pros:**
+
+- More granular than country-level inference
+
+**Cons:**
+
+- Requires embedding a large IP→TZ database client-side
+- VPN usage makes IP-based inference unreliable
+- Maintenance burden; conflicts with the privacy-first principle
+
+### Option 3: Apply offset at query time via template variable
+
+Store the UTC `ts` column as-is and inject a `${tzOffsetMinutes}` template variable into every SQL query, replacing `ts::timestamp` with `(ts::timestamp + INTERVAL ${tzOffsetMinutes} MINUTE)`.
+
+**Pros:**
+
+- No schema change
+- Raw data fully preserved
+
+**Cons:**
+
+- All ~50 SQL files and TypeScript inline queries require modification
+- All `ts::date` usages are also affected (streams around midnight shift dates), so no query is truly "safe" — the scope is universal
+
+### Option 4: Two-column approach (`ts` UTC + `ts_local`)
+
+Keep `ts` as the immutable UTC source of truth and add a `ts_local` column computed at insert time.
+
+**Pros:**
+
+- Chart queries read `ts_local` with no offset arithmetic
+- On timezone change: a single `UPDATE` statement recalculates `ts_local`
+
+**Cons:**
+
+- The `UPDATE` must know the previously applied offset to reverse it before applying the new one, requiring the original `ts` to be preserved anyway
+- Precomputed tables must still be rebuilt on timezone change
+- Extra column in the schema
+
+### Option 5: DuckDB view `music_streams` over raw table `music_streams_raw`
+
+Store raw data in `music_streams_raw` (UTC, never modified). Create a DuckDB view named `music_streams` that exposes the same schema with `ts` shifted by the user's timezone offset. All existing queries transparently use the view via the `${table}` template variable.
+
+**Pros:**
+
+- Zero changes to the ~50 existing SQL files
+- Raw UTC data preserved and fully reversible
+- Clean separation: raw source vs. timezone-adjusted query surface
+- On timezone change: recreate the view and rebuild precomputed tables (already a known operation triggered on every import)
+
+**Cons:**
+
+- View must be recreated whenever the timezone offset changes, which also triggers a precompute rebuild
+- The timezone approximation remains imperfect: users who listened in multiple timezones (travel, relocation) will still see some misattributed streams
+
+## Decision Outcome
+
+Chosen option: **Option 5 — DuckDB view**, because it requires zero changes to existing SQL queries, preserves the raw UTC data as an immutable source of truth, and reuses the existing precompute lifecycle. The timezone offset defaults to the browser's local timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`) and can be overridden in settings.
+
+### Consequences
+
+* Good, because all existing chart queries work without modification
+* Good, because the raw data is never mutated and the offset can be changed or removed at any time
+* Good, because the override mechanism (settings UI + precompute rebuild) is self-contained and client-side
+* Bad, because users who consumed music across multiple timezones will still see approximated results — this limitation is documented in the UI with an informational message on time-sensitive charts
+* Bad, because a timezone change triggers a full precompute rebuild, which adds latency in the settings flow
+
+## More Information
+
+- [Issue #203 — The time counted is not the actual listening time](https://github.com/Gudsfile/tracksy/issues/203)


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Streaming timestamps are stored and queried in UTC with no timezone conversion. Date-based statistics (calendar heatmap, daily counts, top artists by year...) use UTC boundaries instead of the user's local time, which can shift days and years depending on the timezone.

Refs #203

## 🎹 Proposal

A raw/view separation is introduced in DuckDB:
- **`music_streams_raw`** stores immutable UTC data as imported.
- **`music_streams`** (view, same name as before) projects `ts` converted to local time via `ts::TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE '<tz>'`. All existing SQL queries continue targeting `music_streams` without modification.

On data load, `precomputeDerivedTables` recreates the view (timezone detected via `Intl.DateTimeFormat().resolvedOptions().timeZone`) before rebuilding derived tables.

A few preparatory refactors are included: `DROP_TABLE_QUERY` is removed in favour of inline literals, and LLM few-shot examples use the `TABLE` constant instead of a hardcoded name.

An ADR documents the architecture decision.

## 🎶 Comments

PR 1/2. The next PR adds the timezone selector in settings (hook `useTimezone`, on-the-fly view recreation).

> [!IMPORtANT]
> Known limitation: Apple Music exports `Event Start Timestamp` as `TIMESTAMP WITH TIME ZONE`, encoding the exact local time of each listening event. The current transform normalizes it to UTC via `.toISOString()`, losing the original timezone offset. For date-based stats (year/month/day boundaries) this is an improvement over the previous UTC-only behavior, but for listening hour analysis, precision is reduced for events recorded in a timezone different from the user's home timezone. A separate issue tracks the proper fix.

## 🎤 Test

1. Load the demo data for each available provider and verify all are ingested without error.
2. Verify that time-based charts (heatmap, streams per month...) reflect local time rather than UTC.
3. Temporarily change the system timezone and reload: day boundaries should follow.