### PR TITLE
feat(chat): animated vibe loading indicator while LLM is thinking

### DIFF
--- a/app/src/components/Charts/ChatView.tsx
+++ b/app/src/components/Charts/ChatView.tsx
@@ -7,6 +7,7 @@ import { ModelLoader } from '../Chat/ModelLoader'
 import { ChatInput } from '../Chat/ChatInput'
 import { ChatMessageList } from '../Chat/ChatMessageList'
 import { ChatShortcuts } from '../Chat/ChatShortcuts'
+import { ChatThinkingIndicator } from '../Chat/ChatThinkingIndicator'
 
 function generateId(): string {
     return `${Date.now()}-${Math.random().toString(36).slice(2)}`
@@ -139,6 +140,7 @@ export function ChatView() {
                         onSelect={handleSubmit}
                         disabled={isLoading}
                     />
+                    {isAsking && <ChatThinkingIndicator />}
                     <ChatInput
                         disabled={isLoading}
                         isAsking={isAsking}

--- a/app/src/components/Chat/ChatThinkingIndicator.tsx
+++ b/app/src/components/Chat/ChatThinkingIndicator.tsx
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react'
+
+const PHRASES = [
+    'Crate digging through your library…',
+    'Sampling your streams…',
+    'Tuning into your vibes…',
+    'Dropping the beat analysis…',
+    'Rewinding your data…',
+    'Spinning up the algorithm…',
+    'Harmonizing the query…',
+    'Processing the frequency…',
+    'Reading the waveform…',
+    'Sequencing the query…',
+    'Finding the groove in the data…',
+    'Encoding your listening history…',
+]
+
+export function ChatThinkingIndicator() {
+    const [index, setIndex] = useState(0)
+
+    useEffect(() => {
+        setIndex(0)
+        const id = setInterval(() => {
+            setIndex((i) => (i + 1) % PHRASES.length)
+        }, 2800)
+        return () => clearInterval(id)
+    }, [])
+
+    return (
+        <div className="flex items-center justify-center gap-2 text-sm text-gray-400 dark:text-gray-500 h-6">
+            <span>♪</span>
+            <span key={index} className="animate-vibe-pulse">
+                {PHRASES[index]}
+            </span>
+        </div>
+    )
+}

--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -37,6 +37,7 @@
     --animate-fade-in: fadeIn 0.5s ease-in-out;
     --animate-slide-up: slideUp 0.4s ease-out;
     --animate-scale-in: scaleIn 0.3s ease-out;
+    --animate-vibe-pulse: vibePulse 2.8s ease-in-out forwards;
 
     @keyframes fadeIn {
         from {
@@ -66,6 +67,25 @@
         to {
             transform: scale(1);
             opacity: 1;
+        }
+    }
+
+    @keyframes vibePulse {
+        0% {
+            opacity: 0;
+            transform: translateY(4px);
+        }
+        15% {
+            opacity: 1;
+            transform: translateY(0);
+        }
+        75% {
+            opacity: 1;
+            transform: translateY(0);
+        }
+        100% {
+            opacity: 0;
+            transform: translateY(-4px);
         }
     }
 }


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).

## 🔇 Problem

When the LLM is processing a question in the Chat tab, the only feedback was a disabled input with a static "Thinking…" placeholder. The experience felt flat and gave no sense of activity.

## 🎹 Proposal

Added a `ChatThinkingIndicator` component that appears above the chat input while the LLM is running. It cycles through 12 witty phrases that blend music and LLM culture — things like "Crate digging through your library…", "Harmonizing the query…", "Dropping the beat analysis…" — with a smooth fade-in/hold/fade-out animation (new `vibePulse` keyframe in `global.css`). Each phrase is shown for ~2.8 seconds before transitioning to the next. The indicator mounts when `isAsking` becomes true and unmounts automatically when the answer arrives.


https://github.com/user-attachments/assets/7fe75f9a-2083-42ba-a867-73ba346663a6


## 🎶 Comments

- No external animation libraries added — uses the same CSS keyframe pattern already established in `global.css` (`fadeIn`, `slideUp`, `scaleIn`).
- The phrase list is deliberately diverse so users who ask multiple questions see variety.

## 🎤 Test

1. Load the app and navigate to the Chat tab
2. Enable the assistant and wait for the model to load
3. Submit any question
4. Observe the animated phrase appearing above the input while the LLM is thinking
5. Confirm it disappears once the answer renders