### PR TITLE
feat(synthetic-datasets): output Apple Music data as nested ZIP archive

### DIFF
--- a/synthetic-datasets/synthetic_datasets/writers/apple_music.py
+++ b/synthetic-datasets/synthetic_datasets/writers/apple_music.py
@@ -1,7 +1,9 @@
 import csv
+import io
 from datetime import datetime
 from pathlib import Path
 from typing import ClassVar
+from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile, ZipInfo
 
 from rich import get_console, print
 from rich.progress import track
@@ -21,33 +23,120 @@ COLUMNS = [
     "Container Origin Type",
 ]
 
+# A real Apple privacy export is a nested ZIP. A single export is delivered as:
+#   {language_dependent_name}.zip
+#     └── Apple_Media_Services.zip
+#           └── Apple Music Activity/
+#                 └── Apple Music Play Activity.csv
+CSV_NAME = "Apple Music Play Activity.csv"
+ACTIVITY_FOLDER = "Apple Music Activity"
+MEDIA_SERVICES_ZIP_NAME = "Apple_Media_Services.zip"
+
+# The outer per-export archive name is language dependent in real exports; we use
+# a realistic, fixed value so output is deterministic.
+EXPORT_ZIP_STEM = "Apple Media Services information"
+EXPORT_ZIP_NAME = f"{EXPORT_ZIP_STEM}.zip"
+
+# Apple delivers large histories as several export ZIPs (batches). Tracksy imports
+# one file at a time, so multiple batches are combined into a single outer ZIP:
+#   {combined}.zip
+#     ├── {language_dependent_name} - Part 1 of N.zip -> Apple_Media_Services.zip -> ...
+#     ├── {language_dependent_name} - Part 2 of N.zip -> Apple_Media_Services.zip -> ...
+#     └── ...
+COMBINED_ZIP_NAME = f"{EXPORT_ZIP_STEM} - combined parts.zip"
+
+# Number of per-export batches packed into the combined ZIP. Fixed so every run
+# produces the same set of outputs, no configuration required.
+COMBINED_BATCHES = 3
+
 
 class AppleMusicWriter:
     NULL_VALUE: ClassVar[str] = ""
 
     def __init__(self, output_dir: Path, reference_date: datetime) -> None:
-        self.output_path = output_dir / "apple_music" / "Apple Music Play Activity.csv"
+        self.output_dir = output_dir / "apple_music"
         self.reference_date = reference_date
+        self.csv_path = self.output_dir / CSV_NAME
+        self.export_zip_path = self.output_dir / EXPORT_ZIP_NAME
+        self.combined_zip_path = self.output_dir / COMBINED_ZIP_NAME
 
     def write(self, records: list[AppleMusicRecord]) -> None:
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        csv_bytes = self._csv_bytes(records)
         with _console.status("🖍️ Writing csv..."):
