### PR TITLE
feat(chat): user-selectable assistant profiles with device-aware onboarding

### DIFF
--- a/app/astro.config.mjs
+++ b/app/astro.config.mjs
@@ -88,6 +88,21 @@ export default defineConfig({
         build: {
             rollupOptions: {
                 external: DUCKDB_EXTERNALS,
+                output: {
+                    // Keep the light assistant config/device modules in their
+                    // own chunk so they can never be folded into the ~5.7 MB
+                    // web-llm `engine` chunk — which would pull it eagerly when
+                    // the Chat tab opens instead of on "Enable assistant".
+                    manualChunks(id) {
+                        if (
+                            id.includes('src/llm/assistantConfig') ||
+                            id.includes('src/llm/deviceDetection') ||
+                            id.includes('src/llm/modelState')
+                        ) {
+                            return 'assistant-config'
+                        }
+                    },
+                },
             },
         },
         optimizeDeps: {

--- a/app/src/components/Charts/ChatView.tsx
+++ b/app/src/components/Charts/ChatView.tsx
@@ -5,6 +5,7 @@ import type { ChatMessage, AssistantPayload } from '../../llm/types'
 import type { DBRow } from '../../llm/inferChartType'
 import type { ChartConfig } from '../../llm/askChartConfig'
 import { ModelLoader } from '../Chat/ModelLoader'
+import { AssistantSettings } from '../Chat/AssistantSettings'
 import { ChatInput } from '../Chat/ChatInput'
 import { ChatMessageList } from '../Chat/ChatMessageList'
 import { ChatShortcuts } from '../Chat/ChatShortcuts'
@@ -37,11 +38,20 @@ export function ChatView() {
     const [isAsking, setIsAsking] = useState(false)
     const [pendingQuestion, setPendingQuestion] = useState<string | null>(null)
     const [streamingNarrative, setStreamingNarrative] = useState('')
+    const [settingsOpen, setSettingsOpen] = useState(false)
     const streamingMsgIdRef = useRef<string | null>(null)
     const messagesRef = useRef(messages)
     const bottomRef = useRef<HTMLDivElement>(null)
 
-    const { state, ensureLoaded, ask, cancel } = useChatEngine()
+    const {
+        state,
+        config,
+        ensureLoaded,
+        enableWith,
+        applyConfig,
+        ask,
+        cancel,
+    } = useChatEngine()
 
     useEffect(() => {
         const handler = () => {
@@ -166,10 +176,40 @@ export function ChatView() {
     return (
         <div className="flex flex-col gap-4 py-4">
             <MemoryNotice />
-            <ModelLoader state={state} onEnable={handleEnable} />
+
+            {state.kind === 'idle' ? (
+                <AssistantSettings mode="onboarding" onSubmit={enableWith} />
+            ) : (
+                <ModelLoader state={state} onEnable={handleEnable} />
+            )}
+
+            {isReady && settingsOpen && (
+                <AssistantSettings
+                    mode="settings"
+                    initialConfig={config}
+                    onSubmit={(next) => {
+                        applyConfig(next)
+                        setSettingsOpen(false)
+                    }}
+                    onCancel={() => setSettingsOpen(false)}
+                />
+            )}
 
             {isReady && (
                 <div className="flex flex-col gap-4">
+                    <div className="flex justify-end">
+                        <button
+                            type="button"
+                            onClick={() => setSettingsOpen((v) => !v)}
+                            aria-expanded={settingsOpen}
+                            className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+                        >
+                            <span aria-hidden="true" className="text-lg">
+                                ⚙️
+                            </span>
+                            Settings
+                        </button>
+                    </div>
                     <div className="min-h-64">
                         <ChatMessageList
                             messages={messages}

--- a/app/src/components/Chat/AssistantSettings.tsx
+++ b/app/src/components/Chat/AssistantSettings.tsx
@@ -1,0 +1,318 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+    PRESET_NAMES,
+    PRESET_LABELS,
+    PRESETS,
+    MODEL_LARGE,
+    MODEL_SMALL,
+    matchPreset,
+    type AssistantConfig,
+    type ChartMode,
+    type NarrativeMode,
+    type PresetName,
+} from '../../llm/assistantConfig'
+import type { ModelInfo } from '../../llm/engine'
+import { recommendPreset } from '../../llm/recommendPreset'
+
+type Axes = Pick<AssistantConfig, 'modelId' | 'chart' | 'narrative'>
+
+type Props = {
+    mode: 'onboarding' | 'settings'
+    /** Current config, for the settings panel. */
+    initialConfig?: AssistantConfig | null
+    onSubmit: (config: AssistantConfig) => void
+    onCancel?: () => void
+}
+
+const KNOWN_GOOD = new Set([MODEL_LARGE, MODEL_SMALL])
+
+const CHART_LABELS: Record<ChartMode, string> = {
+    llm: 'AI-picked chart',
+    infer: 'Quick chart (heuristic)',
+    off: 'Table only',
+}
+
+const NARRATIVE_LABELS: Record<NarrativeMode, string> = {
+    stream: 'Written insights (AI)',
+    static: 'Plain summary',
+}
+
+function formatSize(vramMB?: number): string {
+    if (!vramMB) return ''
+    return vramMB >= 1024
+        ? `~${(vramMB / 1024).toFixed(1)} GB`
+        : `~${Math.round(vramMB)} MB`
+}
+
+export function AssistantSettings({
+    mode,
+    initialConfig,
+    onSubmit,
+    onCancel,
+}: Props) {
+    const initialAxes: Axes = initialConfig
+        ? {
+              modelId: initialConfig.modelId,
+              chart: initialConfig.chart,
+              narrative: initialConfig.narrative,
+          }
+        : PRESETS.balanced
+
+    const [axes, setAxes] = useState<Axes>(initialAxes)
+    const [recommended, setRecommended] = useState<PresetName | null>(null)
+    // In onboarding we defer enabling until the device probe resolves, so a fast
+    // click can't skip the recommended default and load too heavy a model.
+    const [recommending, setRecommending] = useState(mode === 'onboarding')
+    const [advancedOpen, setAdvancedOpen] = useState(false)
+    const [models, setModels] = useState<ModelInfo[]>([])
+    // Once the user picks anything, stop auto-applying the recommendation.
+    const touchedRef = useRef(mode === 'settings')
+
+    const selectedPreset = useMemo(() => matchPreset(axes), [axes])
+
+    // Compute the device recommendation for onboarding and pre-select it.
+    useEffect(() => {
+        if (mode !== 'onboarding') return
+        let cancelled = false
+        recommendPreset()
+            .then((preset) => {
+                if (cancelled) return
+                const name = preset === 'custom' ? 'balanced' : preset
+                setRecommended(name)
+                if (!touchedRef.current) setAxes(PRESETS[name])
+            })
+            .catch(() => {
+                // recommendPreset isn't written to reject, but keep the default
+                // balanced selection rather than surface an unhandled rejection.
+            })
+            .finally(() => {
+                if (!cancelled) setRecommending(false)
+            })
+        return () => {
+            cancelled = true
+        }
+    }, [mode])
+
+    // Lazy-load the model catalog only when Advanced is opened, so
+    // @mlc-ai/web-llm stays out of the main bundle.
+    useEffect(() => {
+        if (!advancedOpen || models.length > 0) return
+        let cancelled = false
+        import('../../llm/engine').then((mod) => {
+            if (!cancelled) setModels(mod.listModels())
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [advancedOpen, models.length])
+
+    function choosePreset(name: PresetName) {
+        touchedRef.current = true
+        setAxes(PRESETS[name])
+    }
+
+    function updateAxis<K extends keyof Axes>(key: K, value: Axes[K]) {
+        touchedRef.current = true
+        setAxes((prev) => ({ ...prev, [key]: value }))
+    }
+
+    function submit() {
+        onSubmit({ preset: selectedPreset, ...axes })
+    }
+
+    const modelUnverified = !KNOWN_GOOD.has(axes.modelId)
+    const modelChanged =
+        mode === 'settings' && initialConfig?.modelId !== axes.modelId
+    // Prefer the real weight size from the catalogue (only loaded once Advanced
+    // is opened); otherwise fall back to generic phrasing.
+    const selectedModelSize = formatSize(
+        models.find((m) => m.id === axes.modelId)?.vramMB
+    )
+
+    return (
+        <div className="p-6 bg-white dark:bg-slate-900/80 backdrop-blur-md rounded-2xl border border-gray-300/60 dark:border-slate-700/50 text-gray-900 dark:text-gray-100">
+            <h3 className="text-lg font-semibold mb-1">
+                {mode === 'onboarding'
+                    ? '💬 How should the assistant run?'
+                    : '⚙️ Assistant settings'}
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                Everything runs locally in your browser. Pick a profile — one is
+                recommended for your device.
+            </p>
+
+            <fieldset className="space-y-2 mb-4">
+                <legend className="sr-only">Assistant profile</legend>
+                {PRESET_NAMES.map((name) => {
+                    const isSelected = selectedPreset === name
+                    const isRecommended = recommended === name
+                    return (
+                        <label
+                            key={name}
+                            className={`flex items-start gap-3 p-3 rounded-xl border cursor-pointer transition-colors ${
+                                isSelected
+                                    ? 'border-brand-purple bg-brand-purple/5'
+                                    : 'border-gray-200 dark:border-slate-700 hover:border-gray-300 dark:hover:border-slate-600'
+                            }`}
+                        >
+                            <input
+                                type="radio"
+                                name="assistant-preset"
+                                className="mt-1 accent-brand-purple"
+                                checked={isSelected}
+                                onChange={() => choosePreset(name)}
+                            />
+                            <span className="flex-1">
+                                <span className="flex items-center gap-2">
+                                    <span className="font-medium">
+                                        {PRESET_LABELS[name].title}
+                                    </span>
+                                    {isRecommended && (
+                                        <span className="text-xs px-1.5 py-0.5 rounded-full bg-brand-purple/15 text-brand-purple font-medium">
+                                            Recommended
+                                        </span>
+                                    )}
+                                </span>
+                                <span className="block text-sm text-gray-600 dark:text-gray-400">
+                                    {PRESET_LABELS[name].summary}
+                                </span>
+                            </span>
+                        </label>
+                    )
+                })}
+            </fieldset>
+
+            <details
+                open={advancedOpen}
+                onToggle={(e) =>
+                    setAdvancedOpen((e.target as HTMLDetailsElement).open)
+                }
+                className="mb-4"
+            >
+                <summary className="cursor-pointer text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 select-none">
+                    Advanced
+                    {selectedPreset === 'custom' && ' · custom'}
+                </summary>
+                <div className="mt-3 space-y-3">
+                    <label className="block text-sm">
+                        <span className="block mb-1 text-gray-600 dark:text-gray-400">
+                            Model
+                        </span>
+                        <select
+                            className="w-full p-2 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-sm"
+                            value={axes.modelId}
+                            onChange={(e) =>
+                                updateAxis('modelId', e.target.value)
+                            }
+                        >
+                            {models.length === 0 && (
+                                <option value={axes.modelId}>
+                                    {axes.modelId}
+                                </option>
+                            )}
+                            {models.map((m) => (
+                                <option key={m.id} value={m.id}>
+                                    {m.id}
+                                    {m.vramMB
+                                        ? ` — ${formatSize(m.vramMB)}`
+                                        : ''}
+                                    {KNOWN_GOOD.has(m.id)
+                                        ? ''
+                                        : ' (unverified)'}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+
+                    <label className="block text-sm">
+                        <span className="block mb-1 text-gray-600 dark:text-gray-400">
+                            Chart
+                        </span>
+                        <select
+                            className="w-full p-2 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-sm"
+                            value={axes.chart}
+                            onChange={(e) =>
+                                updateAxis('chart', e.target.value as ChartMode)
+                            }
+                        >
+                            {(['llm', 'infer', 'off'] as ChartMode[]).map(
+                                (c) => (
+                                    <option key={c} value={c}>
+                                        {CHART_LABELS[c]}
+                                    </option>
+                                )
+                            )}
+                        </select>
+                    </label>
+
+                    <label className="block text-sm">
+                        <span className="block mb-1 text-gray-600 dark:text-gray-400">
+                            Narrative
+                        </span>
+                        <select
+                            className="w-full p-2 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-sm"
+                            value={axes.narrative}
+                            onChange={(e) =>
+                                updateAxis(
+                                    'narrative',
+                                    e.target.value as NarrativeMode
+                                )
+                            }
+                        >
+                            {(['stream', 'static'] as NarrativeMode[]).map(
+                                (n) => (
+                                    <option key={n} value={n}>
+                                        {NARRATIVE_LABELS[n]}
+                                    </option>
+                                )
+                            )}
+                        </select>
+                    </label>
+
+                    {modelUnverified && (
+                        <p className="text-xs text-amber-600 dark:text-amber-400">
+                            ⚠️ This model isn't verified with Tracksy's prompts
+                            — answers may be unreliable.
+                        </p>
+                    )}
+                </div>
+            </details>
+
+            {modelChanged && (
+                <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                    Changing the model will re-download the new weights.
+                </p>
+            )}
+
+            <div className="flex items-center gap-3">
+                <button
+                    onClick={submit}
+                    disabled={recommending}
+                    className="px-4 py-2 bg-gradient-brand text-white font-semibold rounded-xl shadow-glow transition-all disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                    {recommending
+                        ? 'Checking your device…'
+                        : mode === 'onboarding'
+                          ? 'Enable assistant'
+                          : 'Apply'}
+                </button>
+                {mode === 'settings' && onCancel && (
+                    <button
+                        onClick={onCancel}
+                        className="px-4 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100"
+                    >
+                        Cancel
+                    </button>
+                )}
+            </div>
+
+            {mode === 'onboarding' && (
+                <p className="text-xs text-gray-500 dark:text-gray-500 mt-3">
+                    First enable downloads{' '}
+                    {selectedModelSize || 'the model weights'}; afterwards
+                    everything works offline. You can change this later.
+                </p>
+            )}
+        </div>
+    )
+}

--- a/app/src/components/Chat/ModelLoader.tsx
+++ b/app/src/components/Chat/ModelLoader.tsx
@@ -10,8 +10,8 @@ function DegradedNotice() {
         <div className="flex items-start gap-2 p-3 rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200/60 dark:border-amber-700/40 text-amber-800 dark:text-amber-300 text-sm">
             <span className="shrink-0">⚠️</span>
             <p>
-                A lighter model is used on this device. Responses may be less
-                accurate — especially for time-based questions.
+                A non-default model is in use — responses may be less reliable,
+                especially for time-based questions.
             </p>
         </div>
     )

--- a/app/src/hooks/useChatEngine.test.ts
+++ b/app/src/hooks/useChatEngine.test.ts
@@ -4,8 +4,15 @@ import type { MLCEngineInterface } from '@mlc-ai/web-llm'
 import { useChatEngine, type AskResult } from './useChatEngine'
 import * as engineModule from '../llm/engine'
 import * as askLLMModule from '../llm/askLLM'
+import * as askChartConfigModule from '../llm/askChartConfig'
 import * as queryDBModule from '../db/queries/queryDB'
 import * as deviceDetection from '../llm/deviceDetection'
+import {
+    configFromPreset,
+    saveConfig,
+    ASSISTANT_CONFIG_KEY,
+    type PresetName,
+} from '../llm/assistantConfig'
 import { makeChatAnswer } from '../llm/testHelpers'
 
 const ASSISTANT_ENABLED_KEY = 'tracksy:assistantEnabled'
@@ -24,10 +31,10 @@ beforeEach(() => {
     vi.spyOn(deviceDetection, 'isMobileBrowser').mockReturnValue(false)
 })
 
-async function loadedHook() {
+async function loadedHook(preset: PresetName = 'rich') {
     const hook = renderHook(() => useChatEngine())
     await act(async () => {
-        await hook.result.current.ensureLoaded()
+        await hook.result.current.enableWith(configFromPreset(preset))
     })
     return hook
 }
@@ -42,53 +49,57 @@ async function ask(
     return result!
 }
 
-describe('useChatEngine — fresh visit', () => {
-    it('stays idle when no preference is stored', () => {
+describe('useChatEngine — onboarding gate', () => {
+    it('stays idle when no config is stored', () => {
         const { result } = renderHook(() => useChatEngine())
+        expect(result.current.state.kind).toBe('idle')
+    })
+
+    it('shows onboarding (stays idle) for a pre-feature user who is enabled but has no config', async () => {
+        localStorage.setItem(ASSISTANT_ENABLED_KEY, 'true')
+
+        const { result } = renderHook(() => useChatEngine())
+
+        // Give the mount effect a tick; it must NOT auto-load without a config.
+        await act(async () => {
+            await Promise.resolve()
+        })
         expect(result.current.state.kind).toBe('idle')
     })
 })
 
 describe('useChatEngine — returning visit', () => {
-    it('auto-starts loading when preference key is set', async () => {
+    it('auto-loads when both enabled flag and a stored config are present', async () => {
         localStorage.setItem(ASSISTANT_ENABLED_KEY, 'true')
+        saveConfig(configFromPreset('rich'))
 
         const { result } = renderHook(() => useChatEngine())
 
-        // jsdom has no WebGPU, so ensureLoaded() settles to 'unsupported' —
-        // but any non-idle state proves the auto-load fired.
         await waitFor(() => {
             expect(result.current.state.kind).not.toBe('idle')
         })
     })
 })
 
-describe('useChatEngine — explicit enable', () => {
-    it('writes the preference key to localStorage when ensureLoaded is called', async () => {
+describe('useChatEngine — enableWith', () => {
+    it('persists the config and enabled flag, then leaves idle', async () => {
         const { result } = renderHook(() => useChatEngine())
 
         expect(localStorage.getItem(ASSISTANT_ENABLED_KEY)).toBeNull()
+        expect(localStorage.getItem(ASSISTANT_CONFIG_KEY)).toBeNull()
 
         await act(async () => {
-            await result.current.ensureLoaded()
+            await result.current.enableWith(configFromPreset('lite'))
         })
 
         expect(localStorage.getItem(ASSISTANT_ENABLED_KEY)).toBe('true')
-    })
-
-    it('transitions away from idle after explicit enable', async () => {
-        const { result } = renderHook(() => useChatEngine())
-
-        await act(async () => {
-            await result.current.ensureLoaded()
-        })
-
+        expect(localStorage.getItem(ASSISTANT_CONFIG_KEY)).toContain('lite')
         expect(result.current.state.kind).not.toBe('idle')
     })
 })
 
 describe('useChatEngine.ask (unified SQL path)', () => {
-    it('executes the generated SQL and returns rows for a preset (non-custom) intent', async () => {
+    it('executes the generated SQL and returns rows', async () => {
         const rows = [{ artist_name: 'Radiohead', c: 1204 }]
         vi.spyOn(askLLMModule, 'askLLM').mockResolvedValue(
             answer({ intent: 'top_artists' })
@@ -104,27 +115,62 @@ describe('useChatEngine.ask (unified SQL path)', () => {
         expect(result.rows).toEqual(rows)
     })
 
-    it('attaches streamNarrator on desktop and omits it on mobile', async () => {
+    it('streams the narrative for a stream config (Rich) and skips it for a static config (Lite)', async () => {
         vi.spyOn(askLLMModule, 'askLLM').mockResolvedValue(answer())
         vi.spyOn(queryDBModule, 'queryDBAsJSON').mockResolvedValue([{ x: 1 }])
 
-        const desktop = await ask(await loadedHook())
-        expect(desktop.streamNarrator).toBeTypeOf('function')
+        const rich = await ask(await loadedHook('rich'))
+        expect(rich.streamNarrator).toBeTypeOf('function')
 
-        vi.spyOn(deviceDetection, 'isMobileBrowser').mockReturnValue(true)
-        const mobile = await ask(await loadedHook())
-        expect(mobile.streamNarrator).toBeUndefined()
+        const lite = await ask(await loadedHook('lite'))
+        expect(lite.streamNarrator).toBeUndefined()
     })
 
-    it('omits streamNarrator when SQL returns empty rows to prevent hallucination', async () => {
+    it('runs the ChartAgent for a llm-chart config (Rich)', async () => {
+        vi.spyOn(askLLMModule, 'askLLM').mockResolvedValue(answer())
+        vi.spyOn(queryDBModule, 'queryDBAsJSON').mockResolvedValue([{ x: 1 }])
+        const chartSpy = vi
+            .spyOn(askChartConfigModule, 'askChartConfig')
+            .mockResolvedValue({ type: 'metric', key: 'x' })
+
+        const result = await ask(await loadedHook('rich'))
+
+        expect(chartSpy).toHaveBeenCalledTimes(1)
+        expect(result.chartConfig).toEqual({ type: 'metric', key: 'x' })
+    })
+
+    it('renders a table without the ChartAgent for an off-chart config (Minimal)', async () => {
+        vi.spyOn(askLLMModule, 'askLLM').mockResolvedValue(answer())
+        vi.spyOn(queryDBModule, 'queryDBAsJSON').mockResolvedValue([{ x: 1 }])
+        const chartSpy = vi.spyOn(askChartConfigModule, 'askChartConfig')
+
+        const result = await ask(await loadedHook('minimal'))
+
+        expect(chartSpy).not.toHaveBeenCalled()
+        expect(result.chartConfig).toEqual({ type: 'table' })
+    })
+
+    it('leaves chartConfig undefined for an infer-chart config (Lite)', async () => {
+        vi.spyOn(askLLMModule, 'askLLM').mockResolvedValue(answer())
+        vi.spyOn(queryDBModule, 'queryDBAsJSON').mockResolvedValue([{ x: 1 }])
+        const chartSpy = vi.spyOn(askChartConfigModule, 'askChartConfig')
+
+        const result = await ask(await loadedHook('lite'))
+
+        expect(chartSpy).not.toHaveBeenCalled()
+        expect(result.chartConfig).toBeUndefined()
+    })
+
+    it('omits chart + narrator when SQL returns empty rows', async () => {
         vi.spyOn(askLLMModule, 'askLLM').mockResolvedValue(answer())
         vi.spyOn(queryDBModule, 'queryDBAsJSON').mockResolvedValue([])
 
-        const result = await ask(await loadedHook())
+        const result = await ask(await loadedHook('rich'))
 
         expect(result.payload.kind).toBe('ok')
         expect(result.rows).toEqual([])
         expect(result.streamNarrator).toBeUndefined()
+        expect(result.chartConfig).toBeUndefined()
     })
 
     it('retries once with the error appended when the first SQL fails', async () => {
@@ -140,7 +186,7 @@ describe('useChatEngine.ask (unified SQL path)', () => {
             .mockRejectedValueOnce(new Error('boom'))
             .mockResolvedValueOnce([{ ok: 1 }])
 
-        const result = await ask(await loadedHook())
+        const result = await ask(await loadedHook('minimal'))
 
         expect(askSpy).toHaveBeenCalledTimes(2)
         expect(askSpy.mock.calls[1][1]).toContain('Previous SQL failed with:')
@@ -160,7 +206,7 @@ describe('useChatEngine.ask (unified SQL path)', () => {
             .mockRejectedValueOnce(new Error('boom1'))
             .mockRejectedValueOnce(new Error('boom2'))
 
-        const result = await ask(await loadedHook())
+        const result = await ask(await loadedHook('minimal'))
 
         expect(result.payload.kind).toBe('sql-error')
     })
@@ -171,7 +217,7 @@ describe('useChatEngine.ask (unified SQL path)', () => {
         )
         const querySpy = vi.spyOn(queryDBModule, 'queryDBAsJSON')
 
-        const result = await ask(await loadedHook())
+        const result = await ask(await loadedHook('minimal'))
 
         expect(result.payload.kind).toBe('unsafe-sql')
         expect(querySpy).not.toHaveBeenCalled()

--- a/app/src/hooks/useChatEngine.ts
+++ b/app/src/hooks/useChatEngine.ts
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { queryDBAsJSON } from '../db/queries/queryDB'
 import { validateSql } from '../llm/sqlSafety'
-import { isMobileBrowser } from '../llm/deviceDetection'
+import {
+    getStoredConfig,
+    saveConfig,
+    MODEL_LARGE,
+    type AssistantConfig,
+} from '../llm/assistantConfig'
 import {
     LLMError,
     type AssistantPayload,
@@ -22,64 +27,150 @@ function setAssistantEnabled(): void {
     localStorage.setItem(ASSISTANT_ENABLED_KEY, 'true')
 }
 
+/**
+ * Any model other than the default full model may give lower-quality answers
+ * (a lighter built-in model, or a custom/unverified model chosen in Advanced) —
+ * surfaced via a notice.
+ */
+function isDegradedConfig(config: AssistantConfig): boolean {
+    return config.modelId !== MODEL_LARGE
+}
+
 export type AskResult = {
     payload: AssistantPayload
     rows?: Record<string, string | number | null>[]
     chartConfig?: ChartConfig
     /**
      * Call after rendering the chart to stream a narrative summary of `rows`.
-     * Only attached on capable (non-degraded/desktop) engines — on mobile the
-     * UI shows the static explanation instead. Absent when not available.
+     * Only attached when the active config's narrative mode is `stream`;
+     * otherwise the UI shows the static explanation. Absent when not available.
      */
     streamNarrator?: (onChunk: (delta: string) => void) => Promise<string>
 }
 
 export function useChatEngine() {
-    const isDegraded = isMobileBrowser()
+    const [config, setConfig] = useState<AssistantConfig | null>(
+        getStoredConfig
+    )
     const [state, setState] = useState<EngineState>({
         kind: 'idle',
-        isDegraded,
+        isDegraded: false,
     })
     // Holds the dynamically imported module + engine instance so we don't
     // bloat the main bundle with @mlc-ai/web-llm.
     const moduleRef = useRef<typeof import('../llm/engine') | null>(null)
     const askLLMRef = useRef<typeof import('../llm/askLLM') | null>(null)
     const abortRef = useRef<AbortController | null>(null)
+    // Latest config + the model actually loaded into the engine, read inside
+    // callbacks without adding React deps.
+    const configRef = useRef<AssistantConfig | null>(config)
+    const loadedModelRef = useRef<string | null>(null)
 
+    useEffect(() => {
+        configRef.current = config
+    }, [config])
+
+    const loadModules = useCallback(async () => {
+        if (!moduleRef.current) {
+            moduleRef.current = await import('../llm/engine')
+        }
+        if (!askLLMRef.current) {
+            askLLMRef.current = await import('../llm/askLLM')
+        }
+        return moduleRef.current
+    }, [])
+
+    const loadWith = useCallback(
+        async (cfg: AssistantConfig) => {
+            setAssistantEnabled()
+            try {
+                const { isWebGPUAvailable, getEngine } = await loadModules()
+                if (!isWebGPUAvailable()) {
+                    setState({
+                        kind: 'unsupported',
+                        reason: 'WebGPU is not available in this browser. Use Chrome, Edge, or a recent Safari to enable the chat assistant.',
+                    })
+                    return
+                }
+                setState({ kind: 'loading', progress: 0, text: 'Starting…' })
+                await getEngine(cfg.modelId, (report) => {
+                    setState({
+                        kind: 'loading',
+                        progress: report.progress,
+                        text: report.text,
+                    })
+                })
+                loadedModelRef.current = cfg.modelId
+                setState({ kind: 'ready', isDegraded: isDegradedConfig(cfg) })
+            } catch (e) {
+                setState({
+                    kind: 'error',
+                    error: e instanceof Error ? e.message : String(e),
+                })
+            }
+        },
+        [loadModules]
+    )
+
+    // Load using the current/stored config. No-op until the user has chosen one
+    // (the onboarding picker supplies it via `enableWith`).
     const ensureLoaded = useCallback(async () => {
         if (state.kind === 'ready' || state.kind === 'loading') return
-        setAssistantEnabled()
+        const cfg = configRef.current ?? getStoredConfig()
+        if (!cfg) return
+        await loadWith(cfg)
+    }, [state.kind, loadWith])
+
+    // First-time enable from the onboarding picker: persist the choice, then load.
+    const enableWith = useCallback(
+        async (cfg: AssistantConfig) => {
+            saveConfig(cfg)
+            configRef.current = cfg
+            setConfig(cfg)
+            await loadWith(cfg)
+        },
+        [loadWith]
+    )
+
+    // Apply a config change from the settings panel. Agent-toggle changes take
+    // effect on the next question with no reload; a model change unloads the
+    // engine and re-downloads the new weights.
+    const applyConfig = useCallback(async (cfg: AssistantConfig) => {
+        saveConfig(cfg)
+        const prevModel = loadedModelRef.current
+        configRef.current = cfg
+        setConfig(cfg)
+
+        if (!prevModel || prevModel === cfg.modelId || !moduleRef.current) {
+            // No model swap needed — new axes are read on the next `ask`.
+            setState((prev) =>
+                prev.kind === 'ready'
+                    ? { kind: 'ready', isDegraded: isDegradedConfig(cfg) }
+                    : prev
+            )
+            return
+        }
+
+        setState({ kind: 'loading', progress: 0, text: 'Switching model…' })
         try {
-            if (!moduleRef.current) {
-                moduleRef.current = await import('../llm/engine')
-            }
-            if (!askLLMRef.current) {
-                askLLMRef.current = await import('../llm/askLLM')
-            }
-            const { isWebGPUAvailable, getEngine } = moduleRef.current
-            if (!isWebGPUAvailable()) {
-                setState({
-                    kind: 'unsupported',
-                    reason: 'WebGPU is not available in this browser. Use Chrome, Edge, or a recent Safari to enable the chat assistant.',
-                })
-                return
-            }
-            setState({ kind: 'loading', progress: 0, text: 'Starting…' })
-            await getEngine((report) => {
+            // getEngine tears down the previous model and loads the new one
+            // atomically when the requested modelId differs.
+            await moduleRef.current.getEngine(cfg.modelId, (report) => {
                 setState({
                     kind: 'loading',
                     progress: report.progress,
                     text: report.text,
                 })
             })
-            setState({ kind: 'ready', isDegraded })
+            loadedModelRef.current = cfg.modelId
+            setState({ kind: 'ready', isDegraded: isDegradedConfig(cfg) })
         } catch (e) {
             setState({
                 kind: 'error',
                 error: e instanceof Error ? e.message : String(e),
             })
         }
-    }, [state.kind])
+    }, [])
 
     const ask = useCallback(
         async (
@@ -87,8 +178,9 @@ export function useChatEngine() {
             history: ChatMessage[]
         ): Promise<AskResult> => {
             type QueryResult = Record<string, string | number | null>
+            const cfg = configRef.current
             try {
-                if (!moduleRef.current || !askLLMRef.current) {
+                if (!moduleRef.current || !askLLMRef.current || !cfg) {
                     return {
                         payload: {
                             kind: 'llm-error',
@@ -97,7 +189,7 @@ export function useChatEngine() {
                     }
                 }
                 abortRef.current = new AbortController()
-                const engine = await moduleRef.current.getEngine()
+                const engine = await moduleRef.current.getEngine(cfg.modelId)
                 const answer = await askLLMRef.current.askLLM(
                     engine,
                     userText,
@@ -162,30 +254,40 @@ export function useChatEngine() {
                     rows,
                 }
 
-                // ChartAgent + NarratorAgent only on capable (desktop) engines.
-                // Skip on empty results — nothing to visualize or narrate.
-                if (!isDegraded && rows.length > 0) {
-                    try {
-                        const { askChartConfig } =
-                            await import('../llm/askChartConfig')
-                        result.chartConfig = await askChartConfig(
-                            engine,
-                            userText,
-                            rows
-                        )
-                    } catch {
-                        // GenericChartRenderer falls back to inferConfig — no regression
+                // Chart + narrative are driven by the active config. Skip on
+                // empty results — nothing to visualize or narrate.
+                if (rows.length > 0) {
+                    if (cfg.chart === 'llm') {
+                        try {
+                            const { askChartConfig } =
+                                await import('../llm/askChartConfig')
+                            result.chartConfig = await askChartConfig(
+                                engine,
+                                userText,
+                                rows
+                            )
+                        } catch {
+                            // GenericChartRenderer falls back to inferConfig — no regression
+                        }
+                    } else if (cfg.chart === 'off') {
+                        // Minimal: render the rows verbatim as a table.
+                        result.chartConfig = { type: 'table' }
                     }
-                    result.streamNarrator = async (onChunk) => {
-                        const { askNarrator } =
-                            await import('../llm/askNarrator')
-                        return askNarrator(
-                            engine,
-                            userText,
-                            rows,
-                            onChunk,
-                            finalAnswer.explanation
-                        )
+                    // cfg.chart === 'infer' → leave undefined; GenericChartRenderer
+                    // applies the heuristic inferConfig itself.
+
+                    if (cfg.narrative === 'stream') {
+                        result.streamNarrator = async (onChunk) => {
+                            const { askNarrator } =
+                                await import('../llm/askNarrator')
+                            return askNarrator(
+                                engine,
+                                userText,
+                                rows,
+                                onChunk,
+                                finalAnswer.explanation
+                            )
+                        }
                     }
                 }
 
@@ -202,7 +304,7 @@ export function useChatEngine() {
                 }
             }
         },
-        [isDegraded]
+        []
     )
 
     const cancel = useCallback(() => {
@@ -210,8 +312,24 @@ export function useChatEngine() {
     }, [])
 
     useEffect(() => {
-        if (getAssistantEnabled()) ensureLoaded()
-    }, [])
+        // Auto-load only when the user has both enabled the assistant and
+        // already chosen a config. Enabled-but-no-config (pre-feature users)
+        // falls through to the onboarding picker exactly once.
+        const cfg = getStoredConfig()
+        if (cfg && getAssistantEnabled()) {
+            configRef.current = cfg
+            setConfig(cfg)
+            loadWith(cfg)
+        }
+    }, [loadWith])
 
-    return { state, ensureLoaded, ask, cancel }
+    return {
+        state,
+        config,
+        ensureLoaded,
+        enableWith,
+        applyConfig,
+        ask,
+        cancel,
+    }
 }

--- a/app/src/llm/askChartConfig.test.ts
+++ b/app/src/llm/askChartConfig.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { askChartConfig, inferConfig } from './askChartConfig'
 import type { MLCEngineInterface } from '@mlc-ai/web-llm'
-import * as engineModule from './engine'
+import * as modelState from './modelState'
 import * as devBusModule from '../devToolbar/devBus'
 import type { DBRow } from './inferChartType'
 
@@ -24,7 +24,7 @@ const artistRows: DBRow[] = [
 ]
 
 beforeEach(() => {
-    vi.spyOn(engineModule, 'selectModelId').mockReturnValue('test-model')
+    vi.spyOn(modelState, 'getLoadedModelId').mockReturnValue('test-model')
     vi.spyOn(devBusModule.devBus, 'emit').mockImplementation(() => {})
 })
 

--- a/app/src/llm/askChartConfig.ts
+++ b/app/src/llm/askChartConfig.ts
@@ -1,7 +1,7 @@
 import type { MLCEngineInterface } from '@mlc-ai/web-llm'
 import { inferChartType, type DBRow } from './inferChartType'
 import { devBus } from '../devToolbar/devBus'
-import { selectModelId } from './engine'
+import { getLoadedModelId } from './modelState'
 
 export type ChartConfig =
     | {
@@ -207,7 +207,7 @@ export async function askChartConfig(
     const durationMs = performance.now() - start
     const tokens = response.usage?.completion_tokens ?? 0
     devBus.emit('webllm:inference', {
-        model: selectModelId(),
+        model: getLoadedModelId(),
         durationMs,
         tokensPerSec: durationMs > 0 ? tokens / (durationMs / 1000) : 0,
     })

--- a/app/src/llm/askLLM.ts
+++ b/app/src/llm/askLLM.ts
@@ -8,7 +8,7 @@ import { SYSTEM_PROMPT, FEW_SHOTS, CURRENT_DATE } from './prompt'
 import { resolveYear } from './resolveYear'
 import { LLMError, type ChatAnswer, type ChatMessage } from './types'
 import { devBus } from '../devToolbar/devBus'
-import { selectModelId } from './engine'
+import { getLoadedModelId } from './modelState'
 
 function buildMessages(
     userText: string,
@@ -159,7 +159,7 @@ export async function askLLM(
         const durationMs = performance.now() - start
         const tokens = response.usage?.completion_tokens ?? 0
         devBus.emit('webllm:inference', {
-            model: selectModelId(),
+            model: getLoadedModelId(),
             durationMs,
             tokensPerSec: durationMs > 0 ? tokens / (durationMs / 1000) : 0,
         })

--- a/app/src/llm/askNarrator.test.ts
+++ b/app/src/llm/askNarrator.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { askNarrator } from './askNarrator'
 import type { MLCEngineInterface } from '@mlc-ai/web-llm'
-import * as engineModule from './engine'
+import * as modelState from './modelState'
 import * as devBusModule from '../devToolbar/devBus'
 
 function makeChunk(content: string) {
@@ -25,7 +25,7 @@ function makeMockEngine(deltas: string[]): MLCEngineInterface {
 }
 
 beforeEach(() => {
-    vi.spyOn(engineModule, 'selectModelId').mockReturnValue('test-model')
+    vi.spyOn(modelState, 'getLoadedModelId').mockReturnValue('test-model')
     vi.spyOn(devBusModule.devBus, 'emit').mockImplementation(() => {})
 })
 

--- a/app/src/llm/askNarrator.ts
+++ b/app/src/llm/askNarrator.ts
@@ -1,7 +1,7 @@
 import type { MLCEngineInterface } from '@mlc-ai/web-llm'
 import type { DBRow } from './inferChartType'
 import { devBus } from '../devToolbar/devBus'
-import { selectModelId } from './engine'
+import { getLoadedModelId } from './modelState'
 
 const NARRATOR_SYSTEM_PROMPT = `You are a witty music companion who comments on someone's listening data like a knowledgeable friend, not a report generator.
 
@@ -85,7 +85,7 @@ export async function askNarrator(
 
     const durationMs = performance.now() - start
     devBus.emit('webllm:inference', {
-        model: selectModelId(),
+        model: getLoadedModelId(),
         durationMs,
         tokensPerSec: durationMs > 0 ? tokens / (durationMs / 1000) : 0,
     })

--- a/app/src/llm/assistantConfig.test.ts
+++ b/app/src/llm/assistantConfig.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+    ASSISTANT_CONFIG_KEY,
+    MODEL_LARGE,
+    MODEL_SMALL,
+    PRESETS,
+    configFromPreset,
+    matchPreset,
+    getStoredConfig,
+    saveConfig,
+} from './assistantConfig'
+
+beforeEach(() => {
+    localStorage.clear()
+})
+
+describe('configFromPreset', () => {
+    it('expands a preset into its axes', () => {
+        expect(configFromPreset('rich')).toEqual({
+            preset: 'rich',
+            modelId: MODEL_LARGE,
+            chart: 'llm',
+            narrative: 'stream',
+        })
+        expect(configFromPreset('minimal')).toEqual({
+            preset: 'minimal',
+            modelId: MODEL_SMALL,
+            chart: 'off',
+            narrative: 'static',
+        })
+    })
+})
+
+describe('matchPreset', () => {
+    it('recognizes each preset from its axes', () => {
+        expect(matchPreset(PRESETS.rich)).toBe('rich')
+        expect(matchPreset(PRESETS.balanced)).toBe('balanced')
+        expect(matchPreset(PRESETS.lite)).toBe('lite')
+        expect(matchPreset(PRESETS.minimal)).toBe('minimal')
+    })
+
+    it('returns custom for an off-preset combination', () => {
+        expect(
+            matchPreset({
+                modelId: MODEL_SMALL,
+                chart: 'llm',
+                narrative: 'stream',
+            })
+        ).toBe('custom')
+    })
+})
+
+describe('saveConfig / getStoredConfig', () => {
+    it('round-trips a config', () => {
+        saveConfig(configFromPreset('balanced'))
+        expect(getStoredConfig()).toEqual(configFromPreset('balanced'))
+    })
+
+    it('returns null when nothing is stored', () => {
+        expect(getStoredConfig()).toBeNull()
+    })
+
+    it('returns null for malformed JSON', () => {
+        localStorage.setItem(ASSISTANT_CONFIG_KEY, '{not json')
+        expect(getStoredConfig()).toBeNull()
+    })
+
+    it('normalizes the preset label to match the axes on save', () => {
+        // Claim "rich" but supply custom axes — the stored preset is corrected.
+        saveConfig({
+            preset: 'rich',
+            modelId: MODEL_SMALL,
+            chart: 'llm',
+            narrative: 'stream',
+        })
+        expect(getStoredConfig()?.preset).toBe('custom')
+    })
+
+    it('re-derives the preset when reading custom axes', () => {
+        localStorage.setItem(
+            ASSISTANT_CONFIG_KEY,
+            JSON.stringify({
+                modelId: MODEL_LARGE,
+                chart: 'llm',
+                narrative: 'static',
+            })
+        )
+        expect(getStoredConfig()?.preset).toBe('balanced')
+    })
+})

--- a/app/src/llm/assistantConfig.ts
+++ b/app/src/llm/assistantConfig.ts
@@ -1,0 +1,127 @@
+/**
+ * User-chosen configuration for the local chat assistant.
+ *
+ * This module is intentionally free of any `@mlc-ai/web-llm` import so it can be
+ * pulled into the main bundle (hook + UI) without dragging the engine along —
+ * the heavy engine module stays lazily imported (see `useChatEngine`).
+ */
+
+/** Larger, more capable model — used by the Rich / Balanced presets. */
+export const MODEL_LARGE = 'Qwen2.5-Coder-1.5B-Instruct-q4f16_1-MLC'
+/** Small model with the lightest download — used by Lite / Minimal. */
+export const MODEL_SMALL = 'Qwen2.5-Coder-0.5B-Instruct-q4f16_1-MLC'
+
+/**
+ * How the chart is produced from the executed SQL rows:
+ * - `llm`   — ChartAgent (`askChartConfig`) picks the chart type.
+ * - `infer` — free heuristic (`inferConfig`), no LLM call.
+ * - `off`   — render the rows as a plain table.
+ */
+export type ChartMode = 'llm' | 'infer' | 'off'
+
+/**
+ * How the textual summary is produced:
+ * - `stream` — NarratorAgent (`askNarrator`) streams a written observation.
+ * - `static` — show the deterministic `explanation` from the SQL answer.
+ */
+export type NarrativeMode = 'stream' | 'static'
+
+export const PRESET_NAMES = ['rich', 'balanced', 'lite', 'minimal'] as const
+export type PresetName = (typeof PRESET_NAMES)[number]
+/** A preset name, or `custom` when the axes don't match any preset. */
+export type AssistantPreset = PresetName | 'custom'
+
+export type AssistantConfig = {
+    preset: AssistantPreset
+    modelId: string
+    chart: ChartMode
+    narrative: NarrativeMode
+}
+
+type PresetAxes = Omit<AssistantConfig, 'preset'>
+
+export const PRESETS: Record<PresetName, PresetAxes> = {
+    rich: { modelId: MODEL_LARGE, chart: 'llm', narrative: 'stream' },
+    balanced: { modelId: MODEL_LARGE, chart: 'llm', narrative: 'static' },
+    lite: { modelId: MODEL_SMALL, chart: 'infer', narrative: 'static' },
+    minimal: { modelId: MODEL_SMALL, chart: 'off', narrative: 'static' },
+}
+
+export const PRESET_LABELS: Record<
+    PresetName,
+    { title: string; summary: string }
+> = {
+    rich: {
+        title: 'Rich',
+        summary: 'Best charts and written insights. Needs a capable device.',
+    },
+    balanced: {
+        title: 'Balanced',
+        summary: 'Smart charts, no written insights. Good default.',
+    },
+    lite: {
+        title: 'Lite',
+        summary: 'Smaller model, quick charts, plain summaries.',
+    },
+    minimal: {
+        title: 'Minimal',
+        summary: 'Answers as a table only. Lightest on memory.',
+    },
+}
+
+export const ASSISTANT_CONFIG_KEY = 'tracksy:assistantConfig'
+
+/** Build a full config from a preset name. */
+export function configFromPreset(preset: PresetName): AssistantConfig {
+    return { preset, ...PRESETS[preset] }
+}
+
+/** Identify which preset (if any) a set of axes corresponds to. */
+export function matchPreset(axes: PresetAxes): AssistantPreset {
+    for (const name of PRESET_NAMES) {
+        const p = PRESETS[name]
+        if (
+            p.modelId === axes.modelId &&
+            p.chart === axes.chart &&
+            p.narrative === axes.narrative
+        ) {
+            return name
+        }
+    }
+    return 'custom'
+}
+
+function isChartMode(v: unknown): v is ChartMode {
+    return v === 'llm' || v === 'infer' || v === 'off'
+}
+
+/** Read the persisted config, or `null` if the user hasn't chosen one yet. */
+export function getStoredConfig(): AssistantConfig | null {
+    if (typeof window === 'undefined') return null
+    try {
+        const raw = localStorage.getItem(ASSISTANT_CONFIG_KEY)
+        if (!raw) return null
+        const parsed = JSON.parse(raw) as Partial<AssistantConfig>
+        if (typeof parsed.modelId !== 'string') return null
+        const axes: PresetAxes = {
+            modelId: parsed.modelId,
+            chart: isChartMode(parsed.chart) ? parsed.chart : 'infer',
+            narrative: parsed.narrative === 'stream' ? 'stream' : 'static',
+        }
+        return { ...axes, preset: matchPreset(axes) }
+    } catch {
+        return null
+    }
+}
+
+/** Persist the config, normalizing `preset` to match its axes. */
+export function saveConfig(config: AssistantConfig): void {
+    if (typeof window === 'undefined') return
+    const axes: PresetAxes = {
+        modelId: config.modelId,
+        chart: config.chart,
+        narrative: config.narrative,
+    }
+    const normalized: AssistantConfig = { ...axes, preset: matchPreset(axes) }
+    localStorage.setItem(ASSISTANT_CONFIG_KEY, JSON.stringify(normalized))
+}

--- a/app/src/llm/engine.ts
+++ b/app/src/llm/engine.ts
@@ -1,15 +1,26 @@
 import {
     CreateMLCEngine,
+    prebuiltAppConfig,
     type InitProgressReport,
     type MLCEngineInterface,
 } from '@mlc-ai/web-llm'
-import { isMobileBrowser } from './deviceDetection'
 import { devBus } from '../devToolbar/devBus'
+import {
+    selectModelId,
+    peekLoadedModelId,
+    setLoadedModelId,
+} from './modelState'
 
 export { isSafariIOS, isMobileBrowser } from './deviceDetection'
-
-export const MODEL_ID = 'Qwen2.5-Coder-1.5B-Instruct-q4f16_1-MLC'
-export const MODEL_ID_IOS = 'Qwen2.5-Coder-0.5B-Instruct-q4f16_1-MLC'
+// Re-exported for compatibility; the canonical definitions live in the
+// web-llm-free modelState module so consumers can import them without pulling
+// this heavy engine chunk.
+export {
+    MODEL_ID,
+    MODEL_ID_IOS,
+    selectModelId,
+    getLoadedModelId,
+} from './modelState'
 
 let enginePromise: Promise<MLCEngineInterface> | null = null
 
@@ -21,13 +32,10 @@ export function isWebGPUAvailable(): boolean {
     )
 }
 
-export function selectModelId(): string {
-    return isMobileBrowser() ? MODEL_ID_IOS : MODEL_ID
-}
-
 export type ProgressHandler = (report: InitProgressReport) => void
 
 export async function getEngine(
+    modelId: string = selectModelId(),
     onProgress?: ProgressHandler
 ): Promise<MLCEngineInterface> {
     if (!isWebGPUAvailable()) {
@@ -35,13 +43,28 @@ export async function getEngine(
             'WebGPU is not available in this browser. Try Chrome, Edge, or a recent build of Safari.'
         )
     }
-    if (enginePromise) return enginePromise
+    // Reuse the singleton only when it holds the requested model.
+    if (enginePromise && peekLoadedModelId() === modelId) return enginePromise
 
-    enginePromise = CreateMLCEngine(selectModelId(), {
+    // A different model was requested: tear the current engine down first, in
+    // sequence, so we never hold two engines contending for the GPU at once.
+    if (enginePromise) {
+        const previous = enginePromise
+        enginePromise = null
+        setLoadedModelId(null)
+        try {
+            await (await previous).unload()
+        } catch {
+            // Already failed/unloaded — nothing to clean up.
+        }
+    }
+
+    setLoadedModelId(modelId)
+    enginePromise = CreateMLCEngine(modelId, {
         initProgressCallback: (report) => {
             onProgress?.(report)
             devBus.emit('webllm:load', {
-                model: selectModelId(),
+                model: modelId,
                 progress: report.progress,
                 text: report.text,
             })
@@ -49,8 +72,30 @@ export async function getEngine(
     }).catch((e) => {
         // Reset so a future attempt can retry
         enginePromise = null
+        setLoadedModelId(null)
         throw e
     })
 
     return enginePromise
+}
+
+export type ModelInfo = {
+    id: string
+    vramMB?: number
+    lowResource: boolean
+}
+
+/**
+ * The instruct/coder models from WebLLM's prebuilt catalog, for the Advanced
+ * model picker. Lives here (lazy-loaded) so `prebuiltAppConfig` never reaches
+ * the main bundle.
+ */
+export function listModels(): ModelInfo[] {
+    return prebuiltAppConfig.model_list
+        .filter((m) => /instruct|coder/i.test(m.model_id))
+        .map((m) => ({
+            id: m.model_id,
+            vramMB: m.vram_required_MB,
+            lowResource: m.low_resource_required ?? false,
+        }))
 }

--- a/app/src/llm/modelState.test.ts
+++ b/app/src/llm/modelState.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { selectModelId, MODEL_ID, MODEL_ID_IOS } from './engine'
+import { selectModelId, MODEL_ID, MODEL_ID_IOS } from './modelState'
 
 const setUA = (ua: string) =>
     vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(ua)

--- a/app/src/llm/modelState.ts
+++ b/app/src/llm/modelState.ts
@@ -1,0 +1,35 @@
+import { isMobileBrowser } from './deviceDetection'
+import { MODEL_LARGE, MODEL_SMALL } from './assistantConfig'
+
+// Lightweight, web-llm-free model state. The `ask*` helpers only need the
+// loaded model id for telemetry, so keeping it here (rather than in engine.ts)
+// means importing it never statically pulls the ~5.7 MB web-llm `engine` chunk
+// into the eager Chat-tab bundle. `engine.ts` writes this state during load.
+
+// Legacy UA-split fallback ids, only used when no explicit model is supplied.
+// assistantConfig is the single source of truth; it shares this module's
+// `assistant-config` chunk, so importing the ids adds no web-llm bleed.
+export const MODEL_ID = MODEL_LARGE
+export const MODEL_ID_IOS = MODEL_SMALL
+
+let loadedModelId: string | null = null
+
+/** Fallback model when no explicit choice is supplied (legacy UA split). */
+export function selectModelId(): string {
+    return isMobileBrowser() ? MODEL_ID_IOS : MODEL_ID
+}
+
+/** The model the engine is currently loaded with, for accurate telemetry. */
+export function getLoadedModelId(): string {
+    return loadedModelId ?? selectModelId()
+}
+
+/** Raw loaded id (nullable), for the engine's singleton reuse check. */
+export function peekLoadedModelId(): string | null {
+    return loadedModelId
+}
+
+/** Set by the engine as it loads/tears down a model. */
+export function setLoadedModelId(id: string | null): void {
+    loadedModelId = id
+}

--- a/app/src/llm/recommendPreset.test.ts
+++ b/app/src/llm/recommendPreset.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { recommendPreset } from './recommendPreset'
+import * as deviceDetection from './deviceDetection'
+
+type AdapterLimits = {
+    maxBufferSize?: number
+    maxStorageBufferBindingSize?: number
+}
+
+function setDeviceMemory(gb: number | undefined) {
+    if (gb === undefined) {
+        Reflect.deleteProperty(navigator, 'deviceMemory')
+        return
+    }
+    Object.defineProperty(navigator, 'deviceMemory', {
+        configurable: true,
+        value: gb,
+    })
+}
+
+function setGpu(limits: AdapterLimits | undefined | 'absent') {
+    if (limits === 'absent') {
+        Reflect.deleteProperty(navigator, 'gpu')
+        return
+    }
+    Object.defineProperty(navigator, 'gpu', {
+        configurable: true,
+        value: {
+            requestAdapter: async () =>
+                limits === undefined ? null : { limits },
+        },
+    })
+}
+
+beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(deviceDetection, 'isMobileBrowser').mockReturnValue(false)
+})
+
+afterEach(() => {
+    setDeviceMemory(undefined)
+    setGpu('absent')
+})
+
+describe('recommendPreset — mobile', () => {
+    it('recommends lite on a normal phone', async () => {
+        vi.spyOn(deviceDetection, 'isMobileBrowser').mockReturnValue(true)
+        setDeviceMemory(4)
+        expect(await recommendPreset()).toBe('lite')
+    })
+
+    it('recommends minimal on a tiny phone', async () => {
+        vi.spyOn(deviceDetection, 'isMobileBrowser').mockReturnValue(true)
+        setDeviceMemory(2)
+        expect(await recommendPreset()).toBe('minimal')
+    })
+})
+
+describe('recommendPreset — desktop', () => {
+    it('falls back to balanced when no probe signal is available', async () => {
+        setDeviceMemory(undefined)
+        setGpu('absent')
+        expect(await recommendPreset()).toBe('balanced')
+    })
+
+    it('recommends rich on an ample device', async () => {
+        setDeviceMemory(16)
+        setGpu({
+            maxBufferSize: 2_000_000_000,
+            maxStorageBufferBindingSize: 1_000_000_000,
+        })
+        expect(await recommendPreset()).toBe('rich')
+    })
+
+    it('falls back to balanced when memory is unknown even with an ample GPU', async () => {
+        // Firefox/Safari expose no deviceMemory — unknown RAM must not be
+        // treated as ample and pushed to Rich.
+        setDeviceMemory(undefined)
+        setGpu({
+            maxBufferSize: 2_000_000_000,
+            maxStorageBufferBindingSize: 1_000_000_000,
+        })
+        expect(await recommendPreset()).toBe('balanced')
+    })
+
+    it('recommends minimal on a very constrained desktop', async () => {
+        setDeviceMemory(2)
+        setGpu({
+            maxBufferSize: 2_000_000_000,
+            maxStorageBufferBindingSize: 1_000_000_000,
+        })
+        expect(await recommendPreset()).toBe('minimal')
+    })
+
+    it('recommends lite on a low-memory desktop', async () => {
+        setDeviceMemory(4)
+        setGpu({
+            maxBufferSize: 2_000_000_000,
+            maxStorageBufferBindingSize: 1_000_000_000,
+        })
+        expect(await recommendPreset()).toBe('lite')
+    })
+
+    it('recommends lite when the GPU max buffer is small', async () => {
+        setDeviceMemory(16)
+        setGpu({
+            maxBufferSize: 256 * 1024 * 1024,
+            maxStorageBufferBindingSize: 64 * 1024 * 1024,
+        })
+        expect(await recommendPreset()).toBe('lite')
+    })
+
+    it('recommends balanced on a mid-range device', async () => {
+        setDeviceMemory(6)
+        setGpu({
+            maxBufferSize: 2_000_000_000,
+            maxStorageBufferBindingSize: 1_000_000_000,
+        })
+        expect(await recommendPreset()).toBe('balanced')
+    })
+})

--- a/app/src/llm/recommendPreset.ts
+++ b/app/src/llm/recommendPreset.ts
@@ -1,0 +1,90 @@
+import { isMobileBrowser } from './deviceDetection'
+import type { AssistantPreset } from './assistantConfig'
+
+/**
+ * Picks the preset to recommend for the current device.
+ *
+ * Probes the real WebGPU adapter limits and `navigator.deviceMemory` so a
+ * low-RAM desktop (which the old UA-only split couldn't detect) is nudged to a
+ * lighter preset instead of OOM-ing on the 1.5B model. When those signals are
+ * unavailable (Firefox / Safari expose no `deviceMemory`), it falls back to the
+ * UA binary with a conservative default (desktop → Balanced, mobile → Lite).
+ *
+ * Assumes WebGPU support has already been confirmed; callers show the
+ * `unsupported` state when it is missing.
+ */
+
+type NavigatorMemory = Navigator & { deviceMemory?: number }
+
+type AdapterLimits = {
+    maxBufferSize?: number
+    maxStorageBufferBindingSize?: number
+}
+type GPUAdapterLike = { limits?: AdapterLimits }
+type NavigatorGPU = Navigator & {
+    gpu?: { requestAdapter(): Promise<GPUAdapterLike | null> }
+}
+
+// Thresholds. Kept deliberately loose — the goal is to steer away from OOM,
+// not to squeeze the largest model onto every device.
+const AMPLE_MEMORY_GB = 8
+const LOW_MEMORY_GB = 4
+const VERY_LOW_MEMORY_GB = 2 // barely enough for even the small model → table-only
+const AMPLE_BUFFER_BYTES = 1_000_000_000 // ~1 GB max buffer → 1.5B is safe
+const LOW_BUFFER_BYTES = 512 * 1024 * 1024 // <512 MB → prefer the small model
+const VERY_LOW_BUFFER_BYTES = 128 * 1024 * 1024 // <128 MB → table-only
+
+function deviceMemoryGb(): number | undefined {
+    if (typeof navigator === 'undefined') return undefined
+    const mem = (navigator as NavigatorMemory).deviceMemory
+    return typeof mem === 'number' ? mem : undefined
+}
+
+async function adapterLimits(): Promise<AdapterLimits | undefined> {
+    if (typeof navigator === 'undefined') return undefined
+    const gpu = (navigator as NavigatorGPU).gpu
+    if (!gpu) return undefined
+    try {
+        const adapter = await gpu.requestAdapter()
+        return adapter?.limits
+    } catch {
+        return undefined
+    }
+}
+
+export async function recommendPreset(): Promise<AssistantPreset> {
+    const mem = deviceMemoryGb()
+
+    if (isMobileBrowser()) {
+        // Very small phones can't even hold the 0.5B comfortably.
+        return mem !== undefined && mem <= 2 ? 'minimal' : 'lite'
+    }
+
+    const limits = await adapterLimits()
+    const maxBuffer = limits?.maxBufferSize
+    const maxStorage = limits?.maxStorageBufferBindingSize
+
+    // No usable probe signal at all → conservative desktop default.
+    if (mem === undefined && limits === undefined) return 'balanced'
+
+    // Extremely constrained desktop: even the small model is risky → table-only.
+    const veryLowMemory = mem !== undefined && mem <= VERY_LOW_MEMORY_GB
+    const veryLowBuffer =
+        maxBuffer !== undefined && maxBuffer < VERY_LOW_BUFFER_BYTES
+    if (veryLowMemory || veryLowBuffer) return 'minimal'
+
+    const lowMemory = mem !== undefined && mem <= LOW_MEMORY_GB
+    const lowBuffer = maxBuffer !== undefined && maxBuffer < LOW_BUFFER_BYTES
+    if (lowMemory || lowBuffer) return 'lite'
+
+    // Require a positive confirmation of ample memory — unknown RAM
+    // (Firefox/Safari expose no deviceMemory) must not be treated as ample, or
+    // a device with a big GPU buffer but tiny RAM would be pushed to Rich.
+    const ampleMemory = mem !== undefined && mem >= AMPLE_MEMORY_GB
+    const ampleBuffer =
+        (maxBuffer === undefined || maxBuffer >= AMPLE_BUFFER_BYTES) &&
+        (maxStorage === undefined || maxStorage >= AMPLE_BUFFER_BYTES / 4)
+    if (ampleMemory && ampleBuffer) return 'rich'
+
+    return 'balanced'
+}


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [x] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The chat assistant OOMs on **some** devices, and #420 decided how the assistant runs from a blunt UA binary (`isMobileBrowser()`) — which can't tell a low-RAM laptop from a capable one, and gives the user no say. As agreed in the [#420 follow-up discussion](https://github.com/Gudsfile/tracksy/pull/420#issuecomment-4948663627), the assistant should **ask the user** how to run instead of guessing, with a device-aware default. This keeps the beta feature available on every device without hiding it or risking a crash.

## 🎹 Proposal

On first use of the Chat tab, the user picks how the assistant runs from four named profiles, with the one best suited to their device pre-selected and badged **Recommended**:

- **Rich** — larger model, AI-picked chart, streamed written insights.
- **Balanced** — larger model, AI-picked chart, plain summary.
- **Lite** — small model, quick heuristic chart, plain summary.
- **Minimal** — small model, answers as a table only (lightest on memory).

The recommendation comes from real device probing — WebGPU adapter limits plus available memory — so a constrained device is steered to a lighter profile rather than crashing on the big model; where those signals aren't exposed it falls back conservatively. An **Advanced** section lets power users override the model (from the WebLLM catalogue, with download sizes and an "unverified" caveat on non-default models), the chart mode, and the narrative mode independently.

The choice is remembered. A **Settings** control in the Chat tab reopens the panel to reconfigure a running assistant — profile and agent toggles apply on the next question, and a model change reloads the engine. Existing users who had already enabled the assistant see the picker once. When WebGPU is unavailable the unsupported state is shown as before.

## 🎶 Comments

- Model selection is now user-driven, so inference telemetry reports the model actually loaded rather than the UA fallback.
- The config module is deliberately free of `@mlc-ai/web-llm`; the model catalogue is lazy-loaded only when the Advanced section is opened, keeping the engine out of the main bundle.
- This builds on the single-source-of-truth pipeline from #420 — chart, narrative, and SQL still all read from the one executed result set, so they stay consistent under every profile.

## 🎤 Test

1. `moon run app:dev` → load demo data → **Chat (beta)** tab → the picker appears with the device-recommended profile pre-selected; **Enable** stays disabled until the device check resolves.
2. Enable **Rich** on a capable desktop → ask "number of tracks in 2025" → the streamed narrative, the metric chart, and the collapsed **Generated SQL** all agree on the same number.
3. Expand **Advanced** → the model dropdown lists the catalogue with sizes; chart/narrative can be overridden to `custom`.
4. Open **⚙️ Settings** → switch profile → agent toggles apply on the next question with no reload; changing the model reloads the engine.
5. `moon run app:test` · `app:lint` · `app:format-check` all pass.

Follows up on #420.
