### PR TITLE
feat(demo): replace Spinner with progress bar during data loading

### DIFF
--- a/app/src/components/ProgressBar/ProgressBar.test.tsx
+++ b/app/src/components/ProgressBar/ProgressBar.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ProgressBar } from './ProgressBar'
+
+describe('ProgressBar', () => {
+    it('renders the stage label', () => {
+        render(<ProgressBar stage="Fetching demo data…" percent={25} />)
+        expect(screen.getByText('Fetching demo data…')).toBeDefined()
+    })
+
+    it('sets bar width to the given percent', () => {
+        const { container } = render(
+            <ProgressBar stage="Loading…" percent={60} />
+        )
+        const bar = container.querySelector('[style]') as HTMLElement
+        expect(bar.style.width).toBe('60%')
+    })
+
+    it('renders at 0%', () => {
+        const { container } = render(
+            <ProgressBar stage="Starting…" percent={0} />
+        )
+        const bar = container.querySelector('[style]') as HTMLElement
+        expect(bar.style.width).toBe('0%')
+    })
+
+    it('renders at 100%', () => {
+        const { container } = render(<ProgressBar stage="Done" percent={100} />)
+        const bar = container.querySelector('[style]') as HTMLElement
+        expect(bar.style.width).toBe('100%')
+    })
+})

--- a/app/src/components/ProgressBar/ProgressBar.tsx
+++ b/app/src/components/ProgressBar/ProgressBar.tsx
@@ -1,0 +1,20 @@
+type ProgressBarProps = {
+    stage: string
+    percent: number
+}
+
+export function ProgressBar({ stage, percent }: ProgressBarProps) {
+    return (
+        <div className="w-full max-w-sm mx-auto flex flex-col gap-2">
+            <p className="text-sm text-center text-gray-500 dark:text-slate-400">
+                {stage}
+            </p>
+            <div className="h-2 rounded-full bg-gray-200 dark:bg-slate-700 overflow-hidden">
+                <div
+                    className="h-full rounded-full bg-gradient-brand transition-all duration-300 ease-out"
+                    style={{ width: `${percent}%` }}
+                />
+            </div>
+        </div>
+    )
+}

--- a/app/src/components/TracksyWrapper.tsx
+++ b/app/src/components/TracksyWrapper.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { getDB } from '../db/getDB'
 import { DropzoneWrapper } from './Dropzone/DropzoneWrapper'
 import { insertFilesInDatabase } from '../db/queries/insertFilesInDatabase'
-import { Spinner } from './Spinner/Spinner'
+import { ProgressBar } from './ProgressBar/ProgressBar'
 import type { DuckdbApp as DuckdbAppType } from '../db/setupDB'
 import { DemoButton } from './DemoButton/DemoButton'
 import { HowToButton } from './HowToButton/HowToButton'
