### PR TITLE
fix(chat): respect dark theme in SQL preview

### DIFF
--- a/app/src/components/Chat/ChatMessageList.test.tsx
+++ b/app/src/components/Chat/ChatMessageList.test.tsx
@@ -155,6 +155,18 @@ describe('ChatMessageList (unified SQL rendering)', () => {
         expect(screen.getByText('🔍 Generated SQL')).toBeTruthy()
     })
 
+    it('renders the SQL block with readable text colors in both themes', () => {
+        const { messages, customRows } = okMessages([{ total_streams: 1550 }])
+        const { container } = render(
+            <ChatMessageList messages={messages} customRows={customRows} />
+        )
+
+        const pre = container.querySelector('pre')
+        expect(pre).toBeTruthy()
+        expect(pre?.className).toContain('text-gray-800')
+        expect(pre?.className).toContain('dark:text-gray-100')
+    })
+
     it('falls back to the static explanation when no narrative is present (mobile)', () => {
         const { messages, customRows } = okMessages([{ total_streams: 1550 }])
         render(<ChatMessageList messages={messages} customRows={customRows} />)

--- a/app/src/components/Chat/ChatMessageList.tsx
+++ b/app/src/components/Chat/ChatMessageList.tsx
@@ -19,7 +19,7 @@ function SqlBlock({ sql }: { sql: string }) {
             <summary className="cursor-pointer text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 select-none">
                 🔍 Generated SQL
             </summary>
-            <pre className="mt-2 p-3 bg-gray-100 dark:bg-slate-800 rounded-xl overflow-x-auto whitespace-pre-wrap break-all">
+            <pre className="mt-2 p-3 bg-gray-100 dark:bg-slate-800 text-gray-800 dark:text-gray-100 rounded-xl overflow-x-auto whitespace-pre-wrap break-all">
                 {sql}
             </pre>
         </details>


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

In dark mode, the generated SQL preview in the Chat tab was hard to read. The block set a dark background (`dark:bg-slate-800`) but never set a text colour, so the query inherited a dark colour and rendered as near-black text on a dark background with very low contrast.

| Dark mode | Light Mode |
|-|-|
| <img width="471" height="409" alt="SQL preview in dark mode is not readable (black)" src="https://github.com/user-attachments/assets/bc6e85d4-9096-4c99-a814-2e5e8ef6b9c3" />  | <img width="471" height="409" alt="SQL preview in light mode is readable (black)" src="https://github.com/user-attachments/assets/111ab658-fa2d-4f72-9075-0a58e14d836e" /> |

Closes #427

## 🎹 Proposal

Give the SQL `<pre>` block explicit text colours that follow the active theme, matching how the rest of the app handles dark mode via the `dark:` variant: dark text on the light background, light text on the dark background. The query now stays legible in both light and dark themes.

## 🎶 Comments

Minimal, focused change confined to the Chat SQL preview block.

## 🎤 Test

- Enable dark mode in the application.
- Open the Chat tab, ask a question, and wait for a response.
- Expand "🔍 Generated SQL" and confirm the query is clearly legible.
- Repeat in light mode to confirm no regression.

| Dark mode | Light Mode |
|-|-|
| <img width="471" height="409" alt="SQL preview in dark mode is readable (white)" src="https://github.com/user-attachments/assets/b9f5f784-4e4d-4de6-8734-0f647ed40856" /> | <img width="471" height="409" alt="SQL preview in light mode still readable (black)" src="https://github.com/user-attachments/assets/f270cfa7-0468-4a6b-9600-9b9afb0d9b19" /> |
