### PR TITLE
chore(deps): bump vitest-leak-detector from 1.0.2 to 1.0.3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -38,7 +38,7 @@
         "prettier-plugin-astro": "^0.14.1",
         "vite-plugin-static-copy": "^4.1.1",
         "vitest": "^4.1.9",
-        "vitest-leak-detector": "^1.0.2"
+        "vitest-leak-detector": "^1.0.3"
     },
     "engines": {
         "node": ">=24 <25"

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@20.19.40)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
       vitest-leak-detector:
-        specifier: ^1.0.2
-        version: 1.0.2(vitest@4.1.9)
+        specifier: ^1.0.3
+        version: 1.0.3(vitest@4.1.9)
 
 packages:
 
@@ -3698,8 +3698,8 @@ packages:
       vite:
         optional: true
 
-  vitest-leak-detector@1.0.2:
-    resolution: {integrity: sha512-ESsAc8p6nPFbE5JoGl0jZI/yfpIIoMqKQIY6fTRExl2NrOkx+n6txoGMnMSNlseT7AaBFko+ARfLr1E41TDoYg==}
+  vitest-leak-detector@1.0.3:
+    resolution: {integrity: sha512-6iCq8Fx5hErd0iE9laspR9gJ66klh6FtXHbSjm/NNgeWWtUZQ7fW2XuPXZlwhI5+F/J2z/IXSR9PwLIdEVVxYg==}
     engines: {node: '>=24'}
     peerDependencies:
       vitest: '>=4.0.0'
@@ -8074,7 +8074,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.5(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
-  vitest-leak-detector@1.0.2(vitest@4.1.9):
+  vitest-leak-detector@1.0.3(vitest@4.1.9):
     dependencies:
       vitest: 4.1.9(@types/node@20.19.40)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
 


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [x] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

[vitest-leak-detector v1.0.3](https://github.com/Tarektouati/vitest-leak-detector/releases/tag/v1.0.3) was released with a fix for false positives: timers that were properly cleaned up were still being reported as leaks ([Tarektouati/vitest-leak-detector#16](https://github.com/Tarektouati/vitest-leak-detector/pull/16)).

## 🎹 Proposal

Bump `vitest-leak-detector` from `^1.0.2` to `^1.0.3` in the app's dev dependencies. No API changes, so the existing setup file and reporter entries in `vitest.config.ts` are untouched.

## 🎶 Comments

The lockfile must be refreshed with pnpm 9 (the version pinned in `.moon/toolchains.yml`) — a newer pnpm rewrites the lockfile and drops the `package.json#pnpm.overrides` entries.

## 🎤 Test

Ran the app test suite (`vitest run`) with the new version: the leak-detector setup and reporter load correctly, and the Async Leak Report now flags a single genuine timer leak (in `DuckDBShell.test.tsx`) instead of false positives. Five unrelated tests fail identically before and after the bump (pre-existing date/locale-sensitive failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)