### PR TITLE
feat(chat): replace Ask button with Stop to cancel ongoing LLM query

### DIFF
--- a/app/src/components/Charts/ChatView.tsx
+++ b/app/src/components/Charts/ChatView.tsx
@@ -33,7 +33,7 @@ export function ChatView() {
     const [pendingQuestion, setPendingQuestion] = useState<string | null>(null)
     const bottomRef = useRef<HTMLDivElement>(null)
 
-    const { state, ensureLoaded, ask } = useChatEngine()
+    const { state, ensureLoaded, ask, cancel } = useChatEngine()
 
     useEffect(() => {
         const handler = () => {
@@ -94,7 +94,9 @@ export function ChatView() {
                         ? JSON.stringify(payload.answer)
                         : payload.kind === 'llm-error'
                           ? `error: ${payload.error}`
-                          : `error: ${payload.kind}`,
+                          : payload.kind === 'aborted'
+                            ? 'aborted'
+                            : `error: ${payload.kind}`,
                 payload,
             }
 
@@ -139,12 +141,14 @@ export function ChatView() {
                     />
                     <ChatInput
                         disabled={isLoading}
+                        isAsking={isAsking}
                         placeholder={
                             isAsking
                                 ? 'Thinking…'
                                 : 'Ask about your listening history…'
                         }
                         onSubmit={handleSubmit}
+                        onCancel={cancel}
                     />
                 </div>
             )}

--- a/app/src/components/Chat/ChatInput.tsx
+++ b/app/src/components/Chat/ChatInput.tsx
@@ -2,11 +2,19 @@ import { useState, type KeyboardEvent } from 'react'
 
 type ChatInputProps = {
     disabled?: boolean
+    isAsking?: boolean
     placeholder?: string
     onSubmit: (text: string) => void
+    onCancel?: () => void
 }
 
-export function ChatInput({ disabled, placeholder, onSubmit }: ChatInputProps) {
+export function ChatInput({
+    disabled,
+    isAsking,
+    placeholder,
+    onSubmit,
+    onCancel,
+}: ChatInputProps) {
     const [value, setValue] = useState('')
 
     const submit = () => {
@@ -46,13 +54,23 @@ export function ChatInput({ disabled, placeholder, onSubmit }: ChatInputProps) {
                 }
                 className="flex-1 resize-none bg-transparent outline-none text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 disabled:opacity-50"
             />
-            <button
-                type="submit"
-                disabled={disabled || value.trim().length === 0}
-                className="px-4 py-2 bg-gradient-brand text-white font-semibold rounded-xl shadow-glow disabled:opacity-50 disabled:cursor-not-allowed transition-all"
-            >
-                Ask
-            </button>
+            {isAsking ? (
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="px-4 py-2 bg-gradient-brand text-white font-semibold rounded-xl shadow-glow transition-all"
+                >
+                    Stop
+                </button>
+            ) : (
+                <button
+                    type="submit"
+                    disabled={disabled || value.trim().length === 0}
+                    className="px-4 py-2 bg-gradient-brand text-white font-semibold rounded-xl shadow-glow disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+                >
+                    Ask
+                </button>
+            )}
         </form>
     )
 }

--- a/app/src/components/Chat/ChatMessageList.tsx
+++ b/app/src/components/Chat/ChatMessageList.tsx
@@ -77,6 +77,16 @@ function AssistantCard({
         )
     }
 
+    if (payload.kind === 'aborted') {
+        return (
+            <div className="p-4 bg-gray-50 dark:bg-slate-800/50 rounded-2xl border border-gray-200 dark:border-slate-700/50">
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                    Request cancelled.
+                </p>
+            </div>
+        )
+    }
+
     // payload.kind === 'ok'
     const { answer } = payload
     return (

--- a/app/src/hooks/useChatEngine.ts
+++ b/app/src/hooks/useChatEngine.ts
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { queryDBAsJSON } from '../db/queries/queryDB'
 import { validateSql } from '../llm/sqlSafety'
 import { isMobileBrowser } from '../llm/deviceDetection'
-import type { AssistantPayload, ChatMessage, EngineState } from '../llm/types'
+import {
+    LLMError,
+    type AssistantPayload,
+    type ChatMessage,
+    type EngineState,
+} from '../llm/types'
 
 const ASSISTANT_ENABLED_KEY = 'tracksy:assistantEnabled'
 
@@ -31,6 +36,7 @@ export function useChatEngine() {
     // bloat the main bundle with @mlc-ai/web-llm.
     const moduleRef = useRef<typeof import('../llm/engine') | null>(null)
     const askLLMRef = useRef<typeof import('../llm/askLLM') | null>(null)
+    const abortRef = useRef<AbortController | null>(null)
 
     const ensureLoaded = useCallback(async () => {
         if (state.kind === 'ready' || state.kind === 'loading') return
@@ -81,11 +87,13 @@ export function useChatEngine() {
                         },
                     }
                 }
+                abortRef.current = new AbortController()
                 const engine = await moduleRef.current.getEngine()
                 const answer = await askLLMRef.current.askLLM(
                     engine,
                     userText,
-                    history
+                    history,
+                    abortRef.current.signal
                 )
 
                 if (answer.intent !== 'custom') {
@@ -123,6 +131,9 @@ export function useChatEngine() {
                     }
                 }
             } catch (e) {
+                if (e instanceof LLMError && e.kind === 'aborted') {
+                    return { payload: { kind: 'aborted' } }
+                }
                 return {
                     payload: {
                         kind: 'llm-error',
@@ -134,9 +145,13 @@ export function useChatEngine() {
         []
     )
 
+    const cancel = useCallback(() => {
+        abortRef.current?.abort()
+    }, [])
+
     useEffect(() => {
         if (getAssistantEnabled()) ensureLoaded()
     }, [])
 
-    return { state, ensureLoaded, ask }
+    return { state, ensureLoaded, ask, cancel }
 }

--- a/app/src/llm/askLLM.ts
+++ b/app/src/llm/askLLM.ts
@@ -1,4 +1,5 @@
 import type {
+    ChatCompletion,
     ChatCompletionMessageParam,
     MLCEngineInterface,
 } from '@mlc-ai/web-llm'
@@ -129,17 +130,32 @@ export function parseChatAnswer(raw: string): ChatAnswer {
 export async function askLLM(
     engine: MLCEngineInterface,
     userText: string,
-    history: ChatMessage[]
+    history: ChatMessage[],
+    signal?: AbortSignal
 ): Promise<ChatAnswer> {
     const messages = buildMessages(userText, history)
     let response
     const start = performance.now()
     try {
-        response = await engine.chat.completions.create({
+        const completionPromise = engine.chat.completions.create({
             messages,
             temperature: 0.1,
             max_tokens: 512,
-        })
+        }) as Promise<ChatCompletion>
+        if (signal) {
+            const abortPromise = new Promise<never>((_, reject) => {
+                if (signal.aborted) {
+                    reject(new LLMError('Cancelled', 'aborted'))
+                    return
+                }
+                signal.addEventListener('abort', () =>
+                    reject(new LLMError('Cancelled', 'aborted'))
+                )
+            })
+            response = await Promise.race([completionPromise, abortPromise])
+        } else {
+            response = await completionPromise
+        }
         const durationMs = performance.now() - start
         const tokens = response.usage?.completion_tokens ?? 0
         devBus.emit('webllm:inference', {
@@ -148,6 +164,9 @@ export async function askLLM(
             tokensPerSec: durationMs > 0 ? tokens / (durationMs / 1000) : 0,
         })
     } catch (e) {
+        if (e instanceof LLMError && e.kind === 'aborted') {
+            throw e
+        }
         const reason = e instanceof Error ? e.message : String(e)
         throw new LLMError(reason, 'engine')
     }

--- a/app/src/llm/types.ts
+++ b/app/src/llm/types.ts
@@ -20,6 +20,7 @@ export type AssistantPayload =
     | { kind: 'unsafe-sql'; answer: ChatAnswer; reason: string }
     | { kind: 'sql-error'; answer: ChatAnswer; error: string }
     | { kind: 'llm-error'; error: string }
+    | { kind: 'aborted' }
 
 export type ChatMessage =
     | { id: string; role: 'user'; text: string }


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [x] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Once a question is submitted, the input and button are disabled until the LLM responds. There was no way to interrupt an in-flight query — users had to wait for the full response even if they changed their mind or sent the wrong question.

## 🎹 Proposal

While a query is running, the "Ask" button is replaced by a "Stop" button. Clicking Stop aborts the in-flight LLM call via `AbortController`. The user's question stays in the conversation but no assistant reply is appended — the input re-enables cleanly so they can ask again.

Internally, an `AbortController` is created per query in `useChatEngine` and threaded down to `askLLM`, where a `Promise.race` between the completion and an abort sentinel makes cancellation immediate. A new `aborted` variant was added to `AssistantPayload` (the `LLMError` kind was already typed for this).

## 🎶 Comments

The web-llm `ChatCompletionRequest` type doesn't expose a `signal` field, so cancellation is implemented with `Promise.race` + an abort promise rather than passing the signal directly to the engine.

## 🎤 Test

1. Load the chat (requires a WebGPU-capable browser: Chrome, Edge, or recent Safari).
2. Enable the assistant and wait for the model to load.
3. Type any question and submit — observe the "Ask" button changes to "Stop".
4. Click "Stop" — the query is cancelled, the input re-enables, and no assistant message is added.
5. Submit another question and let it complete normally — the full response appears as before.