### PR TITLE
fix(results): keep tab panels mounted to stop switch flicker

### DIFF
--- a/app/src/components/Charts/ChatView.tsx
+++ b/app/src/components/Charts/ChatView.tsx
@@ -15,18 +15,6 @@ function generateId(): string {
     return `${Date.now()}-${Math.random().toString(36).slice(2)}`
 }
 
-function MemoryNotice() {
-    return (
-        <div className="flex items-start gap-2 p-3 rounded-xl bg-blue-50 dark:bg-blue-900/20 border border-blue-200/60 dark:border-blue-700/40 text-blue-800 dark:text-blue-300 text-sm">
-            <span className="shrink-0">💡</span>
-            <p>
-                Chat history is kept in memory for this session and is cleared
-                when you load new data.
-            </p>
-        </div>
-    )
-}
-
 export function ChatView() {
     const [messages, setMessages] = useState<ChatMessage[]>([])
     const [customRows, setCustomRows] = useState<Map<string, DBRow[]>>(
@@ -175,8 +163,6 @@ export function ChatView() {
 
     return (
         <div className="flex flex-col gap-4 py-4">
-            <MemoryNotice />
-
             {state.kind === 'idle' ? (
                 <AssistantSettings mode="onboarding" onSubmit={enableWith} />
             ) : (

--- a/app/src/components/Charts/ChatView.tsx
+++ b/app/src/components/Charts/ChatView.tsx
@@ -20,8 +20,8 @@ function MemoryNotice() {
         <div className="flex items-start gap-2 p-3 rounded-xl bg-blue-50 dark:bg-blue-900/20 border border-blue-200/60 dark:border-blue-700/40 text-blue-800 dark:text-blue-300 text-sm">
             <span className="shrink-0">💡</span>
             <p>
-                Chat history is stored in memory only — switching to another tab
-                will clear the conversation.
+                Chat history is kept in memory for this session and is cleared
+                when you load new data.
             </p>
         </div>
     )

--- a/app/src/components/Results/Results.test.tsx
+++ b/app/src/components/Results/Results.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { Results } from './Results'
 import * as query from '../../db/queries/queryDB'
 import * as db from '../../db/getDB'
+import * as chatEngine from '../../hooks/useChatEngine'
 
 describe('Results Component', () => {
     beforeEach(() => {
@@ -71,7 +72,66 @@ describe('Results Component', () => {
         })
         fireEvent.click(simpleButton)
 
-        // Lab View content should not be visible again
-        expect(screen.queryByText(/Work in Progress/i)).toBeNull()
+        // Lab View stays mounted but hidden (no remount, avoids flicker #560):
+        // its content is still in the DOM, but its tab panel is hidden.
+        const labPanel = screen
+            .getByText(/Work in Progress/i)
+            .closest('[role="tabpanel"]')
+        expect(labPanel?.hasAttribute('hidden')).toBe(true)
+    })
+
+    it('does not re-run queries when returning to a visited tab (#560)', async () => {
+        render(<Results />)
+
+        // Visit Lab, then Simple, then Lab again.
+        const labButton = screen.getByRole('tab', { name: '🔬 Lab' })
+        fireEvent.click(labButton)
+        await screen.findByText(/Work in Progress/i, undefined, {
+            timeout: 5000,
+        })
+        const callsAfterFirstVisit = vi.mocked(query.queryDBAsJSON).mock.calls
+            .length
+
+        fireEvent.click(screen.getByRole('tab', { name: '✨ Simple' }))
+        fireEvent.click(labButton)
+
+        // Panel stayed mounted, so no additional queries fire on re-entry.
+        expect(vi.mocked(query.queryDBAsJSON).mock.calls.length).toBe(
+            callsAfterFirstVisit
+        )
+    })
+
+    it('keeps the chat conversation across a tab switch (#560)', async () => {
+        // Force a ready engine so a message can be sent; `ask` is stubbed so
+        // the submit resolves without loading the real LLM.
+        vi.spyOn(chatEngine, 'useChatEngine').mockReturnValue({
+            state: { kind: 'ready', isDegraded: false },
+            ensureLoaded: vi.fn(),
+            ask: vi.fn().mockResolvedValue({ payload: { kind: 'aborted' } }),
+            cancel: vi.fn(),
+        } as unknown as ReturnType<typeof chatEngine.useChatEngine>)
+        // jsdom has no layout engine; the message list auto-scrolls on update.
+        Element.prototype.scrollIntoView = vi.fn()
+
+        render(<Results />)
+
+        // Open the Chat tab (lazy-loaded) and send a message.
+        fireEvent.click(screen.getByRole('tab', { name: '💬 Chat (beta)' }))
+        const input = await screen.findByLabelText(
+            'Ask the assistant',
+            undefined,
+            { timeout: 5000 }
+        )
+        fireEvent.change(input, { target: { value: 'remember me' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Ask' }))
+        await screen.findByText('remember me')
+
+        // Switch away to Simple and back to Chat.
+        fireEvent.click(screen.getByRole('tab', { name: '✨ Simple' }))
+        fireEvent.click(screen.getByRole('tab', { name: '💬 Chat (beta)' }))
+
+        // Panel stayed mounted, so the conversation survives the switch (no
+        // remount wiping ChatView's message state).
+        expect(screen.getByText('remember me')).toBeTruthy()
     })
 })

--- a/app/src/components/Results/Results.tsx
+++ b/app/src/components/Results/Results.tsx
@@ -1,7 +1,15 @@
-import { lazy, Suspense, useCallback, useRef, useState } from 'react'
+import {
+    lazy,
+    Suspense,
+    useCallback,
+    useRef,
+    useState,
+    type ReactNode,
+} from 'react'
 import { SimpleView } from '../Charts/SimpleView'
 import { Spinner } from '../Spinner/Spinner'
 import { QueryTabContext } from './QueryTabContext'
+import { TabPanelActiveContext } from './TabPanelContext'
 
 const LabView = lazy(() =>
     import('../Charts/LabView').then((m) => ({ default: m.LabView }))
@@ -38,17 +46,65 @@ const TABS: { id: Tab; label: string; tooltip: string }[] = [
     },
 ]
 
+function TabFallback() {
+    return (
+        <div className="flex justify-center py-12">
+            <Spinner />
+        </div>
+    )
+}
+
+// Keep each panel mounted once visited and toggle visibility instead of
+// unmounting, so switching tabs does not remount the view (which caused a
+// visible jump/refresh flicker and re-ran the view's queries). See #560.
+function TabPanel({
+    id,
+    active,
+    children,
+}: {
+    id: Tab
+    active: boolean
+    children: ReactNode
+}) {
+    return (
+        <div
+            role="tabpanel"
+            id={`panel-${id}`}
+            aria-labelledby={`tab-${id}`}
+            tabIndex={active ? 0 : -1}
+            hidden={!active}
+        >
+            <TabPanelActiveContext.Provider value={active}>
+                {children}
+            </TabPanelActiveContext.Provider>
+        </div>
+    )
+}
+
 export function Results() {
     const [activeTab, setActiveTab] = useState<Tab>('simple')
+    const [visitedTabs, setVisitedTabs] = useState<Set<Tab>>(
+        () => new Set<Tab>(['simple'])
+    )
     const [queryKey, setQueryKey] = useState(0)
     const pendingQueryRef = useRef<string | undefined>(undefined)
     const tabIndex = TABS.findIndex((t) => t.id === activeTab)
 
-    const openInQueryTab = useCallback((sql: string) => {
-        pendingQueryRef.current = sql
-        setActiveTab('query')
-        setQueryKey((k) => k + 1)
+    const selectTab = useCallback((tab: Tab) => {
+        setActiveTab(tab)
+        setVisitedTabs((prev) =>
+            prev.has(tab) ? prev : new Set(prev).add(tab)
+        )
     }, [])
+
+    const openInQueryTab = useCallback(
+        (sql: string) => {
+            pendingQueryRef.current = sql
+            selectTab('query')
+            setQueryKey((k) => k + 1)
+        },
+        [selectTab]
+    )
 
     const clearPendingQuery = () => {
         pendingQueryRef.current = undefined
@@ -70,10 +126,12 @@ export function Results() {
                         {TABS.map((tab) => (
                             <button
                                 key={tab.id}
+                                id={`tab-${tab.id}`}
                                 role="tab"
                                 aria-selected={activeTab === tab.id}
+                                aria-controls={`panel-${tab.id}`}
                                 title={tab.tooltip}
-                                onClick={() => setActiveTab(tab.id)}
+                                onClick={() => selectTab(tab.id)}
                                 className={`relative z-10 flex-1 px-4 py-3 text-sm font-semibold rounded-xl transition-all duration-300 ${
                                     activeTab === tab.id
                                         ? 'text-white'
@@ -87,27 +145,34 @@ export function Results() {
                 </div>
 
                 <div>
-                    <Suspense
-                        fallback={
-                            <div className="flex justify-center py-12">
-                                <Spinner />
-                            </div>
-                        }
-                    >
-                        {activeTab === 'simple' ? (
-                            <SimpleView />
-                        ) : activeTab === 'lab' ? (
-                            <LabView />
-                        ) : activeTab === 'query' ? (
-                            <QueryView
-                                key={queryKey}
-                                initialQuery={pendingQueryRef.current}
-                                onQueryConsumed={clearPendingQuery}
-                            />
-                        ) : (
-                            <ChatView />
-                        )}
-                    </Suspense>
+                    <TabPanel id="simple" active={activeTab === 'simple'}>
+                        <SimpleView />
+                    </TabPanel>
+                    {visitedTabs.has('lab') && (
+                        <TabPanel id="lab" active={activeTab === 'lab'}>
+                            <Suspense fallback={<TabFallback />}>
+                                <LabView />
+                            </Suspense>
+                        </TabPanel>
+                    )}
+                    {visitedTabs.has('chat') && (
+                        <TabPanel id="chat" active={activeTab === 'chat'}>
+                            <Suspense fallback={<TabFallback />}>
+                                <ChatView />
+                            </Suspense>
+                        </TabPanel>
+                    )}
+                    {visitedTabs.has('query') && (
+                        <TabPanel id="query" active={activeTab === 'query'}>
+                            <Suspense fallback={<TabFallback />}>
+                                <QueryView
+                                    key={queryKey}
+                                    initialQuery={pendingQueryRef.current}
+                                    onQueryConsumed={clearPendingQuery}
+                                />
+                            </Suspense>
+                        </TabPanel>
+                    )}
                 </div>
             </div>
         </QueryTabContext.Provider>

--- a/app/src/components/Results/TabPanelContext.tsx
+++ b/app/src/components/Results/TabPanelContext.tsx
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react'
+
+// Whether the enclosing tab panel is currently active (visible). Panels stay
+// mounted when inactive (see #560), so components that escape the panel's DOM
+// subtree — e.g. a `createPortal` to `document.body` — must consult this to
+// avoid rendering while their panel is hidden. Defaults to `true` so consumers
+// used outside a TabPanel render normally.
+export const TabPanelActiveContext = createContext<boolean>(true)
+export const useTabPanelActive = () => useContext(TabPanelActiveContext)

--- a/app/src/components/YearSidebar/YearSidebar.test.tsx
+++ b/app/src/components/YearSidebar/YearSidebar.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { YearSidebar } from './YearSidebar'
+import { TabPanelActiveContext } from '../Results/TabPanelContext'
 
 describe('YearSidebar', () => {
     it('renders an "All time" button and one button per year', () => {
@@ -88,5 +89,23 @@ describe('YearSidebar', () => {
         fireEvent.click(screen.getByRole('button', { name: 'All time' }))
 
         expect(onChange).toHaveBeenCalledWith(undefined)
+    })
+
+    it('renders nothing when its tab panel is inactive (#560)', () => {
+        // A hidden panel stays mounted; the floating variant portals to
+        // document.body and would otherwise overlap the active panel's sidebar.
+        const { container } = render(
+            <TabPanelActiveContext.Provider value={false}>
+                <YearSidebar
+                    value={2024}
+                    onChange={vi.fn()}
+                    min={2020}
+                    max={2024}
+                />
+            </TabPanelActiveContext.Provider>
+        )
+
+        expect(container.firstChild).toBeNull()
+        expect(screen.queryByRole('button', { name: 'All time' })).toBeNull()
     })
 })

--- a/app/src/components/YearSidebar/YearSidebar.tsx
+++ b/app/src/components/YearSidebar/YearSidebar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { useTabPanelActive } from '../Results/TabPanelContext'
 
 interface YearSidebarProps {
     value: number | undefined
@@ -22,6 +23,7 @@ function readFloatingMatch(): boolean {
 }
 
 export function YearSidebar({ value, onChange, min, max }: YearSidebarProps) {
+    const isPanelActive = useTabPanelActive()
     const [isFloating, setIsFloating] = useState(readFloatingMatch)
 
     useEffect(() => {
@@ -32,6 +34,11 @@ export function YearSidebar({ value, onChange, min, max }: YearSidebarProps) {
         mq.addEventListener('change', update)
         return () => mq.removeEventListener('change', update)
     }, [])
+
+    // The floating variant portals to `document.body`, escaping the panel's
+    // `hidden` subtree, so a hidden panel's sidebar would otherwise stay visible
+    // and overlap the active one (#560). Render nothing while inactive.
+    if (!isPanelActive) return null
 
     const years: number[] = []
     for (let year = max; year >= min; year--) years.push(year)


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Closes #560. Switching between the Simple / Lab / Chat / Query tabs produced a visible "jump" / "refresh" flicker: the content remounted and reflowed instead of transitioning smoothly. This is not a recent regression — the tabs were always rendered through a ternary, so every switch unmounted the previous view and mounted the next one, which also re-ran that view's queries each time.

https://github.com/user-attachments/assets/e2af0827-4468-4abb-9542-4982a62f7de0

## 🎹 Proposal

Each tab panel is now mounted on its first visit and stays mounted afterwards; switching tabs toggles visibility with the `hidden` attribute instead of unmounting. Re-activating a tab no longer remounts its view, so the flicker and the redundant re-queries are gone.

Panels use a complete ARIA tabs pattern: each `role="tab"` button is linked to its `role="tabpanel"` via `id` / `aria-controls` / `aria-labelledby`, and the active panel is focusable (`tabIndex`).

Lazy-loading is preserved. The Lab, Chat and Query panels are only rendered — and their chunks only fetched — once the tab is first opened, so the heavy Chat (web-llm) bundle is still not loaded until the Chat tab is used and initial page load is unchanged.

## 🎶 Comments

Trade-off: previously visited panels stay in the DOM (hidden) rather than being torn down. That retained state is exactly what removes the flicker and the re-query, and the memory cost is negligible.

Behavior change: manually returning to the Query tab now preserves the previous SQL and results instead of resetting. The editor only resets when a query is pushed via "open in Query" (`key`-based remount), which is unchanged.

Because panels now stay mounted, the floating `YearSidebar` (which `createPortal`s to `document.body` on wide screens) escaped its panel's `hidden` subtree, so Simple's and Lab's year filters overlapped. A `TabPanelActiveContext` now tells the sidebar to render nothing while its panel is inactive.

## 🎤 Test

1. Open the app
2. Switch between tabs repeatedly: content stays put, no jump/refresh.

First open of a lazy tab still shows the loading spinner once; subsequent switches are instant with no reload.

https://github.com/user-attachments/assets/e63a5de7-b8fc-4055-86db-7a3c9a55155c
