### PR TITLE
feat(chat): style assistant response bubbles

### DIFF
--- a/app/src/components/Chat/ChatMessageList.test.tsx
+++ b/app/src/components/Chat/ChatMessageList.test.tsx
@@ -204,6 +204,25 @@ describe('ChatMessageList (unified SQL rendering)', () => {
         ).toBeNull()
     })
 
+    it('wraps the assistant response in a left-aligned message bubble', () => {
+        const { messages, customRows } = okMessages(
+            [{ total_streams: 1550 }],
+            'You streamed 1,550 tracks in 2025.'
+        )
+        render(<ChatMessageList messages={messages} customRows={customRows} />)
+
+        // The narrative text lives inside a styled bubble container.
+        const narrative = screen.getByText('You streamed 1,550 tracks in 2025.')
+        const bubble = narrative.parentElement
+        expect(bubble?.className).toContain('rounded-2xl')
+        expect(bubble?.className).toContain('rounded-bl-sm')
+        expect(bubble?.className).toContain('border-gray-200')
+
+        // The bubble is rendered on the left (assistant) side of the row.
+        const row = bubble?.closest('div.flex')
+        expect(row?.className).toContain('justify-start')
+    })
+
     it('renders a Retry button on sql-error that re-submits the preceding question', () => {
         const onRetry = vi.fn()
         const messages: ChatMessage[] = [

--- a/app/src/components/Chat/ChatMessageList.tsx
+++ b/app/src/components/Chat/ChatMessageList.tsx
@@ -45,7 +45,7 @@ function AssistantCard({
 
     if (payload.kind === 'llm-error') {
         return (
-            <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-2xl border border-red-200 dark:border-red-700/50">
+            <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-2xl rounded-bl-sm border border-red-200 dark:border-red-700/50 shadow-sm">
                 <p className="text-sm font-medium text-red-700 dark:text-red-300">
                     ⚠️ Assistant error
                 </p>
@@ -59,7 +59,7 @@ function AssistantCard({
     if (payload.kind === 'unsafe-sql') {
         return (
             <div className="space-y-2">
-                <div className="p-4 bg-amber-50 dark:bg-amber-900/20 rounded-2xl border border-amber-200 dark:border-amber-700/50">
+                <div className="p-4 bg-amber-50 dark:bg-amber-900/20 rounded-2xl rounded-bl-sm border border-amber-200 dark:border-amber-700/50 shadow-sm">
                     <p className="text-sm font-medium text-amber-700 dark:text-amber-300">
                         🔒 Query blocked
                     </p>
@@ -75,7 +75,7 @@ function AssistantCard({
     if (payload.kind === 'sql-error') {
         return (
             <div className="space-y-2">
-                <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-2xl border border-red-200 dark:border-red-700/50">
+                <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-2xl rounded-bl-sm border border-red-200 dark:border-red-700/50 shadow-sm">
                     <p className="text-sm font-medium text-red-700 dark:text-red-300">
                         ⚠️ Query failed
                     </p>
@@ -99,7 +99,7 @@ function AssistantCard({
 
     if (payload.kind === 'aborted') {
         return (
-            <div className="p-4 bg-gray-50 dark:bg-slate-800/50 rounded-2xl border border-gray-200 dark:border-slate-700/50">
+            <div className="p-4 bg-gray-50 dark:bg-slate-800/60 rounded-2xl rounded-bl-sm border border-gray-200 dark:border-slate-700/60 shadow-sm">
                 <p className="text-sm text-gray-500 dark:text-gray-400">
                     Request cancelled.
                 </p>
@@ -121,8 +121,8 @@ function AssistantCard({
         (hasNoResults ? 'No results found for this query.' : answer.explanation)
     const isStreaming = !narrative && !!streamingNarrative
     return (
-        <div className="space-y-2">
-            <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed px-1">
+        <div className="space-y-2 p-4 bg-white dark:bg-slate-800/60 border border-gray-200 dark:border-slate-700/60 rounded-2xl rounded-bl-sm shadow-sm">
+            <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
                 {narrativeText}
                 {isStreaming && <span className="animate-pulse">▌</span>}
             </p>


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

In the Chat tab, user prompts are rendered as rounded chat bubbles aligned to the right, but assistant answers were displayed as plain content blocks without any message container. This created a visual inconsistency and made the exchange feel less like a real conversation.

Closes #428

## 🎹 Proposal

Assistant answers now appear inside a dedicated, left-aligned message bubble, mirroring the user bubbles on the opposite side. The bubble uses the existing design system: a subtle surface background, a light border, and a chat "tail" corner (the bottom-left corner is squared off, the mirror image of the user bubble's bottom-right tail). It reads correctly in both light and dark themes.

The tail corner is also applied to the other assistant states (query blocked, query failed, assistant error, and cancelled request) so every assistant message shares the same bubble identity.

| Before | After | 
|-|-|
| <img width="942" height="818" alt="current render of the agent message" src="https://github.com/user-attachments/assets/d16b489f-45ce-43a0-823b-bc7e3351e1e0" /> | <img width="942" height="818" alt="pr s render of the agent message" src="https://github.com/user-attachments/assets/7d607aee-bc1e-4345-8c40-3ec80672d644" /> |

## 🎶 Comments

The change is scoped to the Chat message rendering only. The error, warning and aborted states already had their own coloured containers and keep their semantics; they just gain the shared tail corner for consistency.

## 🎤 Test

Manual check: open the Chat tab, ask a question (e.g. "Top artists in 2022"), and confirm the assistant response is shown inside a left-aligned bubble in both light and dark mode.