-            self.output_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.output_path, "w", newline="", encoding="utf-8") as f:
-                writer = csv.DictWriter(f, fieldnames=COLUMNS)
-                writer.writeheader()
-                for record in track(records, description=f"📦 Writing {self.output_path.name}"):
-                    writer.writerow(
-                        {
-                            "Event Start Timestamp": record.serialize_event_start_timestamp(
-                                record.event_start_timestamp
-                            ),
-                            "Song Name": record.song_name,
-                            "Album Name": record.album_name,
-                            "Container Artist Name": self.NULL_VALUE,
-                            "Media Type": record.media_type,
-                            "Play Duration Milliseconds": str(record.play_duration_ms),
-                            "Device Type": record.device_type,
-                            "Container Origin Type": record.container_origin_type or self.NULL_VALUE,
-                        }
-                    )
-        print(f"🖍️ Write csv: [green]success[/green] {self.output_path.absolute()} ({len(records)} records)")
+            self.csv_path.write_bytes(csv_bytes)
+        print(f"🖍️ Write csv: [green]success[/green] {self.csv_path.absolute()} ({len(records)} records)")
+
+        with _console.status("🗜️ Writing export zip..."):
+            self.export_zip_path.write_bytes(self._export_zip_from_csv(csv_bytes))
+        print(f"🖍️ Write export zip: [green]success[/green] {self.export_zip_path.absolute()} ({len(records)} records)")
+
+        with _console.status("🗜️ Writing combined zip..."):
+            self.combined_zip_path.write_bytes(self._build_combined_zip(records))
+        print(
+            f"🖍️ Write combined zip: [green]success[/green] {self.combined_zip_path.absolute()} "
+            f"({len(records)} records, {COMBINED_BATCHES} exports)"
+        )
+
+    def _date_time(self) -> tuple[int, int, int, int, int, int]:
+        d = self.reference_date
+        return (d.year, d.month, d.day, d.hour, d.minute, d.second)
+
+    def _csv_bytes(self, records: list[AppleMusicRecord]) -> bytes:
+        buffer = io.StringIO()
+        writer = csv.DictWriter(buffer, fieldnames=COLUMNS)
+        writer.writeheader()
+        for record in track(records, description=f"📦 Writing {CSV_NAME}"):
+            writer.writerow(
+                {
+                    "Event Start Timestamp": record.serialize_event_start_timestamp(record.event_start_timestamp),
+                    "Song Name": record.song_name,
+                    "Album Name": record.album_name,
+                    "Container Artist Name": self.NULL_VALUE,
+                    "Media Type": record.media_type,
+                    "Play Duration Milliseconds": str(record.play_duration_ms),
+                    "Device Type": record.device_type,
+                    "Container Origin Type": record.container_origin_type or self.NULL_VALUE,
+                }
+            )
+        return buffer.getvalue().encode("utf-8")
+
+    def _zip_bytes(self, entries: list[tuple[str, bytes, bool]]) -> bytes:
+        """Build a ZIP archive in memory from (archive_name, data, compress) entries."""
+        buffer = io.BytesIO()
+        with ZipFile(buffer, "w") as archive:
+            for archive_name, data, compress in entries:
+                info = ZipInfo(archive_name)
+                info.date_time = self._date_time()
+                info.compress_type = ZIP_DEFLATED if compress else ZIP_STORED
+                archive.writestr(info, data)
+        return buffer.getvalue()
+
+    def _export_zip_from_csv(self, csv_bytes: bytes) -> bytes:
+        """Wrap a play-activity CSV in the nested export ZIP (language_dependent_name.zip content)."""
+        media_services_zip = self._zip_bytes([(f"{ACTIVITY_FOLDER}/{CSV_NAME}", csv_bytes, True)])
+        # Inner ZIP is already compressed; store it to avoid pointless double work.
+        return self._zip_bytes([(MEDIA_SERVICES_ZIP_NAME, media_services_zip, False)])
+
+    def _build_export_zip(self, records: list[AppleMusicRecord]) -> bytes:
+        """Build a single nested export ZIP (language_dependent_name.zip content)."""
+        return self._export_zip_from_csv(self._csv_bytes(records))
+
+    def _build_combined_zip(self, records: list[AppleMusicRecord]) -> bytes:
+        """Combine several export ZIPs into one outer ZIP (a_zip_file.zip content)."""
+        entries: list[tuple[str, bytes, bool]] = []
+        for index, batch in enumerate(self._split(records), start=1):
+            export_zip = self._build_export_zip(batch)
+            entries.append((f"{EXPORT_ZIP_STEM} - Part {index} of {COMBINED_BATCHES}.zip", export_zip, False))
+        return self._zip_bytes(entries)
+
+    def _split(self, records: list[AppleMusicRecord]) -> list[list[AppleMusicRecord]]:
+        base, extra = divmod(len(records), COMBINED_BATCHES)
+        chunks: list[list[AppleMusicRecord]] = []
+        start = 0
+        for i in range(COMBINED_BATCHES):
+            size = base + (1 if i < extra else 0)
+            chunks.append(records[start : start + size])
+            start += size
+        return chunks

