### PR TITLE
feat(results): export results as image

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,6 +16,7 @@
         "d3": "^7.9.0",
         "dayjs": "^1.11.21",
         "eslint-plugin-import": "^2.32.0",
+        "html-to-image": "^1.11.13",
         "libarchive.js": "^2.0.2",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       eslint-plugin-import:
         specifier: ^2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       libarchive.js:
         specifier: ^2.0.2
         version: 2.0.2
@@ -2543,6 +2546,9 @@ packages:
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -6708,6 +6714,8 @@ snapshots:
   html-escaper@2.0.2: {}
 
   html-escaper@3.0.3: {}
+
+  html-to-image@1.11.13: {}
 
   html-void-elements@3.0.0: {}
 

--- a/app/src/components/ExportButton/ExportButton.test.tsx
+++ b/app/src/components/ExportButton/ExportButton.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import type { RefObject } from 'react'
+import { ExportButton } from './ExportButton'
+import * as exporter from '../../utils/exportElementAsImage'
+
+describe('ExportButton', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    const renderWithTarget = (filename?: string) => {
+        const element = document.createElement('div')
+        const targetRef = { current: element } as RefObject<HTMLDivElement>
+        render(<ExportButton targetRef={targetRef} filename={filename} />)
+        return element
+    }
+
+    it('renders the export button', () => {
+        renderWithTarget()
+        const button = screen.getByRole('button', { name: /export/i })
+        expect(button.textContent).toContain('Export as image')
+    })
+
+    it('captures the target element when clicked', async () => {
+        const spy = vi
+            .spyOn(exporter, 'exportElementAsImage')
+            .mockResolvedValue(undefined)
+
+        const element = renderWithTarget('my-stats.png')
+        fireEvent.click(screen.getByRole('button', { name: /export/i }))
+
+        await waitFor(() =>
+            expect(spy).toHaveBeenCalledWith(element, 'my-stats.png')
+        )
+    })
+
+    it('shows a failure state when export throws', async () => {
+        vi.spyOn(exporter, 'exportElementAsImage').mockRejectedValue(
+            new Error('capture failed')
+        )
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        renderWithTarget()
+        fireEvent.click(screen.getByRole('button', { name: /export/i }))
+
+        await screen.findByText(/Export failed/i)
+    })
+
+    it('does nothing when the target is missing', () => {
+        const spy = vi
+            .spyOn(exporter, 'exportElementAsImage')
+            .mockResolvedValue(undefined)
+
+        const targetRef = { current: null } as RefObject<HTMLDivElement>
+        render(<ExportButton targetRef={targetRef} />)
+        fireEvent.click(screen.getByRole('button', { name: /export/i }))
+
+        expect(spy).not.toHaveBeenCalled()
+    })
+})

--- a/app/src/components/ExportButton/ExportButton.tsx
+++ b/app/src/components/ExportButton/ExportButton.tsx
@@ -1,0 +1,48 @@
+import { useCallback, useState, type RefObject } from 'react'
+import { exportElementAsImage } from '../../utils/exportElementAsImage'
+
+type ExportButtonProps = {
+    /** Element to capture as an image. */
+    targetRef: RefObject<HTMLElement | null>
+    /** Optional filename for the downloaded PNG. */
+    filename?: string
+}
+
+type Status = 'idle' | 'exporting' | 'error'
+
+const LABELS: Record<Status, string> = {
+    idle: '📸 Export as image',
+    exporting: '⏳ Exporting…',
+    error: '⚠️ Export failed',
+}
+
+export function ExportButton({ targetRef, filename }: ExportButtonProps) {
+    const [status, setStatus] = useState<Status>('idle')
+
+    const handleClick = useCallback(async () => {
+        const element = targetRef.current
+        if (!element) return
+
+        setStatus('exporting')
+        try {
+            await exportElementAsImage(element, filename)
+            setStatus('idle')
+        } catch (error) {
+            console.error('Failed to export results as image:', error)
+            setStatus('error')
+        }
+    }, [targetRef, filename])
+
+    return (
+        <button
+            type="button"
+            title="Export your results as a shareable image"
+            aria-label="Export your results as a shareable image"
+            disabled={status === 'exporting'}
+            onClick={handleClick}
+            className="px-4 py-2 rounded-2xl bg-gray-100 dark:bg-slate-800/50 backdrop-blur-md shadow-lg border border-gray-300/60 dark:border-slate-700/50 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-all duration-200 disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+            <span className="whitespace-nowrap">{LABELS[status]}</span>
+        </button>
+    )
+}

--- a/app/src/components/Results/Results.tsx
+++ b/app/src/components/Results/Results.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useCallback, useRef, useState } from 'react'
 import { SimpleView } from '../Charts/SimpleView'
 import { Spinner } from '../Spinner/Spinner'
