### PR TITLE
perf(query+render): cache DB queries and memoize charts

### DIFF
--- a/app/src/components/Charts/LabView.tsx
+++ b/app/src/components/Charts/LabView.tsx
@@ -1,8 +1,8 @@
-import { StreamTimeline } from './LabCharts/StreamTimeline'
-import { StreamVariety } from './LabCharts/StreamVariety'
-import { StreamDiscovery } from './LabCharts/StreamDiscovery'
+import { StreamTimeline as StreamTimelineRaw } from './LabCharts/StreamTimeline'
+import { StreamVariety as StreamVarietyRaw } from './LabCharts/StreamVariety'
+import { StreamDiscovery as StreamDiscoveryRaw } from './LabCharts/StreamDiscovery'
 import { YearSidebar } from '../YearSidebar/YearSidebar'
-import { useState, useEffect, useCallback } from 'react'
+import { memo, useState, useEffect, useCallback } from 'react'
 import {
     summarizeQuery,
     type SummarizeDataQueryResult,
@@ -10,14 +10,26 @@ import {
 import { queryDBAsJSON } from '../../db/queries/queryDB'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import { DATA_LOADED_EVENT } from '../../db/dataSignal'
-import { ListeningStreaks } from './LabCharts/ListeningStreaks'
-import { Top10Evolution } from './LabCharts/Top10Evolution'
-import { Top10AlbumsEvolution } from './LabCharts/Top10AlbumsEvolution'
-import { Top10TracksEvolution } from './LabCharts/Top10TracksEvolution'
-import { ListeningBingo } from './LabCharts/ListeningBingo'
-import { Top10Race } from './LabCharts/Top10Race'
-import { Top10BillboardRace } from './LabCharts/Top10BillboardRace'
-import { SessionAnalysis as SessionAnalysisDetailed } from './LabCharts/SessionAnalysis'
+import { ListeningStreaks as ListeningStreaksRaw } from './LabCharts/ListeningStreaks'
+import { Top10Evolution as Top10EvolutionRaw } from './LabCharts/Top10Evolution'
+import { Top10AlbumsEvolution as Top10AlbumsEvolutionRaw } from './LabCharts/Top10AlbumsEvolution'
+import { Top10TracksEvolution as Top10TracksEvolutionRaw } from './LabCharts/Top10TracksEvolution'
+import { ListeningBingo as ListeningBingoRaw } from './LabCharts/ListeningBingo'
+import { Top10Race as Top10RaceRaw } from './LabCharts/Top10Race'
+import { Top10BillboardRace as Top10BillboardRaceRaw } from './LabCharts/Top10BillboardRace'
+import { SessionAnalysis as SessionAnalysisDetailedRaw } from './LabCharts/SessionAnalysis'
+
+const StreamTimeline = memo(StreamTimelineRaw)
+const StreamVariety = memo(StreamVarietyRaw)
+const StreamDiscovery = memo(StreamDiscoveryRaw)
+const ListeningStreaks = memo(ListeningStreaksRaw)
+const Top10Evolution = memo(Top10EvolutionRaw)
+const Top10AlbumsEvolution = memo(Top10AlbumsEvolutionRaw)
+const Top10TracksEvolution = memo(Top10TracksEvolutionRaw)
+const ListeningBingo = memo(ListeningBingoRaw)
+const Top10Race = memo(Top10RaceRaw)
+const Top10BillboardRace = memo(Top10BillboardRaceRaw)
+const SessionAnalysisDetailed = memo(SessionAnalysisDetailedRaw)
 
 export function LabView() {
     const [year, setYear] = useState<number | undefined>(2006)

--- a/app/src/components/Charts/SimpleView.tsx
+++ b/app/src/components/Charts/SimpleView.tsx
@@ -1,33 +1,55 @@
-import { ConcentrationScore } from './SimpleCharts/ConcentrationScore'
-import { ListeningRhythm } from './SimpleCharts/ListeningRhythm'
-import { Regularity } from './SimpleCharts/Regularity'
-import { SeasonalPatterns } from './SimpleCharts/SeasonalPatterns'
-import { EvolutionOverTime } from './SimpleCharts/EvolutionOverTime'
-import { NewVsOld } from './SimpleCharts/NewVsOld'
-import { SkipRate } from './SimpleCharts/SkipRate'
-import { RepeatBehavior } from './SimpleCharts/RepeatBehavior'
-import { FunFacts } from './SimpleCharts/FunFacts'
-import { PrincipalPlatform } from './SimpleCharts/PrincipalPlatform'
-import { ArtistLoyalty } from './SimpleCharts/ArtistLoyalty'
-import { FavoriteWeekday } from './SimpleCharts/FavoriteWeekday'
-import { UnbeatableStreak } from './SimpleCharts/UnbeatableStreak'
-import { BingeListener } from './SimpleCharts/BingeListener'
-import { VarietyDay } from './SimpleCharts/VarietyDay'
-import { CalendarHeatmap } from './SimpleCharts/CalendarHeatmap'
-import { HourlyStreams } from './SimpleCharts/HourlyStreams'
-import { SessionAnalysis } from './SimpleCharts/SessionAnalysis'
-import { TopArtists } from './SimpleCharts/TopArtists'
-import { TopAlbums } from './SimpleCharts/TopAlbums'
-import { TopTracks } from './SimpleCharts/TopTracks'
+import { ConcentrationScore as ConcentrationScoreRaw } from './SimpleCharts/ConcentrationScore'
+import { ListeningRhythm as ListeningRhythmRaw } from './SimpleCharts/ListeningRhythm'
+import { Regularity as RegularityRaw } from './SimpleCharts/Regularity'
+import { SeasonalPatterns as SeasonalPatternsRaw } from './SimpleCharts/SeasonalPatterns'
+import { EvolutionOverTime as EvolutionOverTimeRaw } from './SimpleCharts/EvolutionOverTime'
+import { NewVsOld as NewVsOldRaw } from './SimpleCharts/NewVsOld'
+import { SkipRate as SkipRateRaw } from './SimpleCharts/SkipRate'
+import { RepeatBehavior as RepeatBehaviorRaw } from './SimpleCharts/RepeatBehavior'
+import { FunFacts as FunFactsRaw } from './SimpleCharts/FunFacts'
+import { PrincipalPlatform as PrincipalPlatformRaw } from './SimpleCharts/PrincipalPlatform'
+import { ArtistLoyalty as ArtistLoyaltyRaw } from './SimpleCharts/ArtistLoyalty'
+import { FavoriteWeekday as FavoriteWeekdayRaw } from './SimpleCharts/FavoriteWeekday'
+import { UnbeatableStreak as UnbeatableStreakRaw } from './SimpleCharts/UnbeatableStreak'
+import { BingeListener as BingeListenerRaw } from './SimpleCharts/BingeListener'
+import { VarietyDay as VarietyDayRaw } from './SimpleCharts/VarietyDay'
+import { CalendarHeatmap as CalendarHeatmapRaw } from './SimpleCharts/CalendarHeatmap'
+import { HourlyStreams as HourlyStreamsRaw } from './SimpleCharts/HourlyStreams'
+import { SessionAnalysis as SessionAnalysisRaw } from './SimpleCharts/SessionAnalysis'
+import { TopArtists as TopArtistsRaw } from './SimpleCharts/TopArtists'
+import { TopAlbums as TopAlbumsRaw } from './SimpleCharts/TopAlbums'
+import { TopTracks as TopTracksRaw } from './SimpleCharts/TopTracks'
 import { YearSidebar } from '../YearSidebar/YearSidebar'
 import { queryDBAsJSON } from '../../db/queries/queryDB'
 import {
     type SummarizeDataQueryResult,
     summarizeQuery,
 } from './Summarize/summarizeQuery'
-import { useState, useEffect, useCallback } from 'react'
+import { memo, useState, useEffect, useCallback } from 'react'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import { DATA_LOADED_EVENT } from '../../db/dataSignal'
+
+const ConcentrationScore = memo(ConcentrationScoreRaw)
+const ListeningRhythm = memo(ListeningRhythmRaw)
+const Regularity = memo(RegularityRaw)
+const SeasonalPatterns = memo(SeasonalPatternsRaw)
+const EvolutionOverTime = memo(EvolutionOverTimeRaw)
+const NewVsOld = memo(NewVsOldRaw)
+const SkipRate = memo(SkipRateRaw)
+const RepeatBehavior = memo(RepeatBehaviorRaw)
+const FunFacts = memo(FunFactsRaw)
+const PrincipalPlatform = memo(PrincipalPlatformRaw)
+const ArtistLoyalty = memo(ArtistLoyaltyRaw)
+const FavoriteWeekday = memo(FavoriteWeekdayRaw)
+const UnbeatableStreak = memo(UnbeatableStreakRaw)
+const BingeListener = memo(BingeListenerRaw)
+const VarietyDay = memo(VarietyDayRaw)
+const CalendarHeatmap = memo(CalendarHeatmapRaw)
+const HourlyStreams = memo(HourlyStreamsRaw)
+const SessionAnalysis = memo(SessionAnalysisRaw)
+const TopArtists = memo(TopArtistsRaw)
+const TopAlbums = memo(TopAlbumsRaw)
+const TopTracks = memo(TopTracksRaw)
 
 export function SimpleView() {
     const [year, setYear] = useState<number | undefined>(undefined)

--- a/app/src/db/queries/queryDBCached.test.ts
+++ b/app/src/db/queries/queryDBCached.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+    queryDBCached,
+    getCachedResult,
+    clearQueryCache,
+} from './queryDBCached'
+import * as queryDB from './queryDB'
+import { DATA_LOADED_EVENT } from '../dataSignal'
+
+type Row = { id: number }
+
+describe('queryDBCached', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        clearQueryCache()
+    })
+
+    it('runs the query on first call and caches the result', async () => {
+        const spy = vi
+            .spyOn(queryDB, 'queryDBAsJSON')
+            .mockResolvedValue([{ id: 1 }])
+
+        const rows = await queryDBCached<Row>('SELECT 1')
+        expect(rows).toEqual([{ id: 1 }])
+        expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns the cached result on the second call without re-running the query', async () => {
+        const spy = vi
+            .spyOn(queryDB, 'queryDBAsJSON')
+            .mockResolvedValue([{ id: 1 }])
+
+        await queryDBCached<Row>('SELECT 1')
+        await queryDBCached<Row>('SELECT 1')
+
+        expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it('exposes a synchronous getter for cached results', async () => {
+        vi.spyOn(queryDB, 'queryDBAsJSON').mockResolvedValue([{ id: 42 }])
+
+        expect(getCachedResult<Row>('SELECT 1')).toBeUndefined()
+        await queryDBCached<Row>('SELECT 1')
+        expect(getCachedResult<Row>('SELECT 1')).toEqual([{ id: 42 }])
+    })
+
+    it('dedupes concurrent identical queries by sharing the in-flight promise', async () => {
+        let resolveQuery!: (rows: Row[]) => void
+        const pending = new Promise<Row[]>((res) => {
+            resolveQuery = res
+        })
+        const spy = vi.spyOn(queryDB, 'queryDBAsJSON').mockReturnValue(pending)
+
+        const a = queryDBCached<Row>('SELECT 1')
+        const b = queryDBCached<Row>('SELECT 1')
+
+        expect(spy).toHaveBeenCalledTimes(1)
+
+        resolveQuery([{ id: 7 }])
+        await expect(a).resolves.toEqual([{ id: 7 }])
+        await expect(b).resolves.toEqual([{ id: 7 }])
+    })
+
+    it('does not cache errors, retries on the next call', async () => {
+        const spy = vi.spyOn(queryDB, 'queryDBAsJSON')
+        spy.mockRejectedValueOnce(new Error('boom'))
+        spy.mockResolvedValueOnce([{ id: 1 }])
+
+        await expect(queryDBCached<Row>('SELECT 1')).rejects.toThrow('boom')
+        await expect(queryDBCached<Row>('SELECT 1')).resolves.toEqual([
+            { id: 1 },
+        ])
+        expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('clears the cache on DATA_LOADED_EVENT', async () => {
+        const spy = vi
+            .spyOn(queryDB, 'queryDBAsJSON')
+            .mockResolvedValue([{ id: 1 }])
+
+        await queryDBCached<Row>('SELECT 1')
+        expect(getCachedResult<Row>('SELECT 1')).toBeDefined()
+
+        window.dispatchEvent(new CustomEvent(DATA_LOADED_EVENT))
+
+        expect(getCachedResult<Row>('SELECT 1')).toBeUndefined()
+        await queryDBCached<Row>('SELECT 1')
+        expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('caches by SQL string, distinct queries are stored separately', async () => {
+        const spy = vi.spyOn(queryDB, 'queryDBAsJSON')
+        spy.mockResolvedValueOnce([{ id: 2024 }])
+        spy.mockResolvedValueOnce([{ id: 2025 }])
+
+        const a = await queryDBCached<Row>('SELECT 2024')
+        const b = await queryDBCached<Row>('SELECT 2025')
+
+        expect(a).toEqual([{ id: 2024 }])
+        expect(b).toEqual([{ id: 2025 }])
+        expect(spy).toHaveBeenCalledTimes(2)
+
+        await queryDBCached<Row>('SELECT 2024')
+        await queryDBCached<Row>('SELECT 2025')
+        expect(spy).toHaveBeenCalledTimes(2)
+    })
+})

--- a/app/src/db/queries/queryDBCached.ts
+++ b/app/src/db/queries/queryDBCached.ts
@@ -1,0 +1,48 @@
+import { queryDBAsJSON } from './queryDB'
+import { DATA_LOADED_EVENT } from '../dataSignal'
+
+type DBRow = Record<string, string | number | null | undefined>
+
+const inFlight = new Map<string, Promise<unknown[]>>()
+const resolved = new Map<string, unknown[]>()
+
+if (typeof window !== 'undefined') {
+    window.addEventListener(DATA_LOADED_EVENT, () => {
+        inFlight.clear()
+        resolved.clear()
+    })
+}
+
+export function getCachedResult<T extends DBRow>(sql: string): T[] | undefined {
+    return resolved.get(sql) as T[] | undefined
+}
+
+export function queryDBCached<T extends DBRow>(
+    sql: string,
+    source?: string
+): Promise<T[]> {
+    const cached = resolved.get(sql)
+    if (cached) return Promise.resolve(cached as T[])
+
+    const ongoing = inFlight.get(sql) as Promise<T[]> | undefined
+    if (ongoing) return ongoing
+
+    const promise = queryDBAsJSON<T>(sql, source)
+        .then((rows) => {
+            resolved.set(sql, rows)
+            inFlight.delete(sql)
+            return rows
+        })
+        .catch((e) => {
+            inFlight.delete(sql)
+            throw e
+        })
+
+    inFlight.set(sql, promise)
+    return promise
+}
+
+export function clearQueryCache(): void {
+    inFlight.clear()
+    resolved.clear()
+}

--- a/app/src/hooks/useDBQuery.test.ts
+++ b/app/src/hooks/useDBQuery.test.ts
@@ -2,6 +2,7 @@ import { renderHook, waitFor, act } from '@testing-library/react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useDBQueryFirst, useDBQueryMany } from './useDBQuery'
 import * as queryDB from '../db/queries/queryDB'
+import { clearQueryCache } from '../db/queries/queryDBCached'
 import { DATA_LOADED_EVENT } from '../db/dataSignal'
 
 type User = { id: number; name?: string; year?: number }
@@ -9,6 +10,7 @@ type User = { id: number; name?: string; year?: number }
 describe('useDBQueryMany', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        clearQueryCache()
     })
 
     it('should start loading initially', () => {
@@ -88,6 +90,7 @@ describe('useDBQueryMany', () => {
 describe('useDBQueryFirst', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        clearQueryCache()
     })
 
     it('should return only the first row', async () => {
@@ -129,6 +132,7 @@ describe('useDBQueryFirst', () => {
 describe('stale-while-revalidate', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        clearQueryCache()
     })
 
     it('keeps isLoading false during refetch after initial load', async () => {
@@ -210,6 +214,7 @@ describe('stale-while-revalidate', () => {
 describe('shared behavior', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        clearQueryCache()
     })
 
     it('should refetch when year changes', async () => {

--- a/app/src/hooks/useDBQuery.ts
+++ b/app/src/hooks/useDBQuery.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { queryDBAsJSON } from '../db/queries/queryDB'
+import { queryDBCached, getCachedResult } from '../db/queries/queryDBCached'
 import { DATA_LOADED_EVENT } from '../db/dataSignal'
 import { resolveCallerSource } from '../devToolbar/resolveCallerSource'
 
@@ -22,11 +22,12 @@ export function useDBQueryMany<T extends DBRow>({
     year,
 }: BaseOptions): UseDBQueryResult<T[]> {
     const source = resolveCallerSource()
-    const [data, setData] = useState<T[] | undefined>(undefined)
-    const [isLoading, setIsLoading] = useState(true)
+    const cachedInitial = getCachedResult<T>(query)
+    const [data, setData] = useState<T[] | undefined>(cachedInitial)
+    const [isLoading, setIsLoading] = useState(cachedInitial === undefined)
     const [error, setError] = useState<Error | undefined>(undefined)
     const requestIdRef = useRef(0)
-    const hasLoadedRef = useRef(false)
+    const hasLoadedRef = useRef(cachedInitial !== undefined)
     const [triggerRefetch, setTriggerRefetch] = useState(0)
 
     useEffect(() => {
@@ -42,12 +43,21 @@ export function useDBQueryMany<T extends DBRow>({
     useEffect(() => {
         const id = ++requestIdRef.current
 
+        const cached = getCachedResult<T>(query)
+        if (cached) {
+            setData(cached)
+            setError(undefined)
+            setIsLoading(false)
+            hasLoadedRef.current = true
+            return
+        }
+
         const fetchData = async () => {
             setIsLoading(!hasLoadedRef.current)
             setError(undefined)
 
             try {
-                const rows = await queryDBAsJSON<T>(query, source)
+                const rows = await queryDBCached<T>(query, source)
                 if (id === requestIdRef.current) {
                     setData(rows)
                     hasLoadedRef.current = true


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Two sources of avoidable work hit every year-sidebar interaction:

1. `useDBQueryMany` re-ran every SQL string on every mount and on every year change. Going from 2024 to 2025 then back to 2024 reissued 20+ identical queries against DuckDB even though the data had not changed.
2. None of the 30+ chart wrappers were memoized. Unrelated state changes inside `SimpleView` or `LabView` (summarize load, debounce tick, year sidebar bookkeeping) re-rendered every chart wrapper even when its year prop was unchanged.

DuckDB WASM exposes a single connection, so any redundant query also blocks the others in a sequential queue: paying for the same SQL twice penalizes every subsequent chart on the page.

## 🎹 Proposal

**Cache layer (`queryDBCached`)** on top of `queryDBAsJSON`:

- Resolved results are cached by exact SQL string
- Concurrent calls for the same SQL share a single in-flight promise (the first call dedupes the rest)
- Failed queries are evicted so the next call retries
- The cache is cleared when a new dataset is loaded (`DATA_LOADED_EVENT`)

`useDBQueryMany` performs a **synchronous** cache lookup on entry: revisiting a previously seen year now renders without any async hop. Direct callers of `queryDBAsJSON` (Chat, DuckDB shell) stay uncached because they may run user-driven SQL.

**`React.memo` on chart components** at the call site in `SimpleView` and `LabView` via `Raw`-suffixed import aliases. Each chart takes a single primitive prop (typically `year`), so shallow comparison is safe and effective. Containing the change to two files keeps each chart's own module untouched.

## 🎶 Comments

The cache could be measured further with a small in-app counter, but the behavior is observable in the DevTools network/console: switching years back and forth no longer triggers DuckDB telemetry on `devBus` once a query has been seen.

A follow-up could push the cache key to include a dataset version so that partial re-imports could invalidate selectively, but with the current full-rebuild import flow the event-based clear is sufficient.

## 🎤 Test

1. Load any dataset.
2. Open the Simple tab, change the year sidebar to year A. Confirm queries fire in the DuckDB query telemetry (devBus).
3. Change the year to B. New queries fire.
4. Change back to A. **No queries fire**, charts render instantly.
5. Trigger a data reload (re-upload). All caches clear; queries fire again on first interaction.
6. Run a query manually in the Query tab. Confirm it is **not** cached (re-running shows it executes again).