### PR TITLE
fix(chat): align Chat tab layout width with other tabs

### DIFF
--- a/app/src/components/Charts/ChatView.test.tsx
+++ b/app/src/components/Charts/ChatView.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { ChatView } from './ChatView'
+
+describe('ChatView', () => {
+    it('uses the full container width like the other tabs', () => {
+        const { container } = render(<ChatView />)
+
+        const root = container.firstChild as HTMLElement
+        expect(root).toBeTruthy()
+        // The Chat tab must not constrain its content to a narrower width than
+        // the other tabs (see issue #431).
+        expect(root.className).not.toMatch(/max-w-/)
+    })
+})

--- a/app/src/components/Charts/ChatView.tsx
+++ b/app/src/components/Charts/ChatView.tsx
@@ -164,7 +164,7 @@ export function ChatView() {
     const isLoading = state.kind === 'loading' || isAsking
 
     return (
-        <div className="flex flex-col gap-4 max-w-3xl mx-auto py-4">
+        <div className="flex flex-col gap-4 py-4">
             <MemoryNotice />
             <ModelLoader state={state} onEnable={handleEnable} />
 


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The Chat tab rendered its content in a narrower column than the Simple, Lab, and Query tabs. Those tabs fill the shared page container (`max-w-4xl`), but the Chat tab added an extra `max-w-3xl` constraint on its root element, so the content sat in a narrower box. This made the layout jump inward when switching to the Chat tab and back, an inconsistent experience.

Closes #431

## 🎹 Proposal

Remove the extra `max-w-3xl mx-auto` width constraint from the Chat tab's root container so it uses the same maximum width and responsive layout behaviour as the other tabs, all bounded by the shared page container.

| Simple tab | Chat tab before | Chat tab now | 
|-|-|-|
| <img width="942" height="818" alt="simple tab" src="https://github.com/user-attachments/assets/1e126389-7550-4bb9-8c57-256b626976df" /> | <img width="942" height="818" alt="current chat tab" src="https://github.com/user-attachments/assets/c6a6ad70-72aa-46b6-a8b9-09c192875299" /> | <img width="942" height="818" alt="pr s chat tab, similar width as the simple tab " src="https://github.com/user-attachments/assets/6fe5f9ce-b61a-4f8f-a15c-7401ce150415" /> |


## 🎶 Comments

The change is limited to the Chat view container. All other tabs already relied on the shared page-level width, so no changes were needed there.

## 🎤 Test

1. Load data (or use the demo dataset).
2. Switch between the Simple, Lab, Query, and Chat tabs.
3. The content area keeps the same width across all tabs; the Chat tab no longer shrinks inward.

A regression test asserts the Chat view root no longer applies a `max-w-*` constraint.
