### PR TITLE
feat(devToolbar): automatic source attribution for DuckDB queries

### DIFF
--- a/app/src/db/queries/queryDB.test.ts
+++ b/app/src/db/queries/queryDB.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { AsyncDuckDB, AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
 import * as db from '../getDB'
+import * as devBusModule from '../../devToolbar/devBus'
 import { queryDBAsJSON } from './queryDB'
 
 describe('queryDBAsJSON', () => {
@@ -13,6 +14,7 @@ describe('queryDBAsJSON', () => {
             conn: mockConnection,
             db: {} as unknown as AsyncDuckDB,
         })
+        vi.spyOn(devBusModule.devBus, 'emit').mockImplementation(() => {})
         vi.clearAllMocks()
     })
 
@@ -38,5 +40,37 @@ describe('queryDBAsJSON', () => {
 
         expect(mockConnection.query).toHaveBeenCalledWith(query)
         expect(result).toEqual(mockData)
+    })
+
+    it('emits duckdb:query event with source when provided', async () => {
+        const mockTable = {
+            toArray: () => [{ toJSON: () => ({ x: 1 }) }],
+        }
+        ;(mockConnection.query as ReturnType<typeof vi.fn>).mockResolvedValue(
+            mockTable
+        )
+
+        await queryDBAsJSON('SELECT 1', 'MyComponent')
+
+        expect(devBusModule.devBus.emit).toHaveBeenCalledWith(
+            'duckdb:query',
+            expect.objectContaining({ source: 'MyComponent' })
+        )
+    })
+
+    it('emits duckdb:query event with source=undefined when not provided and no components/ frame in stack', async () => {
+        const mockTable = {
+            toArray: () => [],
+        }
+        ;(mockConnection.query as ReturnType<typeof vi.fn>).mockResolvedValue(
+            mockTable
+        )
+
+        await queryDBAsJSON('SELECT 1')
+
+        expect(devBusModule.devBus.emit).toHaveBeenCalledWith(
+            'duckdb:query',
+            expect.objectContaining({ source: undefined })
+        )
     })
 })

--- a/app/src/db/queries/queryDB.ts
+++ b/app/src/db/queries/queryDB.ts
@@ -1,9 +1,13 @@
 import { getDB } from '../getDB'
 import { devBus } from '../../devToolbar/devBus'
+import { parseCallerFrame } from '../../devToolbar/parseCallerFrame'
 
 export async function queryDBAsJSON<
     T extends Record<string, string | number | null | undefined>,
->(query: string): Promise<T[]> {
+>(query: string, source?: string): Promise<T[]> {
+    const resolvedSource =
+        source ??
+        (import.meta.env.DEV ? parseCallerFrame(new Error().stack) : undefined)
     const { conn } = await getDB()
     const start = performance.now()
     try {
@@ -13,6 +17,7 @@ export async function queryDBAsJSON<
             sql: query,
             durationMs: performance.now() - start,
             rowCount: jsonResult.length,
+            source: resolvedSource,
         })
         return jsonResult as T[]
     } catch (e) {
@@ -20,6 +25,7 @@ export async function queryDBAsJSON<
             sql: query,
             durationMs: performance.now() - start,
             rowCount: 0,
+            source: resolvedSource,
             error: String(e),
         })
         throw e

--- a/app/src/db/queries/queryDB.ts
+++ b/app/src/db/queries/queryDB.ts
@@ -1,13 +1,11 @@
 import { getDB } from '../getDB'
 import { devBus } from '../../devToolbar/devBus'
