### PR TITLE
chore(chat): inform user that chat history lives in memory only

### DIFF
--- a/app/src/components/Charts/ChatView.tsx
+++ b/app/src/components/Charts/ChatView.tsx
@@ -12,6 +12,18 @@ function generateId(): string {
     return `${Date.now()}-${Math.random().toString(36).slice(2)}`
 }
 
+function MemoryNotice() {
+    return (
+        <div className="flex items-start gap-2 p-3 rounded-xl bg-blue-50 dark:bg-blue-900/20 border border-blue-200/60 dark:border-blue-700/40 text-blue-800 dark:text-blue-300 text-sm">
+            <span className="shrink-0">💡</span>
+            <p>
+                Chat history is stored in memory only — switching to another tab
+                will clear the conversation.
+            </p>
+        </div>
+    )
+}
+
 export function ChatView() {
     const [messages, setMessages] = useState<ChatMessage[]>([])
     const [customRows, setCustomRows] = useState<Map<string, DBRow[]>>(
@@ -109,6 +121,7 @@ export function ChatView() {
 
     return (
         <div className="flex flex-col gap-4 max-w-3xl mx-auto py-4">
+            <MemoryNotice />
             <ModelLoader state={state} onEnable={handleEnable} />
 
             {isReady && (


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [x] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The Chat tab holds conversation history in React state. Because tabs are conditionally rendered (not hidden), switching away from Chat unmounts the component and clears all messages. Users had no indication of this behaviour.

## 🎹 Proposal

Add a small, always-visible `MemoryNotice` banner at the top of the Chat tab (above the model loader card) telling users that chat history is in memory only and will be cleared when they switch tabs. Styled in blue following the same pattern as the existing `DegradedNotice` in `ModelLoader`.

## 🎶 Comments

No new dependencies, no localStorage, no dismissal logic — just a permanent contextual hint.

## 🎤 Test

1. Open the Chat tab — the blue info banner should appear at the top in both light and dark mode.
2. Send a message, then switch to another tab and back — the banner is still there and the conversation is gone, matching the message.