### PR TITLE
feat(devToolbar): raise query history cap to 50

### DIFF
--- a/app/src/devToolbar/tracksyToolbar.ts
+++ b/app/src/devToolbar/tracksyToolbar.ts
@@ -6,7 +6,7 @@ const PREFIX = 'tracksy:dev:'
 type DuckDBEntry = DevBusEventMap['duckdb:query'] & { ts: number }
 type InferenceEntry = DevBusEventMap['webllm:inference'] & { ts: number }
 
-const MAX_QUERIES = 20
+const MAX_QUERIES = 50
 
 // Styles for slot content inside astro-dev-toolbar-window.
 // Positioning, background, border, shadow, and z-index are all owned by the

--- a/app/src/devToolbar/tracksyToolbar.ts
+++ b/app/src/devToolbar/tracksyToolbar.ts
@@ -54,6 +54,7 @@ export default defineToolbarApp({
 
         // --- State ---
         const queries: DuckDBEntry[] = []
+        let totalQueries = 0
         let loadState: DevBusEventMap['webllm:load'] | null = null
         let lastInference: InferenceEntry | null = null
         let lastStream:
@@ -112,7 +113,7 @@ export default defineToolbarApp({
         function render(): void {
             sections.innerHTML = `
           <div class="section">
-            <div class="section-header">DuckDB — ${queries.length} queries</div>
+            <div class="section-header">DuckDB — ${totalQueries > MAX_QUERIES ? `last ${MAX_QUERIES} of ${totalQueries} queries` : `${totalQueries} ${totalQueries === 1 ? 'query' : 'queries'}`}</div>
             <div class="section-body">${renderDuckDB()}</div>
           </div>
           <div class="section">
@@ -139,6 +140,7 @@ export default defineToolbarApp({
 
         listen('duckdb:query', (d) => {
             queries.push({ ...d, ts: Date.now() })
+            totalQueries++
             if (queries.length > MAX_QUERIES) queries.shift()
             render()
         })


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The devToolbar DuckDB section was capped at 20 queries. SimpleView fires 21+ chart queries per page render, so the history wrapped before a full session was visible. Once the buffer filled, the counter appeared frozen at 20 with no indication that older entries were being dropped.

## 🎹 Proposal

Raise `MAX_QUERIES` from 20 to 50. Track total query count separately so the header shows "last 50 of 123 queries" once the ring buffer is full, making the capping behaviour explicit. No layout impact as the section already scrolls.

## 🎶 Comments

Closes #449

## 🎤 Test

Open the devToolbar DuckDB section on SimpleView and verify:
- query count increments normally up to 50
- beyond 50, the header reads "last 50 of N queries" and keeps updating