### PR TITLE
test(duckdb-shell): clear timeout to fix async leak in loading-state test

### DIFF
--- a/app/src/components/DuckDBShell/DuckDBShell.test.tsx
+++ b/app/src/components/DuckDBShell/DuckDBShell.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { DuckDBShell } from './DuckDBShell'
 import * as db from '../../db/getDB'
 
 describe('DuckDBShell', () => {
     const mockQuery = vi.fn()
+    const pendingTimers: ReturnType<typeof setTimeout>[] = []
 
     beforeEach(() => {
         vi.clearAllMocks()
@@ -15,6 +16,12 @@ describe('DuckDBShell', () => {
                 query: mockQuery,
             },
         } as unknown as Awaited<ReturnType<typeof db.getDB>>)
+    })
+
+    afterEach(() => {
+        while (pendingTimers.length > 0) {
+            clearTimeout(pendingTimers.pop())
+        }
     })
 
     it('should render the component with default query', () => {
@@ -41,18 +48,20 @@ describe('DuckDBShell', () => {
         // Mock a slow query
         mockQuery.mockImplementation(
             () =>
-                new Promise((resolve) =>
-                    setTimeout(
-                        () =>
-                            resolve({
-                                schema: {
-                                    fields: [{ name: 'answer' }],
-                                },
-                                toArray: () => [{ answer: 42 }],
-                            }),
-                        100
+                new Promise((resolve) => {
+                    pendingTimers.push(
+                        setTimeout(
+                            () =>
+                                resolve({
+                                    schema: {
+                                        fields: [{ name: 'answer' }],
+                                    },
+                                    toArray: () => [{ answer: 42 }],
+                                }),
+                            100
+                        )
                     )
-                )
+                })
         )
 
         render(<DuckDBShell />)


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Closes #558

Running the app test suite reported an async leak in the DuckDBShell test. The test `should display loading state when running query` mocks a slow query with a `new Promise` wrapping a `setTimeout` (100 ms). The test only waits for the loading state to appear and returns before the timer fires, so the `Timeout` was never cleared and outlived the test. This produced an `Async Leak Report` and is a potential source of order-dependent flakiness and noise in CI.

## 🎹 Proposal

The timer created by the slow-query mock is now tracked in a list and cleared in an `afterEach` hook, so any timer still pending when a test ends is cancelled during cleanup. The test still asserts exactly what it did before — that the loading state (`Run in progress…`) is displayed while the query is running — so behaviour and coverage are unchanged. This follows the repo's testing conventions (`vi.spyOn`, no `vi.mock`).

## 🎶 Comments

Change is scoped to the single test file. No production code touched.

## 🎤 Test

Before: `moon run app:test` ended with `1 async leak detected` pointing at `DuckDBShell.test.tsx`.
After: all tests pass and no async leak is reported.
