### PR TITLE
feat(tz): timezone selector and persistent preference

### DIFF
--- a/app/src/components/App.tsx
+++ b/app/src/components/App.tsx
@@ -1,42 +1,46 @@
 import { ThemeProvider } from '../hooks/ThemeContext'
+import { TimezoneProvider } from '../hooks/TimezoneContext'
 import { TracksyWrapper } from './TracksyWrapper'
 import { ThemeToggle } from './ThemeToggle/ThemeToggle'
+import { TimezoneSelector } from './TimezoneSelector/TimezoneSelector'
 
 export function App() {
     return (
         <ThemeProvider>
-            <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-slate-950 relative transition-colors duration-300">
-                {/* Theme toggle button */}
-                <div className="absolute top-6 right-6 z-50">
-                    <ThemeToggle />
-                </div>
-
-                {/* Main content area */}
-                <div className="flex flex-1 items-center justify-center px-4 relative z-10">
-                    <div className="max-w-4xl w-full mx-auto py-12">
-                        <h1 className="text-4xl md:text-5xl font-bold text-center mb-8 animate-fade-in">
-                            <a
-                                href={`${import.meta.env.BASE_URL}`}
-                                className="bg-gradient-brand bg-clip-text text-transparent hover:opacity-80 transition-opacity drop-shadow-sm"
-                            >
-                                Tracksy
-                            </a>
-                        </h1>
-                        <TracksyWrapper />
+            <TimezoneProvider>
+                <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-slate-950 relative transition-colors duration-300">
+                    <div className="absolute top-6 right-6 z-50 flex items-center gap-2">
+                        <TimezoneSelector />
+                        <ThemeToggle />
                     </div>
-                </div>
 
-                <footer className="relative z-10 pb-6 text-center text-sm text-gray-400 dark:text-slate-500">
-                    <a
-                        href="https://github.com/Gudsfile/tracksy"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hover:text-gray-600 dark:hover:text-slate-300 transition-colors"
-                    >
-                        Music stats made with ❤️ & 🔐 · View on GitHub
-                    </a>
-                </footer>
-            </div>
+                    {/* Main content area */}
+                    <div className="flex flex-1 items-center justify-center px-4 relative z-10">
+                        <div className="max-w-4xl w-full mx-auto py-12">
+                            <h1 className="text-4xl md:text-5xl font-bold text-center mb-8 animate-fade-in">
+                                <a
+                                    href={`${import.meta.env.BASE_URL}`}
+                                    className="bg-gradient-brand bg-clip-text text-transparent hover:opacity-80 transition-opacity drop-shadow-sm"
+                                >
+                                    Tracksy
+                                </a>
+                            </h1>
+                            <TracksyWrapper />
+                        </div>
+                    </div>
+
+                    <footer className="relative z-10 pb-6 text-center text-sm text-gray-400 dark:text-slate-500">
+                        <a
+                            href="https://github.com/Gudsfile/tracksy"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="hover:text-gray-600 dark:hover:text-slate-300 transition-colors"
+                        >
+                            Music stats made with ❤️ & 🔐 · View on GitHub
+                        </a>
+                    </footer>
+                </div>
+            </TimezoneProvider>
         </ThemeProvider>
     )
 }

--- a/app/src/components/Charts/SimpleView.tsx
+++ b/app/src/components/Charts/SimpleView.tsx
@@ -25,11 +25,13 @@ import {
     type SummarizeDataQueryResult,
     summarizeQuery,
 } from './Summarize/summarizeQuery'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useContext } from 'react'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import { DATA_LOADED_EVENT } from '../../db/dataSignal'
+import { TimezoneContext } from '../../hooks/TimezoneContext'
 
 export function SimpleView() {
+    const { timezone } = useContext(TimezoneContext)
     const [year, setYear] = useState<number | undefined>(undefined)
     const [summarize, setSummarize] = useState<
         SummarizeDataQueryResult | undefined
@@ -79,6 +81,10 @@ export function SimpleView() {
                         ).getFullYear()}
                         onChange={setYear}
                     />
+
+                    <p className="text-xs text-gray-400 dark:text-slate-500 text-right mb-2">
+                        Time-based charts use timezone: {timezone}
+                    </p>
 
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                         <TopTracks year={debouncedYear} />