--- a/synthetic-datasets/tests/writers/test_apple_music.py
+++ b/synthetic-datasets/tests/writers/test_apple_music.py
@@ -1,56 +1,57 @@
 import csv
+import io
 from datetime import datetime
+from zipfile import ZipFile
 
-from synthetic_datasets.writers.apple_music import COLUMNS, AppleMusicWriter
+from synthetic_datasets.models.apple_music import AppleMusicRecord
+from synthetic_datasets.writers.apple_music import (
+    ACTIVITY_FOLDER,
+    COLUMNS,
+    COMBINED_BATCHES,
+    COMBINED_ZIP_NAME,
+    CSV_NAME,
+    EXPORT_ZIP_NAME,
+    EXPORT_ZIP_STEM,
+    MEDIA_SERVICES_ZIP_NAME,
+    AppleMusicWriter,
+)
 
 
-def test_write_creates_file(tmp_path, apple_music_record):
-    # given
-    reference_date = datetime(2026, 2, 8)
-    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=reference_date)
-    # when
-    writer.write([apple_music_record])
-    # then
-    assert writer.output_path.exists()
+def _open_media_services_zip(export_zip: ZipFile) -> ZipFile:
+    """Given a language_dependent_name.zip, return its inner Apple_Media_Services.zip."""
+    assert export_zip.namelist() == [MEDIA_SERVICES_ZIP_NAME]
+    inner_bytes = export_zip.read(MEDIA_SERVICES_ZIP_NAME)
+    return ZipFile(io.BytesIO(inner_bytes))
 
 
-def test_write_csv_headers(tmp_path, apple_music_record):
+def _read_csv_rows(export_zip: ZipFile) -> list[dict[str, str]]:
+    media_zip = _open_media_services_zip(export_zip)
+    csv_bytes = media_zip.read(f"{ACTIVITY_FOLDER}/{CSV_NAME}")
+    reader = csv.DictReader(io.StringIO(csv_bytes.decode("utf-8")))
+    return list(reader)
+
+
+def _read_flat_csv_rows(path) -> list[dict[str, str]]:
+    with open(path, encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+# --- outputs are always all three -------------------------------------------------
+
+
+def test_write_creates_all_three_outputs(tmp_path, apple_music_record):
     # given
     writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
     # when
     writer.write([apple_music_record])
     # then
-    with open(writer.output_path, newline="", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        assert reader.fieldnames == COLUMNS
-
-
-def test_write_csv_row_count(tmp_path, apple_music_record):
-    # given
-    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
-    num_records = 5
-    records = [apple_music_record] * num_records
-    # when
-    writer.write(records)
-    # then
-    with open(writer.output_path, newline="", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        rows = list(reader)
-    assert len(rows) == num_records
-
-
-def test_write_csv_timestamp_format(tmp_path, apple_music_record):
-    # given
-    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
-    # when
-    writer.write([apple_music_record])
-    # then
-    with open(writer.output_path, newline="", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        row = next(reader)
-    ts_str = row["Event Start Timestamp"]
-    parsed = datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%S.000Z")
-    assert parsed is not None
+    assert writer.csv_path.exists()
+    assert writer.csv_path.name == CSV_NAME
+    assert writer.csv_path.parent.name == "apple_music"
+    assert writer.export_zip_path.exists()
+    assert writer.export_zip_path.name == EXPORT_ZIP_NAME
+    assert writer.combined_zip_path.exists()
+    assert writer.combined_zip_path.name == COMBINED_ZIP_NAME
 
 
 def test_write_creates_output_directory(tmp_path, apple_music_record):
@@ -60,26 +61,43 @@ def test_write_creates_output_directory(tmp_path, apple_music_record):
     # when
     writer.write([apple_music_record])
     # then
-    assert writer.output_path.exists()
+    assert writer.csv_path.exists()
+    assert writer.export_zip_path.exists()
+    assert writer.combined_zip_path.exists()
 
 
-def test_write_csv_output_path(tmp_path, apple_music_record):
-    # given
-    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
-    # then
-    assert writer.output_path.name == "Apple Music Play Activity.csv"
-    assert writer.output_path.parent.name == "apple_music"
+# --- flat CSV ---------------------------------------------------------------------
 
 
-def test_write_csv_record_values(tmp_path, apple_music_record):
+def test_flat_csv_headers(tmp_path, apple_music_record):
     # given
     writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
     # when
     writer.write([apple_music_record])
     # then
-    with open(writer.output_path, newline="", encoding="utf-8") as f:
+    with open(writer.csv_path, encoding="utf-8") as f:
         reader = csv.DictReader(f)
-        row = next(reader)
+        assert reader.fieldnames == COLUMNS
+
+
+def test_flat_csv_row_count(tmp_path, apple_music_record):
+    # given
+    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    num_records = 5
+    records = [apple_music_record] * num_records
+    # when
+    writer.write(records)
+    # then
+    assert len(_read_flat_csv_rows(writer.csv_path)) == num_records
+
+
+def test_flat_csv_record_values(tmp_path, apple_music_record):
+    # given
+    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    # when
+    writer.write([apple_music_record])
+    # then
+    row = _read_flat_csv_rows(writer.csv_path)[0]
     assert row["Song Name"] == apple_music_record.song_name
     assert row["Album Name"] == apple_music_record.album_name
     assert row["Media Type"] == apple_music_record.media_type
@@ -87,3 +105,154 @@ def test_write_csv_record_values(tmp_path, apple_music_record):
     assert row["Container Artist Name"] == ""
     assert row["Device Type"] == apple_music_record.device_type
     assert row["Container Origin Type"] == ""
+
+
+def test_flat_csv_timestamp_format(tmp_path, apple_music_record):
+    # given
+    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    # when
+    writer.write([apple_music_record])
+    # then
+    row = _read_flat_csv_rows(writer.csv_path)[0]
+    parsed = datetime.strptime(row["Event Start Timestamp"], "%Y-%m-%dT%H:%M:%S.000Z")
+    assert parsed is not None
+
+
+# --- single nested export ZIP -----------------------------------------------------
+
+
+def test_export_zip_nested_structure(tmp_path, apple_music_record):
+    # given
+    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    # when
+    writer.write([apple_music_record])
+    # then: language_dependent_name.zip -> Apple_Media_Services.zip -> folder/csv
+    with ZipFile(writer.export_zip_path) as export_zip:
+        assert export_zip.namelist() == [MEDIA_SERVICES_ZIP_NAME]
+        media_zip = _open_media_services_zip(export_zip)
+        assert media_zip.namelist() == [f"{ACTIVITY_FOLDER}/{CSV_NAME}"]
+
+
+def test_export_zip_holds_all_records(tmp_path, apple_music_record):
+    # given
+    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    records = [apple_music_record] * 7
+    # when
+    writer.write(records)
+    # then
+    with ZipFile(writer.export_zip_path) as export_zip:
+        rows = _read_csv_rows(export_zip)
+    assert len(rows) == len(records)
+    assert list(rows[0].keys()) == COLUMNS
+    assert rows[0]["Song Name"] == apple_music_record.song_name
+
+
+# --- combined multi-batch ZIP -----------------------------------------------------
+
+
+def test_combined_zip_has_fixed_number_of_batches(tmp_path, apple_music_record):
+    # given
+    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    records = [apple_music_record] * (COMBINED_BATCHES * 3)
+    # when
+    writer.write(records)
+    # then: a_zip_file.zip -> [language_dependent_name - Part 1 of N.zip; ...; Part N of N.zip]
+    with ZipFile(writer.combined_zip_path) as combined:
+        names = combined.namelist()
+        assert names == [
+            f"{EXPORT_ZIP_STEM} - Part {i} of {COMBINED_BATCHES}.zip" for i in range(1, COMBINED_BATCHES + 1)
+        ]
+        total_rows = 0
+        for name in names:
+            with ZipFile(io.BytesIO(combined.read(name))) as export_zip:
+                # every batch is itself a valid nested export with a readable CSV
+                total_rows += len(_read_csv_rows(export_zip))
+    assert total_rows == len(records)
+
+
+def test_combined_zip_batches_are_disjoint_and_cover_all_records(tmp_path):
+    # given records tagged by a unique song name so batches can be checked for overlap
+    records = [
+        AppleMusicRecord(
+            event_start_timestamp=datetime.fromisoformat("2020-08-07T11:48:23"),
+            song_name=f"song-{i}",
+            album_name="album",
+            media_type="AUDIO",
+            play_duration_ms=1000,
+            device_type="IPHONE",
+            container_origin_type=None,
+        )
+        for i in range(10)
+    ]
+    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    # when
+    writer.write(records)
+    # then
+    seen: list[str] = []
+    counts: list[int] = []
+    with ZipFile(writer.combined_zip_path) as combined:
+        for name in combined.namelist():
+            with ZipFile(io.BytesIO(combined.read(name))) as export_zip:
+                rows = _read_csv_rows(export_zip)
+                counts.append(len(rows))
+                seen.extend(row["Song Name"] for row in rows)
+    # batch sizes derive from the constant so the test survives a change to COMBINED_BATCHES
+    base, rem = divmod(len(records), COMBINED_BATCHES)
+    assert counts == [base + 1] * rem + [base] * (COMBINED_BATCHES - rem)
+    # disjoint slices whose union is exactly the full set
+    assert len(seen) == len(set(seen)) == len(records)
+    assert set(seen) == {f"song-{i}" for i in range(10)}
+
+
+def test_combined_zip_handles_fewer_records_than_batches(tmp_path, apple_music_record):
+    # given fewer records than batches, so the split yields empty batches (n=1 -> [1, 0, 0])
+    records = [apple_music_record]
+    assert len(records) < COMBINED_BATCHES
+    writer = AppleMusicWriter(output_dir=tmp_path, reference_date=datetime(2026, 2, 8))
+    # when
+    writer.write(records)
+    # then
+    seen: list[str] = []
+    counts: list[int] = []
+    with ZipFile(writer.combined_zip_path) as combined:
+        names = combined.namelist()
+        # still exactly COMBINED_BATCHES nested exports, even though some hold no records
+        assert names == [
+            f"{EXPORT_ZIP_STEM} - Part {i} of {COMBINED_BATCHES}.zip" for i in range(1, COMBINED_BATCHES + 1)
+        ]
+        for name in names:
+            with ZipFile(io.BytesIO(combined.read(name))) as export_zip:
+                # each batch is a valid nested export: ..._K.zip -> Apple_Media_Services.zip -> folder/csv
+                assert export_zip.namelist() == [MEDIA_SERVICES_ZIP_NAME]
+                media_zip = _open_media_services_zip(export_zip)
+                assert media_zip.namelist() == [f"{ACTIVITY_FOLDER}/{CSV_NAME}"]
+                csv_bytes = media_zip.read(f"{ACTIVITY_FOLDER}/{CSV_NAME}")
+                reader = csv.DictReader(io.StringIO(csv_bytes.decode("utf-8")))
+                # even an empty batch is a valid header-only CSV (header present, no crash)
+                assert reader.fieldnames == COLUMNS
+                rows = list(reader)
+                counts.append(len(rows))
+                seen.extend(row["Song Name"] for row in rows)
+    # the batches with no records produce header-only CSVs with 0 data rows
+    assert counts.count(0) == COMBINED_BATCHES - len(records)
+    # the disjoint union across batches is exactly the full input set
+    assert len(seen) == len(set(seen)) == len(records)
+    assert set(seen) == {r.song_name for r in records}
+
+
+# --- determinism ------------------------------------------------------------------
+
+
+def test_outputs_are_deterministic(tmp_path, apple_music_record):
+    # given identical inputs and reference date
+    ref = datetime(2026, 2, 8, 12, 30, 15)
+    writer_a = AppleMusicWriter(output_dir=tmp_path / "a", reference_date=ref)
+    writer_b = AppleMusicWriter(output_dir=tmp_path / "b", reference_date=ref)
+    records = [apple_music_record] * 5
+    # when
+    writer_a.write(records)
+    writer_b.write(records)
+    # then
+    assert writer_a.csv_path.read_bytes() == writer_b.csv_path.read_bytes()
+    assert writer_a.export_zip_path.read_bytes() == writer_b.export_zip_path.read_bytes()
+    assert writer_a.combined_zip_path.read_bytes() == writer_b.combined_zip_path.read_bytes()


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The synthetic Apple Music generator produced a flat `Apple Music Play Activity.csv`, but a real Apple privacy export is a nested ZIP archive. As a result the generated fixture did not travel through the same import path (recursive ZIP extraction) as a real export, making it a poor stand-in for testing the Apple Music flow.

Closes #421

## 🎹 Proposal

Apple Music data is now written as a nested ZIP that mirrors a real export:

```
Apple Media Services information.zip     # language-dependent outer name
└── Apple_Media_Services.zip
    └── Apple Music Activity/
        └── Apple Music Play Activity.csv
```

Apple splits large histories into several export ZIPs (batches). Because Tracksy imports one file at a time, users combine those batches into a single outer ZIP by hand. The generator can reproduce this with a new `--apple-music-batches N` option, which splits the records across `N` export ZIPs wrapped in one combined archive:

```
Apple Media Services information - combined parts.zip
├── Apple Media Services information - Part 1 of 3.zip   # -> Apple_Media_Services.zip -> ...
├── Apple Media Services information - Part 2 of 3.zip
└── Apple Media Services information - Part 3 of 3.zip
```

The CSV content itself is unchanged — it is only wrapped in the correct archive structure. Output stays deterministic (ZIP entry timestamps are derived from the reference date), so the same seed and reference date yield byte-identical archives.

## 🎶 Comments

Interop with the app was verified read-only (no app code changed): the app's `extractFilesRecursively` recurses into `.zip` entries and flattens folders to their basename, and `AppleMusicStreamProvider` matches `^Apple Music Play Activity\.csv$`. The app's existing `extractFilesRecursively.test.ts` already asserts exactly this nesting (`export.zip` → `Apple_Media_Services.zip` → `Apple Music Play Activity.csv`) and the folder-flattening behaviour, so the emitted archives are consumed by the real import path.

Assumptions: the language-dependent outer archive name is fixed to `Apple Media Services information` for deterministic output; per-batch archives use the `- Part N of M` suffix (a colon is avoided so macOS Finder does not render it as `/`).

## 🎤 Test

`format`, `lint`, `typecheck`, and `test` (409 passing) all green. New tests assert the exact nested entry paths, CSV validity inside the archive, deterministic bytes, and the combined multi-batch layout.

Manual verification:

```bash
moon run synthetic-datasets:generate -- 100 --provider apple-music --seed 42
# Apple Media Services information.zip
#   Apple_Media_Services.zip
#     Apple Music Activity/Apple Music Play Activity.csv

moon run synthetic-datasets:generate -- 100 --provider apple-music --seed 42 --apple-music-batches 3
# Apple Media Services information - combined parts.zip
#   Apple Media Services information - Part 1 of 3.zip -> Apple_Media_Services.zip -> Apple Music Activity/Apple Music Play Activity.csv
#   Apple Media Services information - Part 2 of 3.zip -> ...
#   Apple Media Services information - Part 3 of 3.zip -> ...
```
