### PR TITLE
chore(chat): keep shortcut chips visible throughout the conversation

### DIFF
--- a/app/src/components/Charts/ChatView.tsx
+++ b/app/src/components/Charts/ChatView.tsx
@@ -120,12 +120,10 @@ export function ChatView() {
                         />
                         <div ref={bottomRef} />
                     </div>
-                    {messages.length === 0 && (
-                        <ChatShortcuts
-                            onSelect={handleSubmit}
-                            disabled={isLoading}
-                        />
-                    )}
+                    <ChatShortcuts
+                        onSelect={handleSubmit}
+                        disabled={isLoading}
+                    />
                     <ChatInput
                         disabled={isLoading}
                         placeholder={


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Shortcut chips in the Chat tab disappeared after the user sent their first message, making them inaccessible for the rest of the conversation.

## 🎹 Proposal

Removed the `messages.length === 0` guard from `ChatView.tsx` so `ChatShortcuts` renders unconditionally once the engine is ready. Chips stay above the input for the entire session and remain disabled while the LLM is responding via the existing `isLoading` flag.

## 🎶 Comments

No new logic needed — the `disabled={isLoading}` prop was already in place, so disabling during inference was already handled correctly.

## 🎤 Test

1. Open the Chat tab and confirm chips appear before any message is sent.
2. Send a message — chips should remain visible above the input after the response arrives.
3. Send another message — chips should disable while the LLM is thinking, then re-enable once the response is complete.