--- a/app/src/components/TimezoneSelector/TimezoneSelector.tsx
+++ b/app/src/components/TimezoneSelector/TimezoneSelector.tsx
@@ -1,0 +1,27 @@
+import { useContext } from 'react'
+import { TimezoneContext } from '../../hooks/TimezoneContext'
+
+const TIMEZONES: string[] =
+    typeof Intl.supportedValuesOf === 'function'
+        ? Intl.supportedValuesOf('timeZone')
+        : [Intl.DateTimeFormat().resolvedOptions().timeZone]
+
+export function TimezoneSelector() {
+    const { timezone, setTimezone } = useContext(TimezoneContext)
+
+    return (
+        <select
+            value={timezone}
+            onChange={(e) => void setTimezone(e.target.value)}
+            className="text-sm px-3 py-2 rounded-lg bg-gray-100 dark:bg-slate-800/50 backdrop-blur-md border border-gray-300/60 dark:border-slate-700/50 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors duration-200 focus:outline-none"
+            aria-label="Timezone for charts"
+            title={`Charts timezone: ${timezone}`}
+        >
+            {TIMEZONES.map((tz) => (
+                <option key={tz} value={tz}>
+                    {tz}
+                </option>
+            ))}
+        </select>
+    )
+}

--- a/app/src/db/dataSignal.ts
+++ b/app/src/db/dataSignal.ts
@@ -1,7 +1,14 @@
 export const DATA_LOADED_EVENT = 'tracksy:data-loaded'
+export const TIMEZONE_CHANGED_EVENT = 'tracksy:timezone-changed'
 
 export function dispatchDataLoaded(): void {
     if (typeof window !== 'undefined') {
         window.dispatchEvent(new CustomEvent(DATA_LOADED_EVENT))
+    }
+}
+
+export function dispatchTimezoneChanged(): void {
+    if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent(TIMEZONE_CHANGED_EVENT))
     }
 }