@@ -26,8 +26,15 @@ export function TracksyWrapper({
     const [isDataDropped, setIsDataDropped] = useState(initialIsDataDropped)
     const [isDataReady, setIsDataReady] = useState(initialIsDataReady)
     const [uploadError, setUploadError] = useState<string | null>(null)
+    const [loadProgress, setLoadProgress] = useState<{
+        stage: string
+        percent: number
+    } | null>(null)
     const dismissUploadError = useCallback(() => setUploadError(null), [])
-    const { isDemoReady, handleDemoButtonClick, demoJsonUrl } = useDemo()
+    const { isDemoReady, handleDemoButtonClick, demoJsonUrl, demoProgress } =
+        useDemo()
+
+    const activeProgress = loadProgress ?? demoProgress
 
     useEffect(() => {
         const initDB = async () => {
@@ -41,14 +48,19 @@ export function TracksyWrapper({
         if (!files) return
         setIsDataReady(false)
         setIsDataDropped(true)
+        setLoadProgress(null)
         try {
-            await insertFilesInDatabase(files)
+            await insertFilesInDatabase(files, (stage, percent) =>
+                setLoadProgress({ stage, percent })
+            )
             setIsDataReady(true)
         } catch (error) {
             console.error('Failed to upload files:', error)
             setIsDataReady(false)
             setIsDataDropped(false)
             setUploadError(getUserMessage(error))
+        } finally {
+            setLoadProgress(null)
         }
     }
 
@@ -64,7 +76,7 @@ export function TracksyWrapper({
 
     return (
         <>
-            {(!isDataDropped || isDataReady) && (
+            {(!isDataDropped || isDataReady) && !activeProgress && (
                 <div className="flex flex-col md:flex-row gap-4 items-stretch">
                     <div className="flex-grow transition-all duration-300">
                         <DropzoneWrapper
@@ -89,7 +101,12 @@ export function TracksyWrapper({
                     </div>
                 </div>
             )}
-            {isDataDropped && !isDataReady && <Spinner />}
+            {activeProgress && (
+                <ProgressBar
+                    stage={activeProgress.stage}
+                    percent={activeProgress.percent}
+                />
+            )}
             {(isDataReady || isDemoReady) && <Results />}
             {uploadError && (
                 <UploadError

--- a/app/src/db/precompute.test.ts
+++ b/app/src/db/precompute.test.ts
@@ -65,4 +65,26 @@ describe('precomputeDerivedTables', () => {
             'DuckDB error'
         )
     })
+
+    it('calls onProgress once per step (5 total: 1 main + 4 derived)', async () => {
+        const conn = mockConn()
+        const onProgress = vi.fn()
+        await precomputeDerivedTables(conn, undefined, onProgress)
+        expect(onProgress).toHaveBeenCalledTimes(5)
+    })
+
+    it('calls onProgress with increasing percentages ending at 100', async () => {
+        const conn = mockConn()
+        const percents: number[] = []
+        await precomputeDerivedTables(conn, undefined, (_stage, pct) =>
+            percents.push(pct)
+        )
+        expect(percents[percents.length - 1]).toBe(100)
+        expect(percents).toEqual([...percents].sort((a, b) => a - b))
+    })
+
+    it('works without onProgress (optional)', async () => {
+        const conn = mockConn()
+        await expect(precomputeDerivedTables(conn)).resolves.toBeUndefined()
+    })
 })

--- a/app/src/db/precompute.ts
+++ b/app/src/db/precompute.ts
@@ -19,19 +19,30 @@ const DERIVED_TABLES = [
     [SUMMARIZE_CACHE_TABLE, sqlSummarizeCache],
 ] as const
 
+type OnProgress = (stage: string, percent: number) => void
+
+const TOTAL_STEPS = 1 + DERIVED_TABLES.length
+
 export async function precomputeDerivedTables(
     conn: AsyncDuckDBConnection,
-    tz: string = Intl.DateTimeFormat().resolvedOptions().timeZone
+    tz: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
+    onProgress?: OnProgress
 ): Promise<void> {
     await conn.query(`DROP VIEW IF EXISTS ${TABLE}`)
     await conn.query(`DROP TABLE IF EXISTS ${TABLE}`)
     await conn.query(
         `CREATE TABLE ${TABLE} AS SELECT * EXCLUDE (ts), (ts::TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE '${tz}') AS ts FROM ${RAW_TABLE}`
     )
-    for (const [name, sql] of DERIVED_TABLES) {
+    onProgress?.('Computing statistics…', Math.round((1 / TOTAL_STEPS) * 100))
+
+    for (const [index, [name, sql]] of DERIVED_TABLES.entries()) {
         await conn.query(`DROP TABLE IF EXISTS ${name}`)
         await conn.query(
             `CREATE TABLE ${name} AS\n${sql.replaceAll('${table}', TABLE)}`
+        )
+        onProgress?.(
+            'Computing statistics…',
+            Math.round(((index + 2) / TOTAL_STEPS) * 100)
         )
     }
 }

--- a/app/src/db/queries/insertFilesInDatabase.test.ts
+++ b/app/src/db/queries/insertFilesInDatabase.test.ts
@@ -213,7 +213,11 @@ describe('insertFilesInDatabase', () => {
 
             const precomputeSpy = vi.mocked(precompute.precomputeDerivedTables)
             expect(precomputeSpy).toHaveBeenCalledTimes(1)
-            expect(precomputeSpy).toHaveBeenCalledWith(connectionMock)
+            expect(precomputeSpy).toHaveBeenCalledWith(
+                connectionMock,
+                undefined,
+                expect.any(Function)
+            )
 
             const insertCallOrder = (
                 connectionMock.insertArrowTable as ReturnType<typeof vi.fn>
@@ -221,6 +225,68 @@ describe('insertFilesInDatabase', () => {
             const precomputeCallOrder =
                 precomputeSpy.mock.invocationCallOrder[0]
             expect(precomputeCallOrder).toBeGreaterThan(insertCallOrder)
+        })
+    })
+
+    describe('onProgress callback', () => {
+        it('calls onProgress starting at 0 and ending at 70+ for a single file', async () => {
+            mockDB()
+            const records = [
+                {
+                    track_uri: 'spotify:track:123',
+                    track_name: 'Song',
+                    artist_name: 'Artist',
+                    album_name: 'Album',
+                    ts: '2024-01-01T12:00:00Z',
+                    ms_played: 180000,
+                    platform: 'Platform',
+                },
+            ]
+            const { provider } = mockStreamProviderWithSpy(records)
+            vi.spyOn(adapters, 'detectProvider').mockReturnValue(provider)
+
+            const percents: number[] = []
+            const onProgress = vi.fn((_stage: string, pct: number) =>
+                percents.push(pct)
+            )
+
+            await insertFilesInDatabase(
+                convertArrayToFileList([
+                    mockFile('[]', 'test.json', { type: 'application/json' }),
+                ]),
+                onProgress
+            )
+
+            expect(onProgress).toHaveBeenCalled()
+            expect(percents[0]).toBe(0)
+            expect(percents[percents.length - 1]).toBeGreaterThanOrEqual(70)
+        })
+
+        it('works without onProgress (optional)', async () => {
+            mockDB()
+            const records = [
+                {
+                    track_uri: 'spotify:track:123',
+                    track_name: 'Song',
+                    artist_name: 'Artist',
+                    album_name: 'Album',
+                    ts: '2024-01-01T12:00:00Z',
+                    ms_played: 180000,
+                    platform: 'Platform',
+                },
+            ]
+            const { provider } = mockStreamProviderWithSpy(records)
+            vi.spyOn(adapters, 'detectProvider').mockReturnValue(provider)
+
+            await expect(
+                insertFilesInDatabase(
+                    convertArrayToFileList([
+                        mockFile('[]', 'test.json', {
+                            type: 'application/json',
+                        }),
+                    ])
+                )
+            ).resolves.toBeUndefined()
         })
     })
 

--- a/app/src/db/queries/insertFilesInDatabase.ts
+++ b/app/src/db/queries/insertFilesInDatabase.ts
@@ -6,18 +6,27 @@ import type { StreamRecord } from '../../streamProvider/types'
 import { precomputeDerivedTables } from '../precompute'
 import { dispatchDataLoaded } from '../dataSignal'
 
-export async function insertFilesInDatabase(files: FileList) {
+type OnProgress = (stage: string, percent: number) => void
+
+export async function insertFilesInDatabase(
+    files: FileList,
+    onProgress?: OnProgress
+) {
     if (files.length < 1) {
         console.error('No file to process')
         throw new Error('No file to process')
     }
 
     const allStreamRecords: StreamRecord[] = []
+    const fileArray = Array.from(files)
 
-    for (const file of Array.from(files)) {
+    for (const [index, file] of fileArray.entries()) {
         console.debug(`File ${file.name} is being processed.`)
+        onProgress?.(
+            'Parsing records…',
+            Math.round((index / fileArray.length) * 50)
+        )
 
-        // Detect which provider this file is from
         const provider = detectProvider(file)
         if (!provider) {
             console.warn(
@@ -30,11 +39,10 @@ export async function insertFilesInDatabase(files: FileList) {
             `File ${file.name} detected as ${provider.displayName} format.`
         )
 
-        // Read using the appropriate provider
         const records = await provider.processFile(file)
-
         allStreamRecords.push(...records)
     }
+    onProgress?.('Parsing records…', 50)
 
     if (allStreamRecords.length === 0) {
         console.error('No valid stream records found')
@@ -45,6 +53,7 @@ export async function insertFilesInDatabase(files: FileList) {
 
     const { conn } = await getDB()
 
+    onProgress?.('Loading into database…', 50)
     await conn.query(`DROP TABLE IF EXISTS ${RAW_TABLE}`)
     console.debug(`Table ${RAW_TABLE} dropped.`)
 
@@ -55,7 +64,10 @@ export async function insertFilesInDatabase(files: FileList) {
     console.debug(
         `Table ${RAW_TABLE} created with ${allStreamRecords.length} records.`
     )
+    onProgress?.('Loading into database…', 70)
 
-    await precomputeDerivedTables(conn)
+    await precomputeDerivedTables(conn, undefined, (_stage, pct) =>
+        onProgress?.('Computing statistics…', 70 + Math.round(pct * 0.3))
+    )
     dispatchDataLoaded()
 }

--- a/app/src/db/queries/insertUrlInDatabase.test.ts
+++ b/app/src/db/queries/insertUrlInDatabase.test.ts
@@ -86,6 +86,74 @@ describe('insertUrlInDatabase', () => {
         })
     })
 
+    describe('onProgress callback', () => {
+        it('calls onProgress through all stages with increasing percentages', async () => {
+            mockDB()
+            const mockRecords = [
+                {
+                    track_uri: 'spotify:track:123',
+                    track_name: 'Test Song',
+                    artist_name: 'Test Artist',
+                    album_name: 'Test Album',
+                    ts: '2024-01-01T12:00:00Z',
+                    ms_played: 180000,
+                    platform: 'Test_Platform',
+                },
+            ]
+            const { provider } = mockStreamProviderWithSpy(mockRecords)
+            vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+                ok: true,
+                blob: async () =>
+                    new Blob([JSON.stringify(mockRecords)], {
+                        type: 'application/json',
+                    }),
+            } as Response)
+            vi.spyOn(adapters, 'detectProvider').mockReturnValue(provider)
+
+            const percents: number[] = []
+            const onProgress = vi.fn((_stage: string, pct: number) =>
+                percents.push(pct)
+            )
+
+            await insertUrlInDatabase(
+                new URL('https://example.com/data.json'),
+                onProgress
+            )
+
+            expect(onProgress).toHaveBeenCalled()
+            expect(percents[0]).toBe(0)
+            expect(percents[percents.length - 1]).toBeGreaterThanOrEqual(70)
+        })
+
+        it('works without onProgress (optional)', async () => {
+            mockDB()
+            const mockRecords = [
+                {
+                    track_uri: 'spotify:track:123',
+                    track_name: 'Test Song',
+                    artist_name: 'Test Artist',
+                    album_name: 'Test Album',
+                    ts: '2024-01-01T12:00:00Z',
+                    ms_played: 180000,
+                    platform: 'Test_Platform',
+                },
+            ]
+            const { provider } = mockStreamProviderWithSpy(mockRecords)
+            vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+                ok: true,
+                blob: async () =>
+                    new Blob([JSON.stringify(mockRecords)], {
+                        type: 'application/json',
+                    }),
+            } as Response)
+            vi.spyOn(adapters, 'detectProvider').mockReturnValue(provider)
+
+            await expect(
+                insertUrlInDatabase(new URL('https://example.com/data.json'))
+            ).resolves.toBeUndefined()
+        })
+    })
+
     describe('real provider detection from URL filename', () => {
         it('should detect Spotify provider and process data using real detectProvider', async () => {
             const connectionMock = mockDB()
@@ -193,7 +261,11 @@ describe('insertUrlInDatabase', () => {
 
             const precomputeSpy = vi.mocked(precompute.precomputeDerivedTables)
             expect(precomputeSpy).toHaveBeenCalledTimes(1)
-            expect(precomputeSpy).toHaveBeenCalledWith(connectionMock)
+            expect(precomputeSpy).toHaveBeenCalledWith(
+                connectionMock,
+                undefined,
+                expect.any(Function)
+            )
 
             const insertCallOrder = (
                 connectionMock.insertArrowTable as ReturnType<typeof vi.fn>

--- a/app/src/db/queries/insertUrlInDatabase.ts
+++ b/app/src/db/queries/insertUrlInDatabase.ts
@@ -5,7 +5,13 @@ import { detectProvider } from '../../streamProvider'
 import { precomputeDerivedTables } from '../precompute'
 import { dispatchDataLoaded } from '../dataSignal'
 
-export async function insertUrlInDatabase(jsonUrl: URL) {
+type OnProgress = (stage: string, percent: number) => void
+
+export async function insertUrlInDatabase(
+    jsonUrl: URL,
+    onProgress?: OnProgress
+) {
+    onProgress?.('Fetching demo data…', 0)
     const response = await fetch(jsonUrl.toString())
     if (!response.ok) {
         throw new Error(`Failed to fetch demo data: ${response.statusText}`)
@@ -14,27 +20,34 @@ export async function insertUrlInDatabase(jsonUrl: URL) {
     const blob = await response.blob()
     const filename = jsonUrl.pathname.split('/').pop() || 'streaming_data.json'
     const file = new File([blob], filename, { type: 'application/json' })
+    onProgress?.('Fetching demo data…', 25)
 
     const provider = detectProvider(file)
     if (!provider) {
         throw new Error('No provider found for the demo data URL')
     }
 
+    onProgress?.('Parsing records…', 25)
     const records = await provider.processFile(file)
 
     if (records.length === 0) {
         throw new Error('No valid stream records found in demo data')
     }
+    onProgress?.('Parsing records…', 50)
 
     const arrowTableContent = tableFromJSON(records)
 
     const { conn } = await getDB()
+    onProgress?.('Loading into database…', 50)
     await conn.query(`DROP TABLE IF EXISTS ${RAW_TABLE}`)
     await conn.insertArrowTable(arrowTableContent, {
         name: RAW_TABLE,
         create: true,
     })
+    onProgress?.('Loading into database…', 70)
 
-    await precomputeDerivedTables(conn)
+    await precomputeDerivedTables(conn, undefined, (_stage, pct) =>
+        onProgress?.('Computing statistics…', 70 + Math.round(pct * 0.3))
+    )
     dispatchDataLoaded()
 }

--- a/app/src/hooks/useDemo.test.ts
+++ b/app/src/hooks/useDemo.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { renderHook } from '@testing-library/react'
+import { renderHook, act } from '@testing-library/react'
 import { useDemo } from './useDemo'
+import * as insertUrlModule from '../db/queries/insertUrlInDatabase'
 
 afterEach(() => {
     vi.restoreAllMocks()
@@ -54,6 +55,44 @@ describe('useDemo', () => {
             expect(handleDemoButtonClick).toBeDefined()
             const expectedUrl = new URL('https://example.com')
             expect(demoJsonUrl).toStrictEqual(expectedUrl)
+        })
+    })
+
+    describe('demoProgress', () => {
+        it('starts as null', () => {
+            vi.stubEnv('PUBLIC_DEMO_JSON_URL', 'https://example.com')
+            const { result } = renderHook(() => useDemo())
+            expect(result.current.demoProgress).toBeNull()
+        })
+
+        it('is null after a failed load', async () => {
+            vi.stubEnv('PUBLIC_DEMO_JSON_URL', 'https://example.com')
+            vi.spyOn(insertUrlModule, 'insertUrlInDatabase').mockRejectedValue(
+                new Error('fail')
+            )
+
+            const { result } = renderHook(() => useDemo())
+            await act(async () => {
+                await result.current.handleDemoButtonClick()
+            })
+
+            expect(result.current.demoProgress).toBeNull()
+            expect(result.current.isDemoReady).toBe(false)
+        })
+
+        it('is null after a successful load', async () => {
+            vi.stubEnv('PUBLIC_DEMO_JSON_URL', 'https://example.com')
+            vi.spyOn(insertUrlModule, 'insertUrlInDatabase').mockResolvedValue(
+                undefined
+            )
+
+            const { result } = renderHook(() => useDemo())
+            await act(async () => {
+                await result.current.handleDemoButtonClick()
+            })
+
+            expect(result.current.demoProgress).toBeNull()
+            expect(result.current.isDemoReady).toBe(true)
         })
     })
 })

--- a/app/src/hooks/useDemo.ts
+++ b/app/src/hooks/useDemo.ts
@@ -1,8 +1,11 @@
 import { useState } from 'react'
 import { insertUrlInDatabase } from '../db/queries/insertUrlInDatabase'
 
+type DemoProgress = { stage: string; percent: number }
+
 export function useDemo() {
     const [isDemoReady, setIsDemoReady] = useState(false)
+    const [demoProgress, setDemoProgress] = useState<DemoProgress | null>(null)
 
     const demoJsonUrl: URL | undefined = (() => {
         const url = import.meta.env.PUBLIC_DEMO_JSON_URL
@@ -22,14 +25,19 @@ export function useDemo() {
 
     const handleDemoButtonClick = async () => {
         setIsDemoReady(false)
+        setDemoProgress(null)
         if (!demoJsonUrl) return
         try {
-            await insertUrlInDatabase(demoJsonUrl)
+            await insertUrlInDatabase(demoJsonUrl, (stage, percent) =>
+                setDemoProgress({ stage, percent })
+            )
             setIsDemoReady(true)
         } catch {
             setIsDemoReady(false)
+        } finally {
+            setDemoProgress(null)
         }
     }
 
-    return { isDemoReady, handleDemoButtonClick, demoJsonUrl }
+    return { isDemoReady, handleDemoButtonClick, demoJsonUrl, demoProgress }
 }


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [x] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

When a user clicks "Load demo data" (or drops a file), the UI shows an indeterminate spinner with no indication of how far along the load is. For larger datasets this causes uncertainty about whether anything is happening.

## 🎹 Proposal

Replace the `<Spinner />` with a shared `<ProgressBar />` component that shows named stage labels and a determinate progress percentage for both the demo load and file upload flows.

The loading pipeline is broken into four named stages reported via an optional `onProgress` callback threaded through the call stack:

- **Fetching demo data…** (0 → 25%) — network fetch of the demo JSON
- **Parsing records…** (25 → 50%) — provider detection and record processing
- **Loading into database…** (50 → 70%) — Arrow table insert into DuckDB
- **Computing statistics…** (70 → 100%) — precomputation of 5 derived tables, one step per table

For file uploads the same stages apply (Parse starts at 0% and advances per file).

The `<Spinner />` component is no longer rendered but was not deleted.

## 🎶 Comments

- `onProgress` is optional on all three functions (`insertUrlInDatabase`, `insertFilesInDatabase`, `precomputeDerivedTables`) so existing call sites need no changes.
- Progress percentages for Precompute are remapped from 0–100 → 70–100 at the caller, keeping `precomputeDerivedTables` reusable.
- The async leak reported in `TracksyWrapper` tests (`UploadError` timeout) is pre-existing and unrelated to this change.

## 🎤 Test

1. Set `PUBLIC_DEMO_JSON_URL` to a valid demo JSON URL and start the dev server (`moon run app:dev`).
2. Click "Load demo data" — the dropzone should disappear and a progress bar should appear, advancing through "Fetching demo data…", "Parsing records…", "Loading into database…", "Computing statistics…".
3. Drop a Spotify export file — the same progress bar should appear during processing.
4. On error (invalid file), the progress bar disappears and the error banner appears as before.

Unit tests: `moon run app:test`