### PR TITLE
perf(bundle): lazy-load Lab, Chat and Query tabs

### DIFF
--- a/app/src/components/Results/Results.test.tsx
+++ b/app/src/components/Results/Results.test.tsx
@@ -29,18 +29,16 @@ describe('Results Component', () => {
         expect(screen.queryByText(/Work in Progress/i)).toBeNull()
     })
 
-    it('switches to simple view when Simple button is clicked', async () => {
+    it('switches to lab view when Lab button is clicked', async () => {
         render(<Results />)
-        const simpleButton = screen.getByRole('tab', {
+        const labButton = screen.getByRole('tab', {
             name: '🔬 Lab',
         })
 
-        fireEvent.click(simpleButton)
+        fireEvent.click(labButton)
 
-        // Lab view content should be visible
-        screen.queryByText(/Work in Progress/i)
-
-        // We can check if RangeSlider is present (common) but distinguishing is key.
+        // Lab view is lazy-loaded; wait for it
+        await screen.findByText(/Work in Progress/i)
     })
 
     it('switches to query view when Query button is clicked', async () => {
@@ -48,24 +46,24 @@ describe('Results Component', () => {
 
         fireEvent.click(screen.getByRole('tab', { name: '⌨️ Query' }))
 
-        screen.getByText('⌨️ DuckDB Shell')
+        await screen.findByText('⌨️ DuckDB Shell')
     })
 
-    it('switches to lab view when Lab View button is clicked', async () => {
+    it('switches back to simple view from lab view', async () => {
         render(<Results />)
 
         // First switch to lab view
-        const simpleButton = screen.getByRole('tab', {
+        const labButton = screen.getByRole('tab', {
             name: '🔬 Lab',
         })
-        fireEvent.click(simpleButton)
-        screen.getByText(/Work in Progress/i)
+        fireEvent.click(labButton)
+        await screen.findByText(/Work in Progress/i)
 
         // Then switch back to simple view
-        const labButton = screen.getByRole('tab', {
+        const simpleButton = screen.getByRole('tab', {
             name: '✨ Simple',
         })
-        fireEvent.click(labButton)
+        fireEvent.click(simpleButton)
 
         // Lab View content should not be visible again
         expect(screen.queryByText(/Work in Progress/i)).toBeNull()

--- a/app/src/components/Results/Results.tsx
+++ b/app/src/components/Results/Results.tsx
@@ -1,8 +1,16 @@
-import { LabView } from '../Charts/LabView'
+import { lazy, Suspense, useState } from 'react'
 import { SimpleView } from '../Charts/SimpleView'
-import { ChatView } from '../Charts/ChatView'
-import { QueryView } from '../Charts/QueryView'
-import { useState } from 'react'
+import { Spinner } from '../Spinner/Spinner'
+
+const LabView = lazy(() =>
+    import('../Charts/LabView').then((m) => ({ default: m.LabView }))
+)
+const ChatView = lazy(() =>
+    import('../Charts/ChatView').then((m) => ({ default: m.ChatView }))
+)
+const QueryView = lazy(() =>
+    import('../Charts/QueryView').then((m) => ({ default: m.QueryView }))
+)
 
 type Tab = 'simple' | 'lab' | 'chat' | 'query'
 
@@ -65,15 +73,23 @@ export function Results() {
             </div>
 
             <div>
-                {activeTab === 'simple' ? (
-                    <SimpleView />
-                ) : activeTab === 'lab' ? (
-                    <LabView />
-                ) : activeTab === 'query' ? (
-                    <QueryView />
-                ) : (
-                    <ChatView />
-                )}
+                <Suspense
+                    fallback={
+                        <div className="flex justify-center py-12">
+                            <Spinner />
+                        </div>
+                    }
+                >
+                    {activeTab === 'simple' ? (
+                        <SimpleView />
+                    ) : activeTab === 'lab' ? (
+                        <LabView />
+                    ) : activeTab === 'query' ? (
+                        <QueryView />
+                    ) : (
+                        <ChatView />
+                    )}
+                </Suspense>
             </div>
         </div>
     )


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The Results component imported every tab view eagerly. The initial bundle therefore shipped all 30+ chart components, Observable Plot, d3 and the DuckDB shell even though most users land on the Simple tab and may never open Lab, Chat or Query. Initial JS payload was 252 KB gzipped, above the 200 KB budget commonly used for client-side bundles.

## 🎹 Proposal

Convert `LabView`, `ChatView` and `QueryView` to `React.lazy` imports and wrap the tab area in a single `Suspense` boundary that reuses the existing `Spinner` as fallback. `SimpleView` stays eager because it is the default tab and must render without a visible delay.

Vite produces three lazy chunks plus one shared chunk used by Lab and Chat:

| Chunk             | Before | After  | Loading                               |
|-------------------|--------|--------|---------------------------------------|
| App (main)        | 195 KB | 77 KB  | eager                                 |
| shared (Lab/Chat) | —      | 101 KB | lazy, only when Lab or Chat opens     |
| LabView           | —      | 11 KB  | lazy                                  |
| ChatView          | —      | 6 KB   | lazy                                  |
| QueryView         | —      | 1.4 KB | lazy                                  |
| **Initial JS**    | 252 KB | 138 KB | **-45% (-114 KB gzipped)**            |

Tab navigation cost on first activation: Lab 112 KB, Chat 6 KB (if Lab already opened) or 107 KB cold, Query 1.4 KB.

## 🎶 Comments

Tests under `Results.test.tsx` switched to `findByText` after tab clicks to await Suspense resolution, since lazy chunks resolve asynchronously even when mocked.

A follow-up could split heavier SimpleView charts further or extract `Observable Plot` and `d3` into a dedicated shared chunk, but the present split already brings initial payload comfortably under the 200 KB gzipped budget.

## 🎤 Test

1. Build the app and confirm that `dist/_astro/` contains separate `LabView.*.js`, `ChatView.*.js` and `QueryView.*.js` chunks.
2. Open the network tab in a fresh page load: only the eager App chunk + React client + small shared chunk should load (~138 KB gzipped).
3. Click the Lab tab and confirm the lazy chunks (LabView + shared) load on demand. Verify the Spinner shows briefly during fetch.
4. Click Chat and Query in turn and verify each loads its lazy chunk without breaking.
5. Switch back to Simple and confirm no extra fetches occur.