--- a/app/src/db/precompute.ts
+++ b/app/src/db/precompute.ts
@@ -1,4 +1,5 @@
 import type { AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
+import { getStoredTimezone } from './timezoneStorage'
 import {
     RAW_TABLE,
     TABLE,
@@ -25,7 +26,7 @@ const TOTAL_STEPS = 1 + DERIVED_TABLES.length
 
 export async function precomputeDerivedTables(
     conn: AsyncDuckDBConnection,
-    tz: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
+    tz: string = getStoredTimezone(),
     onProgress?: OnProgress
 ): Promise<void> {
     await conn.query(`DROP VIEW IF EXISTS ${TABLE}`)

--- a/app/src/db/timezoneStorage.ts
+++ b/app/src/db/timezoneStorage.ts
@@ -1,0 +1,5 @@
+export const TIMEZONE_STORAGE_KEY = 'tracksy-timezone' as const
+
+export const getStoredTimezone = (): string =>
+    localStorage.getItem(TIMEZONE_STORAGE_KEY) ??
+    Intl.DateTimeFormat().resolvedOptions().timeZone

--- a/app/src/hooks/TimezoneContext.tsx
+++ b/app/src/hooks/TimezoneContext.tsx
@@ -1,0 +1,22 @@
+import { createContext, type ReactNode } from 'react'
+import { useTimezone } from './useTimezone'
+import { getStoredTimezone } from '../db/timezoneStorage'
+
+interface TimezoneContextValue {
+    timezone: string
+    setTimezone: (tz: string) => Promise<void>
+}
+
+export const TimezoneContext = createContext<TimezoneContextValue>({
+    timezone: getStoredTimezone(),
+    setTimezone: async () => {},
+})
+
+export function TimezoneProvider({ children }: { children: ReactNode }) {
+    const value = useTimezone()
+    return (
+        <TimezoneContext.Provider value={value}>
+            {children}
+        </TimezoneContext.Provider>
+    )
+}

--- a/app/src/hooks/useDBQuery.ts
+++ b/app/src/hooks/useDBQuery.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { queryDBAsJSON } from '../db/queries/queryDB'
-import { DATA_LOADED_EVENT } from '../db/dataSignal'
+import { DATA_LOADED_EVENT, TIMEZONE_CHANGED_EVENT } from '../db/dataSignal'
 import { resolveCallerSource } from '../devToolbar/resolveCallerSource'
 
 type DBPrimitive = string | number | null
@@ -34,9 +34,18 @@ export function useDBQueryMany<T extends DBRow>({
             hasLoadedRef.current = false
             setTriggerRefetch((t) => t + 1)
         }
+        const handleTimezoneChanged = () => {
+            setTriggerRefetch((t) => t + 1)
+        }
         window.addEventListener(DATA_LOADED_EVENT, handleDataLoaded)
-        return () =>
+        window.addEventListener(TIMEZONE_CHANGED_EVENT, handleTimezoneChanged)
+        return () => {
             window.removeEventListener(DATA_LOADED_EVENT, handleDataLoaded)
+            window.removeEventListener(
+                TIMEZONE_CHANGED_EVENT,
+                handleTimezoneChanged
+            )
+        }
     }, [])
 
     useEffect(() => {

--- a/app/src/hooks/useTimezone.ts
+++ b/app/src/hooks/useTimezone.ts
@@ -1,0 +1,21 @@
+import { useState } from 'react'
+import { TIMEZONE_STORAGE_KEY, getStoredTimezone } from '../db/timezoneStorage'
+import { getDB } from '../db/getDB'
+import { precomputeDerivedTables } from '../db/precompute'
+
+export function useTimezone() {
+    const [timezone, setTimezoneState] = useState<string>(getStoredTimezone)
+
+    const setTimezone = async (tz: string) => {
+        setTimezoneState(tz)
+        localStorage.setItem(TIMEZONE_STORAGE_KEY, tz)
+        try {
+            const { conn } = await getDB()
+            await precomputeDerivedTables(conn, tz)
+        } catch {
+            // DB not ready or no data loaded yet
+        }
+    }
+
+    return { timezone, setTimezone } as const
+}

--- a/app/src/hooks/useTimezone.ts
+++ b/app/src/hooks/useTimezone.ts
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { TIMEZONE_STORAGE_KEY, getStoredTimezone } from '../db/timezoneStorage'
 import { getDB } from '../db/getDB'
 import { precomputeDerivedTables } from '../db/precompute'
+import { dispatchTimezoneChanged } from '../db/dataSignal'
 
 export function useTimezone() {
     const [timezone, setTimezoneState] = useState<string>(getStoredTimezone)
@@ -12,6 +13,7 @@ export function useTimezone() {
         try {
             const { conn } = await getDB()
             await precomputeDerivedTables(conn, tz)
+            dispatchTimezoneChanged()
         } catch {
             // DB not ready or no data loaded yet
         }


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).

## 🔇 Problem

Timestamps are now stored and queried relative to the user's local timezone (introduced in #516), but there is no way to override this timezone from the UI. The active timezone is determined solely by `Intl.DateTimeFormat().resolvedOptions().timeZone` at data load time, with no persistence across sessions.

Refs #203

## 🎹 Proposal

A timezone selector is added next to the theme toggle in the top-right corner of the app.

- `timezoneStorage.ts` provides a shared `getStoredTimezone()` helper that reads from `localStorage` with an `Intl` fallback, so data reloads always respect the saved preference.
- `useTimezone` / `TimezoneContext` mirror the `useTheme` pattern: selecting a new timezone saves it to `localStorage`, recreates the DuckDB `music_streams` view via `precomputeDerivedTables(conn, tz)`, and rebuilds all derived tables immediately.
- `TimezoneSelector` renders a native `<select>` populated from `Intl.supportedValuesOf('timeZone')`.
- `SimpleView` displays an informative note below the chart grid: "Time-based charts use timezone: &lt;tz&gt;".

A settings panel grouping theme and timezone controls is tracked in #519.

## 🎶 Comments

PR 2/2 for #203. Depends on #516.

> [!IMPORTANT]
> Known limitation: Apple Music exports `TIMESTAMP WITH TIME ZONE` encoding the original local listening time. The current pipeline normalizes to UTC before storage, so events recorded in a different timezone appear at the home-timezone equivalent rather than the original local time. Tracked in #517.

## 🎤 Test

1. Load the demo data for each available provider and verify all are ingested without error.
2. Verify that time-based charts (heatmap, streams per month...) reflect the selected timezone.
3. Change the timezone in the selector and confirm charts update immediately without reloading data.
4. Reload the page and verify the selected timezone is restored.