+import { ExportButton } from '../ExportButton/ExportButton'
 import { QueryTabContext } from './QueryTabContext'
 
 const LabView = lazy(() =>
@@ -42,6 +43,7 @@ export function Results() {
     const [activeTab, setActiveTab] = useState<Tab>('simple')
     const [queryKey, setQueryKey] = useState(0)
     const pendingQueryRef = useRef<string | undefined>(undefined)
+    const exportRef = useRef<HTMLDivElement>(null)
     const tabIndex = TABS.findIndex((t) => t.id === activeTab)
 
     const openInQueryTab = useCallback((sql: string) => {
@@ -86,7 +88,11 @@ export function Results() {
                     </div>
                 </div>
 
-                <div>
+                <div className="mb-4 flex justify-end">
+                    <ExportButton targetRef={exportRef} />
+                </div>
+
+                <div ref={exportRef}>
                     <Suspense
                         fallback={
                             <div className="flex justify-center py-12">

--- a/app/src/utils/exportElementAsImage.test.ts
+++ b/app/src/utils/exportElementAsImage.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import * as htmlToImage from 'html-to-image'
+import {
+    buildImageFilename,
+    exportElementAsImage,
+} from './exportElementAsImage'
+
+describe('buildImageFilename', () => {
+    it('builds a timestamped png filename', () => {
+        expect(buildImageFilename()).toMatch(/^tracksy-\d{4}-\d{2}-\d{2}\.png$/)
+    })
+
+    it('respects a custom prefix', () => {
+        expect(buildImageFilename('stats')).toMatch(/^stats-/)
+    })
+})
+
+describe('exportElementAsImage', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('captures the element and triggers a download', async () => {
+        const dataUrl = 'data:image/png;base64,abc'
+        const toPngSpy = vi
+            .spyOn(htmlToImage, 'toPng')
+            .mockResolvedValue(dataUrl)
+        const clickSpy = vi
+            .spyOn(HTMLAnchorElement.prototype, 'click')
+            .mockImplementation(() => {})
+
+        const element = document.createElement('div')
+        await exportElementAsImage(element, 'result.png')
+
+        expect(toPngSpy).toHaveBeenCalledWith(
+            element,
+            expect.objectContaining({
+                pixelRatio: 2,
+                backgroundColor: '#f8fafc',
+            })
+        )
+        expect(clickSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('propagates capture failures', async () => {
+        vi.spyOn(htmlToImage, 'toPng').mockRejectedValue(new Error('boom'))
+        const element = document.createElement('div')
+
+        await expect(exportElementAsImage(element)).rejects.toThrow('boom')
+    })
+})

--- a/app/src/utils/exportElementAsImage.ts
+++ b/app/src/utils/exportElementAsImage.ts
@@ -1,0 +1,50 @@
+import { DARK_CLASS } from '../hooks/theme.constants'
+
+/** Page background colours, mirroring the `bg-*` classes used by the app shell. */
+const BACKGROUND = {
+    light: '#f8fafc',
+    dark: '#020617',
+} as const
+
+/** Resolve the current effective theme from the `<html>` element. */
+function currentBackground(): string {
+    const isDark =
+        typeof document !== 'undefined' &&
+        document.documentElement.classList.contains(DARK_CLASS)
+    return isDark ? BACKGROUND.dark : BACKGROUND.light
+}
+
+/** Build a filesystem-friendly, timestamped filename such as `tracksy-2026-07-26.png`. */
+export function buildImageFilename(prefix = 'tracksy'): string {
+    const date = new Date().toISOString().slice(0, 10)
+    return `${prefix}-${date}.png`
+}
+
+/** Trigger a browser download for the given data URL. */
+function downloadDataUrl(dataUrl: string, filename: string): void {
+    const link = document.createElement('a')
+    link.href = dataUrl
+    link.download = filename
+    link.click()
+}
+
+/**
+ * Capture a DOM element as a PNG and download it.
+ *
+ * Renders at 2x pixel ratio for a crisp, shareable image and applies the current
+ * theme background so charts and text stay legible in both light and dark mode.
+ *
+ * @throws if the capture fails (e.g. tainted canvas, unsupported browser).
+ */
+export async function exportElementAsImage(
+    element: HTMLElement,
+    filename = buildImageFilename()
+): Promise<void> {
+    const { toPng } = await import('html-to-image')
+    const dataUrl = await toPng(element, {
+        backgroundColor: currentBackground(),
+        pixelRatio: 2,
+        cacheBust: true,
+    })
+    downloadDataUrl(dataUrl, filename)
+}


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Closes #189.

There was no way to save or share the results screen. Users who want to show off or keep a snapshot of their listening stats had to resort to manual screenshots, which are inconsistent across devices and lose quality.

## 🎹 Proposal

Add an "Export as image" action to the results screen. The button captures the currently displayed results view and downloads it as a shareable PNG card.

Capture is handled by [`html-to-image`](https://github.com/bubkoo/html-to-image) (`toPng`), the maintained, generic option agreed on in the issue discussion. It correctly renders fonts and the D3/Observable Plot SVG charts, and it leaves room to grow toward richer custom share images later.

Details:

- The exported card adopts the current light or dark page background, so it stays legible in either theme.
- Rendering happens at 2× pixel ratio for a crisp result.
- The download uses a sensible timestamped filename (`tracksy-YYYY-MM-DD.png`).
- The button reflects progress (exporting) and fails gracefully with a visible error state if capture cannot complete.
- The button follows the existing UI conventions (Tailwind, `dark:` variants, shared button styling).

Capture logic lives in a small, testable `exportElementAsImage` utility, kept separate from the `ExportButton` UI.

## 🎶 Comments

Scope is intentionally kept to a clean first version: a single export of the active results container. The button lives in the results view, so whichever tab is on screen (Simple, Lab, Chat, Query) is what gets exported.

## 🎤 Test

Automated:

- `moon run app:format`, `moon run app:lint`, `moon run app:typecheck`, `moon run app:test` all pass.
- New unit tests cover the `exportElementAsImage` utility (capture + download, filename format, error propagation) and the `ExportButton` component (render, click-to-capture, failure state, missing target). `html-to-image` is mocked via `vi.spyOn`.

Manual:

1. `moon run app:dev`.
2. Load data (or use the demo button) until the results screen appears.
3. Click "📸 Export as image" — a PNG of the results downloads.
4. Toggle the theme and export again — verify the background matches the active theme.
