### PR TITLE
chore(app): silence upstream DuckDB WASM sourcemap warnings in dev server

### DIFF
--- a/app/astro.config.mjs
+++ b/app/astro.config.mjs
@@ -1,4 +1,5 @@
 // @ts-check
+import { readFile } from 'node:fs/promises'
 import { defineConfig } from 'astro/config'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 import react from '@astrojs/react'
@@ -19,6 +20,48 @@ const DUCKDB_EXTERNALS = [
     '@duckdb/node-bindings-darwin-arm64',
 ]
 
+// As of @duckdb/duckdb-wasm 1.32.0, the browser workers ship inline sourcemaps that
+// reference .ts files living outside the package (an upstream packaging issue in the
+// bundled @duckdb/apache-arrow sources), and one worker's .worker.js.map is missing
+// entirely. When Vite serves those workers in dev this produces a flood of "Sourcemap ...
+// points to a source file outside its package" warnings plus a "Failed to load source
+// map ... ENOENT" warning on every start.
+// We intercept the load of those worker files, strip the inline `//# sourceMappingURL=`
+// comment, and hand back an empty sourcemap. Because Vite then extracts the (now absent)
+// sourcemap from the already-stripped content, both warning classes disappear. Using a
+// `load` hook (rather than `transform`) is required to also suppress the ENOENT warning,
+// which is emitted during the load phase before any transform runs.
+// We must leave the `?url` import (`import worker from '...worker.js?url'` in setupDB)
+// to Vite: that request expects a URL string module, not the worker source, so returning
+// code for it would corrupt worker instantiation. The sourcemap warnings are emitted for
+// the bare worker-file loads, which we still intercept.
+// This is a TEMPORARY workaround for an upstream packaging issue and can be removed once
+// upstream ships correct sourcemaps.
+function duckdbWasmWorkerSourcemapFix() {
+    return {
+        name: 'duckdb-wasm-worker-sourcemap-fix',
+        apply: 'serve',
+        enforce: 'pre',
+        /**
+         * @param {string} id
+         */
+        async load(id) {
+            const [path, query] = id.split('?')
+            if (
+                query === 'url' ||
+                !/@duckdb\/duckdb-wasm\/dist\/[^/]*\.worker\.js$/.test(path)
+            ) {
+                return
+            }
+            const code = await readFile(path, 'utf8')
+            return {
+                code: code.replace(/\n?\/\/# sourceMappingURL=[^\n]*/g, ''),
+                map: { mappings: '' },
+            }
+        },
+    }
+}
+
 // https://astro.build/config
 export default defineConfig({
     site: 'https://gudsfile.github.io',
@@ -27,6 +70,7 @@ export default defineConfig({
     output: 'static',
     vite: {
         plugins: [
+            duckdbWasmWorkerSourcemapFix(),
             // https://github.com/nika-begiashvili/libarchivejs/blob/0989c1a6db20d030d793b1763e20d880068091bd/examples/esbuild/build.mjs#L14
             // @ts-ignore
             // Could be removed when Astro will upgrade its Vite dependency version 7.x


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Running `moon run app:dev` floods the terminal with Vite warnings coming from the DuckDB WASM browser workers:

```
[WARN] [vite] Sourcemap for ".../@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js"
  points to a source file outside its package: ".../@duckdb/apache-arrow/io/whatwg/io/whatwg/builder.ts"
```

The workers shipped by `@duckdb/duckdb-wasm@1.32.0` carry inline sourcemaps that reference `.ts` files living outside the package (an upstream packaging issue in the bundled `@duckdb/apache-arrow` sources, visible in the duplicated path segments such as `io/whatwg/io/whatwg`). It is not our code and it is non-blocking, but the warnings appear every time the worker is loaded and drown out warnings that actually concern us.

Closes #559

## 🎹 Proposal

Add a small, dev-only Vite plugin to the app config that strips the inline `//# sourceMappingURL=` comment from the DuckDB WASM worker files as they are served. With no sourcemap attached, Vite no longer tries to resolve the out-of-package `.ts` sources and stops emitting the warnings.

The plugin is intentionally narrow: it matches only files under `@duckdb/duckdb-wasm/dist/` ending in `.worker.js`, and it runs only in dev (`apply: 'serve'`), so the production build is untouched. Sourcemaps for our own code, and for every other dependency, keep working and keep surfacing legitimate warnings.

The originally suggested `server.sourcemapIgnoreList` option does not silence this particular warning with the Vite version currently bundled by Astro: that warning is emitted while injecting sources content, before the ignore list is applied (the ignore list only sets `x_google_ignoreList` for devtools). Stripping the broken sourcemap at the source is what actually removes the noise.

## 🎶 Comments

This works around an upstream packaging problem; it can be removed once `@duckdb/duckdb-wasm` ships worker sourcemaps that resolve within the package.

## 🎤 Test

1. `moon run app:dev`
2. Open the app and load a dataset so the DuckDB worker is initialised.
3. Confirm the `Sourcemap ... points to a source file outside its package` warnings no longer appear.