-import { parseCallerFrame } from '../../devToolbar/parseCallerFrame'
+import { resolveCallerSource } from '../../devToolbar/resolveCallerSource'
 
 export async function queryDBAsJSON<
     T extends Record<string, string | number | null | undefined>,
 >(query: string, source?: string): Promise<T[]> {
-    const resolvedSource =
-        source ??
-        (import.meta.env.DEV ? parseCallerFrame(new Error().stack) : undefined)
+    const resolvedSource = source ?? resolveCallerSource()
     const { conn } = await getDB()
     const start = performance.now()
     try {

--- a/app/src/devToolbar/devBus.test.ts
+++ b/app/src/devToolbar/devBus.test.ts
@@ -72,6 +72,22 @@ describe('devBus', () => {
         expect(calls).toHaveLength(1)
     })
 
+    it('passes source field through for duckdb:query', () => {
+        vi.stubEnv('DEV', true)
+
+        const received: unknown[] = []
+        const off = devBus.on('duckdb:query', (d) => received.push(d))
+        devBus.emit('duckdb:query', {
+            sql: 'SELECT 1',
+            durationMs: 1,
+            rowCount: 1,
+            source: 'StreamDiscovery',
+        })
+        off()
+
+        expect(received[0]).toMatchObject({ source: 'StreamDiscovery' })
+    })
+
     it('passes error field through for duckdb:query', () => {
         vi.stubEnv('DEV', true)
 

--- a/app/src/devToolbar/devBus.ts
+++ b/app/src/devToolbar/devBus.ts
@@ -3,6 +3,7 @@ type DevBusEventMap = {
         sql: string
         durationMs: number
         rowCount: number
+        source?: string
         error?: string
     }
     'webllm:load': { model: string; progress: number; text: string }

--- a/app/src/devToolbar/parseCallerFrame.test.ts
+++ b/app/src/devToolbar/parseCallerFrame.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { parseCallerFrame } from './parseCallerFrame'
+
+describe('parseCallerFrame', () => {
+    it('extracts parent dir name for index.tsx files', () => {
+        const stack = `Error\n    at http://localhost:4321/src/components/Charts/LabCharts/StreamDiscovery/index.tsx:22:10`
+        expect(parseCallerFrame(stack)).toBe('StreamDiscovery')
+    })
+
+    it('extracts filename stem for named files', () => {
+        const stack = `Error\n    at http://localhost:4321/src/components/Charts/LabView.tsx:32:5`
+        expect(parseCallerFrame(stack)).toBe('LabView')
+    })
+
+    it('extracts deeply nested index.tsx', () => {
+        const stack = `Error\n    at http://localhost:4321/src/components/Charts/LabCharts/Top10Evolution/index.tsx:11:10`
+        expect(parseCallerFrame(stack)).toBe('Top10Evolution')
+    })
+
+    it('returns undefined when no components/ frame', () => {
+        const stack = `Error\n    at fetchData (hooks/useDBQuery.ts:48:5)`
+        expect(parseCallerFrame(stack)).toBeUndefined()
+    })
+
+    it('returns undefined for undefined input', () => {
+        expect(parseCallerFrame(undefined)).toBeUndefined()
+    })
+
+    it('skips non-component frames and finds the right one', () => {
+        const stack = [
+            'Error',
+            '    at queryDBAsJSON (queryDB.ts:9:5)',
+            '    at fetchData (hooks/useDBQuery.ts:48:5)',
+            '    at http://localhost:4321/src/components/Charts/LabCharts/FunFacts/index.tsx:36:10',
+        ].join('\n')
+        expect(parseCallerFrame(stack)).toBe('FunFacts')
+    })
+})

--- a/app/src/devToolbar/parseCallerFrame.ts
+++ b/app/src/devToolbar/parseCallerFrame.ts
@@ -1,0 +1,12 @@
+export function parseCallerFrame(
+    stack: string | undefined
+): string | undefined {
+    if (!stack) return undefined
+    for (const line of stack.split('\n')) {
+        let match = line.match(/components\/(?:.+\/)?([^/]+)\/index\.tsx?:\d+/)
+        if (match) return match[1]
+        match = line.match(/components\/(?:.+\/)?([^/]+)\.tsx?:\d+/)
+        if (match) return match[1]
+    }
+    return undefined
+}

--- a/app/src/devToolbar/resolveCallerSource.test.ts
+++ b/app/src/devToolbar/resolveCallerSource.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { resolveCallerSource } from './resolveCallerSource'
+
+describe('resolveCallerSource', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    it('returns undefined in production build', () => {
+        vi.stubEnv('DEV', false)
+        expect(resolveCallerSource()).toBeUndefined()
+    })
+
+    it('returns undefined in DEV when no components/ frame in stack', () => {
+        vi.stubEnv('DEV', true)
+        // Called from a test frame, not a components/ path.
+        expect(resolveCallerSource()).toBeUndefined()
+    })
+})

--- a/app/src/devToolbar/resolveCallerSource.ts
+++ b/app/src/devToolbar/resolveCallerSource.ts
@@ -1,0 +1,9 @@
+import { parseCallerFrame } from './parseCallerFrame'
+
+/**
+ * Resolve the calling component name from the current stack, in DEV only.
+ * Returns undefined in production builds so no `new Error().stack` cost is paid.
+ */
+export function resolveCallerSource(): string | undefined {
+    return import.meta.env.DEV ? parseCallerFrame(new Error().stack) : undefined
+}

--- a/app/src/devToolbar/tracksyToolbar.ts
+++ b/app/src/devToolbar/tracksyToolbar.ts
@@ -23,6 +23,7 @@ const STYLES = `
   .badge-time { background: #1d4ed8; color: #bfdbfe; }
   .badge-rows { background: #166534; color: #bbf7d0; }
   .badge-error { background: #991b1b; color: #fecaca; }
+  .source { color: rgba(148, 163, 184, 0.5); white-space: nowrap; font-size: 10px; min-width: 80px; }
   .kv { display: flex; gap: 8px; align-items: center; }
   .kv-label { color: rgba(148, 163, 184, 1); }
   .kv-value { color: #f8fafc; font-weight: 600; font-family: ui-monospace, monospace; }
@@ -75,6 +76,7 @@ export default defineToolbarApp({
                 .map(
                     (q) => `
               <div class="row">
+                ${q.source ? `<span class="source">${q.source}</span>` : ''}
                 <span class="sql" title="${q.sql.replace(/"/g, '&quot;')}">${q.sql}</span>
                 <span class="badge badge-time">${fmt(q.durationMs)}</span>
                 <span class="badge badge-rows">${q.rowCount} rows</span>

--- a/app/src/hooks/useDBQuery.test.ts
+++ b/app/src/hooks/useDBQuery.test.ts
@@ -41,7 +41,10 @@ describe('useDBQueryMany', () => {
 
         expect(result.current.isLoading).toBe(false)
         expect(result.current.error).toBeUndefined()
-        expect(queryDB.queryDBAsJSON).toHaveBeenCalledWith('SELECT * FROM test')
+        expect(queryDB.queryDBAsJSON).toHaveBeenCalledWith(
+            'SELECT * FROM test',
+            undefined
+        )
     })
 
     it('should return empty array when DB returns empty', async () => {

--- a/app/src/hooks/useDBQuery.ts
+++ b/app/src/hooks/useDBQuery.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { queryDBAsJSON } from '../db/queries/queryDB'
 import { DATA_LOADED_EVENT } from '../db/dataSignal'
+import { parseCallerFrame } from '../devToolbar/parseCallerFrame'
 
 type DBPrimitive = string | number | null
 type DBRow = Record<string, DBPrimitive>
@@ -20,6 +21,9 @@ export function useDBQueryMany<T extends DBRow>({
     query,
     year,
 }: BaseOptions): UseDBQueryResult<T[]> {
+    const source = import.meta.env.DEV
+        ? parseCallerFrame(new Error().stack)
+        : undefined
     const [data, setData] = useState<T[] | undefined>(undefined)
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState<Error | undefined>(undefined)
@@ -45,7 +49,7 @@ export function useDBQueryMany<T extends DBRow>({
             setError(undefined)
 
             try {
-                const rows = await queryDBAsJSON<T>(query)
+                const rows = await queryDBAsJSON<T>(query, source)
                 if (id === requestIdRef.current) {
                     setData(rows)
                     hasLoadedRef.current = true

--- a/app/src/hooks/useDBQuery.ts
+++ b/app/src/hooks/useDBQuery.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { queryDBAsJSON } from '../db/queries/queryDB'
 import { DATA_LOADED_EVENT } from '../db/dataSignal'
-import { parseCallerFrame } from '../devToolbar/parseCallerFrame'
+import { resolveCallerSource } from '../devToolbar/resolveCallerSource'
 
 type DBPrimitive = string | number | null
 type DBRow = Record<string, DBPrimitive>
@@ -21,9 +21,7 @@ export function useDBQueryMany<T extends DBRow>({
     query,
     year,
 }: BaseOptions): UseDBQueryResult<T[]> {
-    const source = import.meta.env.DEV
-        ? parseCallerFrame(new Error().stack)
-        : undefined
+    const source = resolveCallerSource()
     const [data, setData] = useState<T[] | undefined>(undefined)
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState<Error | undefined>(undefined)


### PR DESCRIPTION
## 1️⃣ First
- [ ] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The devToolbar DuckDB panel showed raw SQL with no indication of which component triggered each query. Tracing a slow or broken query required manually matching SQL text to a component.

<img width="603" height="179" alt="Astro dev Toolbar queries list" src="https://github.com/user-attachments/assets/6576a395-63bf-4cf3-b242-1f250e07c90d" />


## 🎹 Proposal

All DuckDB queries now display the originating component name in the toolbar (e.g. `StreamDiscovery`, `LabView`) before the SQL snippet. Attribution is fully automatic, no annotation required in any component.

Two capture paths handle the two ways components trigger queries:

- **Hook callers** (`useDBQueryMany`): the stack is captured synchronously at render time, when the component frame is still present. The name is passed via closure into the `useEffect` and forwarded to `queryDBAsJSON`.
- **Direct callers** (`Top10Evolution`, `LabView`, etc.): `queryDBAsJSON` falls back to `Error().stack` auto-detection, which works because `fetchData` is defined inside the component file.

`parseCallerFrame` extracts the short name only: parent directory for `index.tsx` files, filename stem otherwise. Both paths are no-ops in production (DEV-gated, tree-shaken by Vite).

## 🎶 Comments

`useChatEngine` is out of scope. Chat queries are a different subsystem and were not part of the issue.

## 🎤 Test

1. `moon run app:dev`
2. Open the Astro devToolbar and navigate to any chart tab
3. DuckDB panel shows component names before each SQL row: `StreamDiscovery`, `Top10Evolution`, etc.

`parseCallerFrame` is unit-tested with synthetic stack strings covering `index.tsx`, named files, missing frames, and multi-frame stacks.


<img width="610" height="181" alt="Astro dev Toolbar queries list prefixed by the Name of the SQL" src="https://github.com/user-attachments/assets/799fb467-cedd-4cc7-b39d-87b2c2a5f342" />


Closes #450