### PR TITLE
perf(db): materialize music_streams as table instead of view

### DIFF
--- a/app/src/db/precompute.test.ts
+++ b/app/src/db/precompute.test.ts
@@ -9,13 +9,13 @@ function mockConn() {
 }
 
 describe('precomputeDerivedTables', () => {
-    it('executes at least 9 queries (1 CREATE VIEW + 4 DROP + 4 CREATE)', async () => {
+    it('executes 11 queries (2 DROP + 1 CREATE TABLE music_streams + 4 DROP + 4 CREATE derived)', async () => {
         const conn = mockConn()
         await precomputeDerivedTables(conn)
-        expect(conn.query).toHaveBeenCalledTimes(9)
+        expect(conn.query).toHaveBeenCalledTimes(11)
     })
 
-    it('creates the timezone view before derived tables', async () => {
+    it('materializes the timezone-adjusted music_streams table before derived tables', async () => {
         const conn = mockConn()
         await precomputeDerivedTables(conn)
 
@@ -23,7 +23,9 @@ describe('precomputeDerivedTables', () => {
             conn.query as ReturnType<typeof vi.fn>
         ).mock.calls.map((c: string[]) => c[0].trim())
 
-        expect(calls[0]).toMatch(/CREATE OR REPLACE VIEW music_streams/)
+        expect(calls[0]).toBe('DROP VIEW IF EXISTS music_streams')
+        expect(calls[1]).toBe('DROP TABLE IF EXISTS music_streams')
+        expect(calls[2]).toMatch(/^CREATE TABLE music_streams AS/)
     })
 
     it('drops all derived tables before creating them', async () => {
@@ -34,10 +36,10 @@ describe('precomputeDerivedTables', () => {
             conn.query as ReturnType<typeof vi.fn>
         ).mock.calls.map((c: string[]) => c[0].trim())
 
-        expect(calls[1]).toBe('DROP TABLE IF EXISTS daily_stream_counts')
-        expect(calls[3]).toBe('DROP TABLE IF EXISTS artist_first_year')
-        expect(calls[5]).toBe('DROP TABLE IF EXISTS stream_sessions')
-        expect(calls[7]).toBe('DROP TABLE IF EXISTS summarize_cache')
+        expect(calls[3]).toBe('DROP TABLE IF EXISTS daily_stream_counts')
+        expect(calls[5]).toBe('DROP TABLE IF EXISTS artist_first_year')
+        expect(calls[7]).toBe('DROP TABLE IF EXISTS stream_sessions')
+        expect(calls[9]).toBe('DROP TABLE IF EXISTS summarize_cache')
     })
 
     it('creates daily_stream_counts, artist_first_year, stream_sessions, summarize_cache', async () => {

--- a/app/src/db/precompute.ts
+++ b/app/src/db/precompute.ts
@@ -23,8 +23,10 @@ export async function precomputeDerivedTables(
     conn: AsyncDuckDBConnection,
     tz: string = Intl.DateTimeFormat().resolvedOptions().timeZone
 ): Promise<void> {
+    await conn.query(`DROP VIEW IF EXISTS ${TABLE}`)
+    await conn.query(`DROP TABLE IF EXISTS ${TABLE}`)
     await conn.query(
-        `CREATE OR REPLACE VIEW ${TABLE} AS SELECT * EXCLUDE (ts), (ts::TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE '${tz}') AS ts FROM ${RAW_TABLE}`
+        `CREATE TABLE ${TABLE} AS SELECT * EXCLUDE (ts), (ts::TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE '${tz}') AS ts FROM ${RAW_TABLE}`
     )
     for (const [name, sql] of DERIVED_TABLES) {
         await conn.query(`DROP TABLE IF EXISTS ${name}`)

--- a/app/src/db/queries/insertFilesInDatabase.test.ts
+++ b/app/src/db/queries/insertFilesInDatabase.test.ts
@@ -6,7 +6,7 @@ import * as adapters from '../../streamProvider'
 import * as precompute from '../precompute'
 import * as dataSignal from '../dataSignal'
 
-import { RAW_TABLE, TABLE } from './constants'
+import { RAW_TABLE } from './constants'
 
 import { mockDB, mockStreamProviderWithSpy } from './__tests__/test-utils'
 
@@ -177,10 +177,7 @@ describe('insertFilesInDatabase', () => {
             expect(processFileSpy1).toHaveBeenCalledTimes(1)
             expect(processFileSpy2).toHaveBeenCalledTimes(1)
 
-            expect(connectionMock.query).toHaveBeenCalledTimes(2)
-            expect(connectionMock.query).toHaveBeenCalledWith(
-                `DROP VIEW IF EXISTS ${TABLE}`
-            )
+            expect(connectionMock.query).toHaveBeenCalledTimes(1)
             expect(connectionMock.query).toHaveBeenCalledWith(
                 `DROP TABLE IF EXISTS ${RAW_TABLE}`
             )
@@ -260,10 +257,7 @@ describe('insertFilesInDatabase', () => {
 
             expect(detectProviderSpy).toHaveBeenCalledTimes(2)
 
-            expect(connectionMock.query).toHaveBeenCalledTimes(2)
-            expect(connectionMock.query).toHaveBeenCalledWith(
-                `DROP VIEW IF EXISTS ${TABLE}`
-            )
+            expect(connectionMock.query).toHaveBeenCalledTimes(1)
             expect(connectionMock.query).toHaveBeenCalledWith(
                 `DROP TABLE IF EXISTS ${RAW_TABLE}`
             )

--- a/app/src/db/queries/insertFilesInDatabase.ts
+++ b/app/src/db/queries/insertFilesInDatabase.ts
@@ -1,5 +1,5 @@
 import { getDB } from '../getDB'
-import { RAW_TABLE, TABLE } from './constants'
+import { RAW_TABLE } from './constants'
 import { tableFromJSON } from 'apache-arrow'
 import { detectProvider } from '../../streamProvider'
 import type { StreamRecord } from '../../streamProvider/types'
@@ -45,7 +45,6 @@ export async function insertFilesInDatabase(files: FileList) {
 
     const { conn } = await getDB()
 
-    await conn.query(`DROP VIEW IF EXISTS ${TABLE}`)
     await conn.query(`DROP TABLE IF EXISTS ${RAW_TABLE}`)
     console.debug(`Table ${RAW_TABLE} dropped.`)
 

--- a/app/src/db/queries/insertUrlInDatabase.test.ts
+++ b/app/src/db/queries/insertUrlInDatabase.test.ts
@@ -8,7 +8,7 @@ import * as dataSignal from '../dataSignal'
 import { mockDB, mockStreamProviderWithSpy } from './__tests__/test-utils'
 
 import type { StreamRecord } from '../../streamProvider/types'
-import { RAW_TABLE, TABLE } from './constants'
+import { RAW_TABLE } from './constants'
 
 describe('insertUrlInDatabase', () => {
     beforeEach(() => {
@@ -120,9 +120,6 @@ describe('insertUrlInDatabase', () => {
             await insertUrlInDatabase(url)
 
             expect(connectionMock.query).toHaveBeenCalledWith(
-                `DROP VIEW IF EXISTS ${TABLE}`
-            )
-            expect(connectionMock.query).toHaveBeenCalledWith(
                 `DROP TABLE IF EXISTS ${RAW_TABLE}`
             )
             expect(connectionMock.insertArrowTable).toHaveBeenCalledTimes(1)
@@ -160,9 +157,6 @@ describe('insertUrlInDatabase', () => {
             await insertUrlInDatabase(url)
 
             expect(processFileSpy).toHaveBeenCalledTimes(1)
-            expect(connectionMock.query).toHaveBeenCalledWith(
-                `DROP VIEW IF EXISTS ${TABLE}`
-            )
             expect(connectionMock.query).toHaveBeenCalledWith(
                 `DROP TABLE IF EXISTS ${RAW_TABLE}`
             )

--- a/app/src/db/queries/insertUrlInDatabase.ts
+++ b/app/src/db/queries/insertUrlInDatabase.ts
@@ -1,5 +1,5 @@
 import { getDB } from '../getDB'
-import { RAW_TABLE, TABLE } from './constants'
+import { RAW_TABLE } from './constants'
 import { tableFromJSON } from 'apache-arrow'
 import { detectProvider } from '../../streamProvider'
 import { precomputeDerivedTables } from '../precompute'
@@ -29,7 +29,6 @@ export async function insertUrlInDatabase(jsonUrl: URL) {
     const arrowTableContent = tableFromJSON(records)
 
     const { conn } = await getDB()
-    await conn.query(`DROP VIEW IF EXISTS ${TABLE}`)
     await conn.query(`DROP TABLE IF EXISTS ${RAW_TABLE}`)
     await conn.insertArrowTable(arrowTableContent, {
         name: RAW_TABLE,

--- a/blog/content/decisions/timezone-aware-timestamps.md
+++ b/blog/content/decisions/timezone-aware-timestamps.md
@@ -85,18 +85,41 @@ Store raw data in `music_streams_raw` (UTC, never modified). Create a DuckDB vie
 
 - View must be recreated whenever the timezone offset changes, which also triggers a precompute rebuild
 - The timezone approximation remains imperfect: users who listened in multiple timezones (travel, relocation) will still see some misattributed streams
+- **DuckDB cannot push date-range predicates (e.g. `year(ts::date) = N`) through the `AT TIME ZONE` shift because of date-boundary correctness, so every chart query pays a full scan plus per-row conversion. Measured impact on a real dataset: queries went from ~300 ms to ~2000 ms (6-7x regression) after switching to the view.**
+
+### Option 6: Materialized table `music_streams` built from `music_streams_raw`
+
+Same shape as Option 5, but `music_streams` is a real table created during `precomputeDerivedTables` via `CREATE TABLE music_streams AS SELECT * EXCLUDE (ts), (ts::TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE '${tz}') AS ts FROM music_streams_raw`. Chart SQL and derived tables remain unchanged because they reference the same `music_streams` name.
+
+**Pros:**
+
+- Zero changes to existing SQL files (same as Option 5)
+- Raw UTC data preserved in `music_streams_raw`, fully reversible
+- Timezone conversion is paid **once at precompute time** instead of on every query: chart query latency returns to the pre-feature baseline (~300 ms range on the reference dataset)
+- Derived tables (`daily_stream_counts`, `stream_sessions`, …) build from a real table, avoiding the same predicate-pushdown limitation during precompute
+
+**Cons:**
+
+- WASM memory now holds both `music_streams_raw` and the materialized `music_streams` (roughly 2x the stream-data footprint). For typical datasets in the 100k-500k row range this is on the order of tens of MB, acceptable client-side
+- A timezone change still triggers a full precompute rebuild (same as Option 5), now slightly more expensive because the main table is rematerialized in addition to the derived tables
 
 ## Decision Outcome
 
-Chosen option: **Option 5 — DuckDB view**, because it requires zero changes to existing SQL queries, preserves the raw UTC data as an immutable source of truth, and reuses the existing precompute lifecycle. The timezone offset defaults to the browser's local timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`) and can be overridden in settings.
+Chosen option: **Option 6 — Materialized table**.
+
+Option 5 (view) was chosen first because it avoided SQL changes and kept the raw data immutable. Both properties also hold for Option 6: chart SQL is unchanged, and `music_streams_raw` remains the untouched source of truth. The pivot is driven by the measured 6-7x query-latency regression introduced by per-row `AT TIME ZONE` evaluation in the view. Paying the conversion once at precompute restores the pre-feature baseline at the cost of a modest extra memory footprint, which is the right trade-off in a client-side WASM context where query responsiveness directly drives the user experience.
+
+The timezone offset defaults to the browser's local timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`) and can be overridden in settings.
 
 ### Consequences
 
 * Good, because all existing chart queries work without modification
 * Good, because the raw data is never mutated and the offset can be changed or removed at any time
+* Good, because chart query latency stays close to the pre-feature baseline (no per-query timezone conversion)
 * Good, because the override mechanism (settings UI + precompute rebuild) is self-contained and client-side
 * Bad, because users who consumed music across multiple timezones will still see approximated results — this limitation is documented in the UI with an informational message on time-sensitive charts
-* Bad, because a timezone change triggers a full precompute rebuild, which adds latency in the settings flow
+* Bad, because a timezone change triggers a full precompute rebuild (including rematerialization of `music_streams`), which adds latency in the settings flow
+* Bad, because WASM memory carries both the raw and the timezone-adjusted copy of the stream data
 
 ## More Information
 


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Every chart query slowed down by 6-7x after the timezone-aware view was introduced (#516). The `music_streams` view applied `AT TIME ZONE 'UTC' AT TIME ZONE '<tz>'` per row, and DuckDB could not push predicates like `year(ts::date) = N` through the timezone shift (date-boundary correctness). Each chart paid a full scan plus conversion. Derived tables built on top of the view inherited the cost during precompute.

Measured on an identical dataset in the DuckDB shell:

| Query | Before regression | Regressed (view) | After fix |
|---|---|---|---|
| `top_artists` (`from music_streams`) | 273 ms | 1497 ms | 293 ms |
| `daily_stream_counts` (precomputed) | 285 ms | 1581 ms | 302 ms |
| Range across 20 queries | 266-445 ms | 1417-3095 ms | 288-415 ms |

## 🎹 Proposal

Replace the `music_streams` view with a materialized table created in `precomputeDerivedTables`. Same timezone formula, same `${table}` placeholder for derived SQL, same lifecycle (rebuild on import or timezone change). The conversion is paid once at precompute time instead of on every query.

Trade-off: WASM memory carries both `music_streams_raw` and the materialized `music_streams`. For 200k rows the extra footprint is on the order of tens of MB, acceptable client-side.

The drop logic for the main table moves into `precompute` so it owns the full lifecycle of `music_streams`. The insert paths only drop `music_streams_raw`.

## 🎶 Comments

The original ADR (`blog/content/decisions/timezone-aware-timestamps.md`, Option 5) selected a view explicitly to keep raw data immutable and avoid mutating SQL. Materializing into a separate table preserves both properties: `music_streams_raw` is still the untouched source of truth, and chart SQL is unchanged.

A follow-up could add a CI regression guard (assert p95 query time on a fixture dataset) so a similar regression is caught earlier.

## 🎤 Test

1. Load a real or synthetic dataset.
2. Open the DuckDB shell tab.
3. Run any chart query against `music_streams` with a `year(ts::date) = N` filter and confirm latency is in the 250-450 ms range (was 1400-3100 ms before this fix).
4. Verify charts render correctly with timezone-adjusted timestamps (hourly distribution, calendar heatmap, sessions).
5. Reload data and confirm precompute rebuilds the table without errors.