### PR TITLE
feat(app): replace the DuckDB init text with an animated duck loader

### DIFF
--- a/app/src/components/DuckLoader/DuckLoader.test.tsx
+++ b/app/src/components/DuckLoader/DuckLoader.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DuckLoader } from './DuckLoader'
+
+describe('DuckLoader', () => {
+    it('exposes the stage as a live status', () => {
+        render(<DuckLoader stage="Waking the duck…" />)
+        expect(screen.getByRole('status').textContent).toBe('Waking the duck…')
+    })
+
+    it('hides the duck from assistive tech', () => {
+        const { container } = render(<DuckLoader stage="Waking the duck…" />)
+        // Screen readers announce 🦆 as "duck", which would talk over the status.
+        const decorative = container.querySelector('[aria-hidden="true"]')
+        expect(decorative?.textContent).toContain('🦆')
+    })
+
+    it('renders a progress bar carrying the percent', () => {
+        render(<DuckLoader stage="Teaching it to swim…" percent={62} />)
+        const bar = screen.getByRole('progressbar')
+        expect(bar.getAttribute('aria-valuenow')).toBe('62')
+        expect(bar.getAttribute('aria-valuemax')).toBe('100')
+    })
+
+    it('omits the bar when no percent is known', () => {
+        render(<DuckLoader stage="Waking the duck…" percent={null} />)
+        expect(screen.queryByRole('progressbar')).toBe(null)
+    })
+
+    it('does not repeat the stage text alongside the bar', () => {
+        render(<DuckLoader stage="Teaching it to swim…" percent={62} />)
+        expect(screen.getAllByText('Teaching it to swim…')).toHaveLength(1)
+    })
+
+    it('replaces the status with an alert on failure', () => {
+        render(
+            <DuckLoader
+                stage="Teaching it to swim…"
+                error={new Error('boom')}
+            />
+        )
+        expect(screen.getByRole('alert').textContent).toContain(
+            'The database engine failed to start.'
+        )
+        expect(screen.queryByRole('status')).toBe(null)
+    })
+
+    it('calls onRetry when the retry button is pressed', () => {
+        const onRetry = vi.fn()
+        render(
+            <DuckLoader
+                stage="Teaching it to swim…"
+                error={new Error('boom')}
+                onRetry={onRetry}
+            />
+        )
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+        expect(onRetry).toHaveBeenCalledTimes(1)
+    })
+
+    it('omits the retry button when there is nothing to retry', () => {
+        render(<DuckLoader stage="Teaching it to swim…" error={new Error()} />)
+        expect(screen.queryByRole('button', { name: 'Retry' })).toBe(null)
+    })
+
+    it('keeps the failure message available so it can be reported', () => {
+        const { container } = render(
+            <DuckLoader
+                stage="Teaching it to swim…"
+                error={new Error('Failed to fetch duckdb-eh.wasm')}
+            />
+        )
+        // Tucked into a <details> so it stays out of the way until asked for.
+        const details = container.querySelector('details')
+        expect(details?.textContent).toContain('Failed to fetch duckdb-eh.wasm')
+    })
+
+    it('stops animating the duck on failure', () => {
+        const { container } = render(
+            <DuckLoader stage="Teaching it to swim…" error={new Error()} />
+        )
+        expect(container.querySelector('.animate-duck-bob')).toBe(null)
+    })
+
+    it('hides the ripples rather than freezing them mid-animation', () => {
+        // Their keyframes have no resting state, so an unanimated ripple is an
+        // opaque ring at full scale — not a faded-out one.
+        const { container, rerender } = render(
+            <DuckLoader stage="Waking the duck…" />
+        )
+        const ripples = container.querySelectorAll('.animate-duck-ripple')
+        expect(ripples).toHaveLength(2)
+        ripples.forEach((ripple) =>
+            expect(ripple.className).toContain('motion-reduce:hidden')
+        )
+
+        rerender(<DuckLoader stage="Waking the duck…" error={new Error()} />)
+        const decorative = container.querySelector('[aria-hidden="true"]')
+        expect(container.querySelector('.animate-duck-ripple')).toBe(null)
+        expect(decorative?.querySelectorAll('.hidden')).toHaveLength(2)
+    })
+
+    it('guards the entrance animation for reduced motion', () => {
+        // Safe to drop rather than hide: fadeIn runs opacity 0→1 with no
+        // forwards, so with no animation the loader sits at full opacity.
+        const { container } = render(<DuckLoader stage="Waking the duck…" />)
+        expect(
+            container.querySelector('.animate-fade-in')?.className
+        ).toContain('motion-reduce:animate-none')
+    })
+})

--- a/app/src/components/DuckLoader/DuckLoader.tsx
+++ b/app/src/components/DuckLoader/DuckLoader.tsx
@@ -1,0 +1,123 @@
+import { ProgressBar } from '../ProgressBar/ProgressBar'
+
+const SIZE = 112
+// The glyph only needs part of the box; the rest is headroom for the ripples.
+const GLYPH_SIZE = SIZE * 0.62
+
+/**
+ * The duck emoji bobbing over two expanding ripples.
+ *
+ * The whole block is decorative and hidden from assistive tech — screen readers
+ * announce 🦆 as "duck", which would talk over the loading status next to it.
+ *
+ * These are the app's only looping animations, so both honour the OS reduced-
+ * motion setting: the duck simply holds still, but the ripples are hidden
+ * outright. Their keyframes have no resting state, so an unanimated ripple is
+ * not a faded-out one — it is an opaque ring at full scale, and two of them
+ * overlapping is worse than no ripples at all. Same reason they go when `still`.
+ */
+function FloatingDuck({ still }: { still: boolean }) {
+    const ripple = [
+        'absolute bottom-1 h-3 w-3/4 rounded-[50%] border-2',
+        'border-slate-300 dark:border-slate-600',
+        still ? 'hidden' : 'animate-duck-ripple motion-reduce:hidden',
+    ].join(' ')
+
+    return (
+        <div
+            aria-hidden="true"
+            className={`relative flex items-end justify-center ${
+                still ? 'opacity-60 grayscale' : ''
+            }`}
+            style={{ width: SIZE, height: SIZE }}
+        >
+            <div className={ripple} />
+            <div className={`${ripple} [animation-delay:1.2s]`} />
+            <span
+                // leading-none: the default line box adds slack around a ~70px
+                // glyph and pushes the duck off-centre.
+                className={`relative leading-none ${
+                    still ? '' : 'animate-duck-bob motion-reduce:animate-none'
+                }`}
+                style={{ fontSize: GLYPH_SIZE }}
+            >
+                🦆
+            </span>
+        </div>
+    )
+}
+
+type DuckLoaderProps = {
+    /** Human-readable description of what is happening right now. */
+    stage: string
+    /** Omit or pass null when no real progress is known — the bar is hidden. */
+    percent?: number | null
+    error?: Error | null
+    onRetry?: () => void
+}
+
+export function DuckLoader({
+    stage,
+    percent = null,
+    error = null,
+    onRetry,
+}: DuckLoaderProps) {
+    return (
+        <div className="flex flex-col items-center justify-center gap-4 py-8 animate-fade-in motion-reduce:animate-none">
+            <FloatingDuck still={error !== null} />
+
+            {error ? (
+                <div
+                    role="alert"
+                    className="flex flex-col items-center gap-3 text-center"
+                >
+                    <p className="text-gray-700 dark:text-slate-300">
+                        The database engine failed to start.
+                    </p>
+                    {onRetry && (
+                        <button
+                            type="button"
+                            onClick={onRetry}
+                            className="rounded-lg bg-gradient-brand px-4 py-2 text-white transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple"
+                        >
+                            Retry
+                        </button>
+                    )}
+                    {/* Nothing else records this: the app has no telemetry, so
+                        without it someone reporting "it won't load" has nothing
+                        to paste. */}
+                    {error.message && (
+                        <details className="max-w-md text-sm text-gray-500 dark:text-slate-400">
+                            <summary className="cursor-pointer">
+                                Details
+                            </summary>
+                            <p className="mt-1 font-mono break-words text-left">
+                                {error.message}
+                            </p>
+                        </details>
+                    )}
+                </div>
+            ) : (
+                <>
+                    {/* The live region is the caption alone — `status` already
+                        implies aria-live="polite". Putting it around the bar too
+                        would make screen readers re-announce on every progress
+                        event. */}
+                    <p
+                        role="status"
+                        className="text-gray-600 dark:text-slate-300"
+                    >
+                        {stage}
+                    </p>
+                    {percent !== null && (
+                        <ProgressBar
+                            stage={stage}
+                            percent={percent}
+                            showLabel={false}
+                        />
+                    )}
+                </>
+            )}
+        </div>
+    )
+}

--- a/app/src/components/ProgressBar/ProgressBar.test.tsx
+++ b/app/src/components/ProgressBar/ProgressBar.test.tsx
@@ -29,4 +29,27 @@ describe('ProgressBar', () => {
         const bar = container.querySelector('[style]') as HTMLElement
         expect(bar.style.width).toBe('100%')
     })
+
+    it('exposes the progress to assistive tech', () => {
+        render(<ProgressBar stage="Parsing records…" percent={60} />)
+        const bar = screen.getByRole('progressbar')
+        expect(bar.getAttribute('aria-valuenow')).toBe('60')
+        expect(bar.getAttribute('aria-valuemin')).toBe('0')
+        expect(bar.getAttribute('aria-valuemax')).toBe('100')
+        expect(bar.getAttribute('aria-label')).toBe('Parsing records…')
+    })
+
+    it('can keep the stage as the accessible name without showing it', () => {
+        render(
+            <ProgressBar
+                stage="Parsing records…"
+                percent={60}
+                showLabel={false}
+            />
+        )
+        expect(screen.queryByText('Parsing records…')).toBe(null)
+        expect(screen.getByRole('progressbar').getAttribute('aria-label')).toBe(
+            'Parsing records…'
+        )
+    })
 })

--- a/app/src/components/ProgressBar/ProgressBar.tsx
+++ b/app/src/components/ProgressBar/ProgressBar.tsx
@@ -1,15 +1,33 @@
 type ProgressBarProps = {
     stage: string
     percent: number
+    /**
+     * Set false when the caller already shows `stage` itself — the bar keeps it
+     * as its accessible name instead of repeating it on screen.
+     */
+    showLabel?: boolean
 }
 
-export function ProgressBar({ stage, percent }: ProgressBarProps) {
+export function ProgressBar({
+    stage,
+    percent,
+    showLabel = true,
+}: ProgressBarProps) {
     return (
         <div className="w-full max-w-sm mx-auto flex flex-col gap-2">
-            <p className="text-sm text-center text-gray-500 dark:text-slate-400">
-                {stage}
-            </p>
-            <div className="h-2 rounded-full bg-gray-200 dark:bg-slate-700 overflow-hidden">
+            {showLabel && (
+                <p className="text-sm text-center text-gray-500 dark:text-slate-400">
+                    {stage}
+                </p>
+            )}
+            <div
+                role="progressbar"
+                aria-label={stage}
+                aria-valuenow={percent}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                className="h-2 rounded-full bg-gray-200 dark:bg-slate-700 overflow-hidden"
+            >
                 <div
                     className="h-full rounded-full bg-gradient-brand transition-all duration-300 ease-out"
                     style={{ width: `${percent}%` }}

--- a/app/src/components/TracksyWrapper.test.tsx
+++ b/app/src/components/TracksyWrapper.test.tsx
@@ -32,7 +32,42 @@ it('should render initialization message when DB is not initialized', async () =
             initialIsDataReady={false}
         />
     )
-    screen.getByText('Initializing the database engine (DuckDB-WASM)...')
+    // Asserted through the role so the live region is covered too, and on the
+    // text so the test still says what the user reads.
+    expect(screen.getByRole('status').textContent).toBe('Waking the duck…')
+})
+
+it('should offer a working retry when the database fails to start', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const getDB = vi
+        .spyOn(db, 'getDB')
+        .mockRejectedValueOnce(new Error('wasm exploded'))
+        .mockResolvedValueOnce({
+            db: vi.fn(),
+            conn: vi.fn(),
+        } as unknown as Awaited<ReturnType<typeof db.getDB>>)
+
+    render(
+        <TracksyWrapper
+            initialDb={undefined}
+            initialIsDataDropped={false}
+            initialIsDataReady={false}
+        />
+    )
+
+    // Covers the wiring the hook and the loader tests each only see one side of:
+    // that the init error reaches DuckLoader and its retry reaches the hook.
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('The database engine failed to start.')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    // The retry clears the error as it starts, so the alert is gone before the
+    // second boot lands — assert the app recovered rather than that it vanished.
+    await screen.findByLabelText(
+        /Drag and drop or click to upload your music streaming data/
+    )
+    expect(getDB).toHaveBeenCalledTimes(2)
 })
 
 it('should render the Dropzone and Buttons when DB is initialized', async () => {
@@ -49,9 +84,7 @@ it('should render the Dropzone and Buttons when DB is initialized', async () => 
             initialIsDataReady={false}
         />
     )
-    await waitForElementToBeRemoved(() =>
-        screen.queryByText('Initializing the database engine (DuckDB-WASM)...')
-    )
+    await waitForElementToBeRemoved(() => screen.queryByRole('status'))
 
     screen.getByLabelText(
         /Drag and drop or click to upload your music streaming data/
@@ -86,9 +119,7 @@ it('should show error banner when insertFilesInDatabase rejects', async () => {
             initialIsDataReady={false}
         />
     )
-    await waitForElementToBeRemoved(() =>
-        screen.queryByText('Initializing the database engine (DuckDB-WASM)...')
-    )
+    await waitForElementToBeRemoved(() => screen.queryByRole('status'))
 
     const input = screen.getByLabelText('upload file')
     const file = new File(['{}'], 'test.json', { type: 'application/json' })
@@ -117,9 +148,7 @@ it("shouldn't render the 'how to' button if no URL is defined", async () => {
         />
     )
 
-    await waitForElementToBeRemoved(() =>
-        screen.queryByText('Initializing the database engine (DuckDB-WASM)...')
-    )
+    await waitForElementToBeRemoved(() => screen.queryByRole('status'))
 
     await waitFor(() =>
         expect(

--- a/app/src/components/TracksyWrapper.tsx
+++ b/app/src/components/TracksyWrapper.tsx
@@ -1,15 +1,23 @@
-import { useState, useEffect, useCallback } from 'react'
-import { getDB } from '../db/getDB'
+import { useState, useCallback } from 'react'
 import { DropzoneWrapper } from './Dropzone/DropzoneWrapper'
 import { insertFilesInDatabase } from '../db/queries/insertFilesInDatabase'
 import { ProgressBar } from './ProgressBar/ProgressBar'
-import type { DuckdbApp as DuckdbAppType } from '../db/setupDB'
+import type { DuckdbApp as DuckdbAppType, DuckdbInitStage } from '../db/setupDB'
 import { DemoButton } from './DemoButton/DemoButton'
 import { HowToButton } from './HowToButton/HowToButton'
 import { useDemo } from '../hooks/useDemo'
+import { useDuckDBInit } from '../hooks/useDuckDBInit'
+import { DuckLoader } from './DuckLoader/DuckLoader'
 import { Results } from './Results/Results'
 import { UploadError } from './UploadError'
 import { getUserMessage } from '../utils/uploadErrorMessages'
+
+const INIT_STAGE_LABELS: Record<DuckdbInitStage, string> = {
+    select: 'Waking the duck…',
+    instantiate: 'Teaching it to swim…',
+    connect: 'Smoothing feathers…',
+    extensions: 'Almost afloat…',
+}
 
 interface TracksyWrapperProps {
     initialDb?: DuckdbAppType | null
@@ -22,7 +30,15 @@ export function TracksyWrapper({
     initialIsDataDropped = false,
     initialIsDataReady = false,
 }: TracksyWrapperProps) {
-    const [db, setDb] = useState<DuckdbAppType | null>(initialDb)
+    const {
+        db,
+        stage,
+        percent,
+        error: initError,
+        retry,
+    } = useDuckDBInit({
+        initialDb,
+    })
     const [isDataDropped, setIsDataDropped] = useState(initialIsDataDropped)
     const [isDataReady, setIsDataReady] = useState(initialIsDataReady)
     const [uploadError, setUploadError] = useState<string | null>(null)
@@ -35,14 +51,6 @@ export function TracksyWrapper({
         useDemo()
 
     const activeProgress = loadProgress ?? demoProgress
-
-    useEffect(() => {
-        const initDB = async () => {
-            const dbInstance = await getDB()
-            setDb(dbInstance)
-        }
-        initDB()
-    }, [])
 
     async function handleFileUpload(files: FileList | null) {
         if (!files) return
@@ -66,18 +74,19 @@ export function TracksyWrapper({
 
     if (!db) {
         return (
-            <>
-                <p className="dark:text-white">
-                    Initializing the database engine (DuckDB-WASM)...
-                </p>
-            </>
+            <DuckLoader
+                stage={INIT_STAGE_LABELS[stage ?? 'select']}
+                percent={percent}
+                error={initError}
+                onRetry={retry}
+            />
         )
     }
 
     return (
         <>
             {(!isDataDropped || isDataReady) && !activeProgress && (
-                <div className="flex flex-col md:flex-row gap-4 items-stretch">
+                <div className="flex flex-col md:flex-row gap-4 items-stretch animate-fade-in motion-reduce:animate-none">
                     <div className="flex-grow transition-all duration-300">
                         <DropzoneWrapper
                             handleValidatedFiles={handleFileUpload}

--- a/app/src/db/getDB.test.ts
+++ b/app/src/db/getDB.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { DuckdbApp, DuckdbInitProgressHandler } from './setupDB'
+
+const fakeApp = () => ({ db: {}, conn: {} }) as unknown as DuckdbApp
+
+/**
+ * `getDB` caches the boot in module scope, so each test needs a fresh copy of
+ * the module — and a clean `window`, which the cache also writes to. Both
+ * imports come from the same reset registry, so the spy below is the binding
+ * the fresh `getDB` calls.
+ */
+async function freshGetDB() {
+    vi.resetModules()
+    const setupDB = await import('./setupDB')
+    const { getDB } = await import('./getDB')
+    return { getDB, setupDuckdb: vi.spyOn(setupDB, 'setupDuckdb') }
+}
+
+type SetupDuckdbSpy = Awaited<ReturnType<typeof freshGetDB>>['setupDuckdb']
+
+/**
+ * Holds a boot open so a test can drive its progress and choose when it lands.
+ * `emit` is the handler `getDB` hands down — the one it broadcasts from.
+ */
+function pendingBoot(setupDuckdb: SetupDuckdbSpy) {
+    const boot = {
+        emit: (() => {}) as DuckdbInitProgressHandler,
+        release: (() => {}) as (app: DuckdbApp) => void,
+    }
+    setupDuckdb.mockImplementation((onProgress) => {
+        boot.emit = onProgress!
+        return new Promise<DuckdbApp>((resolve) => {
+            boot.release = resolve
+        })
+    })
+    return boot
+}
+
+beforeEach(() => {
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
+    // @ts-expect-error the globals are only assigned once a boot succeeds
+    delete window.db
+    // @ts-expect-error idem
+    delete window.conn
+})
+
+describe('getDB', () => {
+    it('boots once and caches the result', async () => {
+        const { getDB, setupDuckdb } = await freshGetDB()
+        setupDuckdb.mockResolvedValue(fakeApp())
+
+        const first = await getDB()
+        const second = await getDB()
+
+        expect(setupDuckdb).toHaveBeenCalledTimes(1)
+        expect(second.conn).toBe(first.conn)
+    })
+
+    it('shares one boot between callers that overlap', async () => {
+        // The resolved value is only cached once setupDuckdb settles, so without
+        // caching the promise every caller arriving before then starts its own
+        // worker and downloads the ~33 MB bundle again.
+        const { getDB, setupDuckdb } = await freshGetDB()
+        const boot = pendingBoot(setupDuckdb)
+
+        const both = Promise.all([getDB(), getDB()])
+        boot.release(fakeApp())
+        const [first, second] = await both
+
+        expect(setupDuckdb).toHaveBeenCalledTimes(1)
+        expect(second.conn).toBe(first.conn)
+    })
+
+    it('lets a retry start a fresh boot after a failure', async () => {
+        const { getDB, setupDuckdb } = await freshGetDB()
+        setupDuckdb
+            .mockRejectedValueOnce(new Error('wasm exploded'))
+            .mockResolvedValueOnce(fakeApp())
+
+        await expect(getDB()).rejects.toThrow('wasm exploded')
+        // The rejected promise must not stay cached, or retry would replay the
+        // same failure forever.
+        await expect(getDB()).resolves.toHaveProperty('conn')
+        expect(setupDuckdb).toHaveBeenCalledTimes(2)
+    })
+
+    it('reports the stage the boot emits before it returns', async () => {
+        // setupDuckdb announces its first stage synchronously, so the booting
+        // caller cannot have subscribed yet — only the replay reaches it.
+        const { getDB, setupDuckdb } = await freshGetDB()
+        setupDuckdb.mockImplementation((onProgress) => {
+            onProgress?.({ stage: 'select', percent: null })
+            return Promise.resolve(fakeApp())
+        })
+        const onProgress = vi.fn()
+
+        await getDB(onProgress)
+
+        expect(onProgress).toHaveBeenCalledWith({
+            stage: 'select',
+            percent: null,
+        })
+    })
+
+    it('reports progress to every caller sharing the boot', async () => {
+        const { getDB, setupDuckdb } = await freshGetDB()
+        const boot = pendingBoot(setupDuckdb)
+        const first = vi.fn()
+        const second = vi.fn()
+
+        const both = Promise.all([getDB(first), getDB(second)])
+        boot.emit({ stage: 'instantiate', percent: 42 })
+        boot.release(fakeApp())
+        await both
+
+        // Without this the joining caller would sit on the first stage for the
+        // whole ~33 MB download.
+        const event = { stage: 'instantiate', percent: 42 }
+        expect(first).toHaveBeenCalledWith(event)
+        expect(second).toHaveBeenCalledWith(event)
+    })
+
+    it('replays the latest stage to a caller that joins late', async () => {
+        const { getDB, setupDuckdb } = await freshGetDB()
+        const boot = pendingBoot(setupDuckdb)
+        const late = vi.fn()
+
+        const first = getDB(vi.fn())
+        boot.emit({ stage: 'instantiate', percent: 42 })
+        const second = getDB(late)
+
+        expect(late).toHaveBeenCalledWith({ stage: 'instantiate', percent: 42 })
+        boot.release(fakeApp())
+        await Promise.all([first, second])
+    })
+
+    it('does not replay a failed attempt into the retry', async () => {
+        const { getDB, setupDuckdb } = await freshGetDB()
+        setupDuckdb
+            .mockImplementationOnce((onProgress) => {
+                onProgress?.({ stage: 'instantiate', percent: 42 })
+                return Promise.reject(new Error('wasm exploded'))
+            })
+            .mockResolvedValueOnce(fakeApp())
+
+        await expect(getDB(vi.fn())).rejects.toThrow('wasm exploded')
+        const retry = vi.fn()
+        await getDB(retry)
+
+        // Otherwise the retry would open at the stage the failure died on.
+        expect(retry).not.toHaveBeenCalled()
+    })
+})

--- a/app/src/db/getDB.ts
+++ b/app/src/db/getDB.ts
@@ -1,4 +1,9 @@
-import { type DuckdbApp, setupDuckdb } from './setupDB'
+import {
+    type DuckdbApp,
+    type DuckdbInitProgress,
+    type DuckdbInitProgressHandler,
+    setupDuckdb,
+} from './setupDB'
 
 declare global {
     interface Window {
@@ -7,15 +12,68 @@ declare global {
     }
 }
 /**
+ * The boot in flight, so overlapping callers share one engine instead of each
+ * starting a worker and downloading the ~33 MB bundle again. Caching the value
+ * alone isn't enough: it is only written once `setupDuckdb` resolves, leaving
+ * every caller that arrives before then to boot its own.
+ */
+let boot: Promise<DuckdbApp> | null = null
+
+/**
+ * Everyone currently awaiting the boot, so a caller that joins one already in
+ * flight still sees it advance instead of sitting on the first stage for the
+ * whole ~33 MB download.
+ */
+const listeners = new Set<DuckdbInitProgressHandler>()
+
+/** The most recent event, replayed to each caller as it subscribes. */
+let lastProgress: DuckdbInitProgress | null = null
+
+const startBoot = () =>
+    setupDuckdb((progress) => {
+        lastProgress = progress
+        listeners.forEach((listener) => listener(progress))
+    }).then((app) => {
+        window.db = app.db
+        window.conn = app.conn
+        console.debug('Database initialized')
+        return app
+    })
+
+/**
  * DuckDB is used on client side (browser) to query data
  * We just need to instantiate it once on the client side for a page render
+ *
+ * Every caller sharing the boot receives its progress. Callers that hit the
+ * cache emit nothing — there is nothing left to wait for.
  */
-export const getDB = async () => {
-    if (!window.db || !window.conn) {
-        const { db, conn } = await setupDuckdb()
-        window.db = db
-        window.conn = conn
-        console.debug('Database initialized')
+export const getDB = async (onProgress?: DuckdbInitProgressHandler) => {
+    if (window.db && window.conn) {
+        return { db: window.db, conn: window.conn }
     }
-    return { db: window.db, conn: window.conn }
+
+    const pending = (boot ??= startBoot())
+
+    if (onProgress) {
+        listeners.add(onProgress)
+        // Replay covers the caller that boots too: `setupDuckdb` reports its
+        // first stage synchronously, before the line above could subscribe.
+        if (lastProgress) onProgress(lastProgress)
+    }
+
+    try {
+        return await pending
+    } catch (error) {
+        // Drop the rejected promise so a retry starts a fresh boot instead of
+        // replaying this failure forever — unless someone already started one,
+        // which several callers failing together would otherwise discard.
+        if (boot === pending) {
+            boot = null
+            // Or the retry would open on the stage the failed attempt died at.
+            lastProgress = null
+        }
+        throw error
+    } finally {
+        if (onProgress) listeners.delete(onProgress)
+    }
 }

--- a/app/src/db/setupDB.test.ts
+++ b/app/src/db/setupDB.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { statSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import * as duckdb from '@duckdb/duckdb-wasm'
+
+import {
+    WASM_BYTES,
+    toInstantiatePercent,
+    setupDuckdb,
+    type DuckdbInitProgress,
+} from './setupDB'
+
+const mocks = vi.hoisted(() => ({
+    instantiate: vi.fn(),
+    connect: vi.fn(),
+    query: vi.fn(),
+    terminate: vi.fn(),
+}))
+
+// The project prefers vi.spyOn, but that only works on modules Vite transforms.
+// @duckdb/duckdb-wasm is an external dependency whose namespace exports are
+// non-configurable — spying on them throws "Cannot redefine property". Replacing
+// the module is the only way to reach setupDuckdb's failure paths.
+// eslint-disable-next-line no-restricted-syntax
+vi.mock('@duckdb/duckdb-wasm', () => ({
+    selectBundle: vi.fn(),
+    ConsoleLogger: class ConsoleLogger {},
+    AsyncDuckDB: class AsyncDuckDB {
+        instantiate = mocks.instantiate
+        connect = mocks.connect
+    },
+}))
+
+/** The size GitHub Pages reports for the gzipped eh bundle — deliberately wrong. */
+const GZIPPED_CONTENT_LENGTH = 7_842_000
+
+type ProgressCallback = (progress: duckdb.InstantiationProgress) => void
+
+/**
+ * Drives `instantiate` through the given download positions, reporting the
+ * bundle's *compressed* size as duckdb does. Nothing here should divide by it.
+ */
+function downloadReaching(...bytesLoaded: number[]) {
+    return async (
+        _mainModule: string,
+        _pthreadWorker: string | null,
+        onProgress?: ProgressCallback
+    ) => {
+        const at = new Date(0)
+        for (const loaded of bytesLoaded) {
+            onProgress?.({
+                startedAt: at,
+                updatedAt: at,
+                bytesTotal: GZIPPED_CONTENT_LENGTH,
+                bytesLoaded: loaded,
+            })
+        }
+    }
+}
+
+/** Resolves selectBundle to the real eh entry, so its URL matches BUNDLE_BYTES. */
+function selectEhBundle() {
+    vi.mocked(duckdb.selectBundle).mockImplementation(
+        async (bundles: duckdb.DuckDBBundles) => ({
+            ...bundles.eh!,
+            pthreadWorker: null,
+        })
+    )
+}
+
+function captureProgress() {
+    const seen: DuckdbInitProgress[] = []
+    return { seen, onProgress: (next: DuckdbInitProgress) => seen.push(next) }
+}
+
+beforeEach(() => {
+    // The mocks are module-level, so call counts would otherwise carry between
+    // tests — and `sequence.shuffle` means the order they carry in varies.
+    vi.clearAllMocks()
+    vi.stubGlobal(
+        'Worker',
+        class Worker {
+            terminate = mocks.terminate
+        }
+    )
+    selectEhBundle()
+    mocks.instantiate.mockImplementation(downloadReaching())
+    mocks.connect.mockResolvedValue({ query: mocks.query })
+    mocks.query.mockResolvedValue({})
+})
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+})
+
+describe('toInstantiatePercent', () => {
+    it('maps the download across the 5–85 band', () => {
+        expect(toInstantiatePercent({ bytesLoaded: 0 }, 1000)).toBe(5)
+        expect(toInstantiatePercent({ bytesLoaded: 500 }, 1000)).toBe(45)
+        expect(toInstantiatePercent({ bytesLoaded: 1000 }, 1000)).toBe(85)
+    })
+
+    it('is indeterminate when the total is unknown', () => {
+        expect(toInstantiatePercent({ bytesLoaded: 500 }, 0)).toBe(null)
+    })
+
+    it('clamps rather than overflowing if the total is understated', () => {
+        expect(toInstantiatePercent({ bytesLoaded: 5000 }, 1000)).toBe(85)
+    })
+})
+
+describe('WASM_BYTES', () => {
+    // The constants are the progress denominator. If a duckdb bump changes a
+    // bundle's size, this fails in CI instead of shipping a bar that lies.
+    const require = createRequire(import.meta.url)
+    const sizeOf = (bundle: string) =>
+        statSync(require.resolve(`@duckdb/duckdb-wasm/dist/${bundle}`)).size
+
+    it('matches the shipped .wasm bundles', () => {
+        expect(WASM_BYTES.eh).toBe(sizeOf('duckdb-eh.wasm'))
+        expect(WASM_BYTES.mvp).toBe(sizeOf('duckdb-mvp.wasm'))
+    })
+})
+
+describe('setupDuckdb', () => {
+    it('reports every stage through to 100%', async () => {
+        mocks.instantiate.mockImplementation(
+            downloadReaching(WASM_BYTES.eh / 2, WASM_BYTES.eh)
+        )
+        const { seen, onProgress } = captureProgress()
+
+        await setupDuckdb(onProgress)
+
+        expect(seen).toEqual([
+            { stage: 'select', percent: null },
+            { stage: 'instantiate', percent: null },
+            { stage: 'instantiate', percent: 45 },
+            { stage: 'instantiate', percent: 85 },
+            { stage: 'connect', percent: 90 },
+            { stage: 'extensions', percent: 95 },
+            { stage: 'extensions', percent: 100 },
+        ])
+    })
+
+    it('measures against the bundle, not the content-length duckdb reports', async () => {
+        // GitHub Pages gzips .wasm, so duckdb's bytesTotal is ~4.4x too small
+        // while bytesLoaded counts decompressed bytes. Dividing one by the other
+        // pinned the bar at 85% a quarter of the way into the download.
+        mocks.instantiate.mockImplementation(
+            downloadReaching(GZIPPED_CONTENT_LENGTH + 158_000)
+        )
+        const { seen, onProgress } = captureProgress()
+
+        await setupDuckdb(onProgress)
+
+        expect(seen).toContainEqual({ stage: 'instantiate', percent: 24 })
+    })
+
+    it('emits only when the rounded percent moves', async () => {
+        // duckdb fires once per chunk; most chunks do not move a 0–100 bar.
+        const nudge = Math.floor(WASM_BYTES.eh / 400)
+        mocks.instantiate.mockImplementation(
+            downloadReaching(nudge, nudge + 1, nudge + 2, nudge * 8)
+        )
+        const { seen, onProgress } = captureProgress()
+
+        await setupDuckdb(onProgress)
+
+        expect(
+            seen.filter((p) => p.stage === 'instantiate' && p.percent !== null)
+        ).toEqual([
+            { stage: 'instantiate', percent: 5 },
+            { stage: 'instantiate', percent: 7 },
+        ])
+    })
+
+    it('stays indeterminate when no byte progress arrives', async () => {
+        const { seen, onProgress } = captureProgress()
+
+        await setupDuckdb(onProgress)
+
+        expect(seen.every((p) => p.percent === null)).toBe(true)
+        expect(seen.map((p) => p.stage)).toEqual([
+            'select',
+            'instantiate',
+            'connect',
+            'extensions',
+        ])
+    })
+
+    it('stays indeterminate rather than guessing for an unknown bundle', async () => {
+        vi.mocked(duckdb.selectBundle).mockResolvedValue({
+            mainModule: 'https://example.test/duckdb-coi.wasm',
+            mainWorker: 'https://example.test/duckdb-browser-coi.worker.js',
+            pthreadWorker: null,
+        })
+        mocks.instantiate.mockImplementation(downloadReaching(1_000_000))
+        const { seen, onProgress } = captureProgress()
+
+        await setupDuckdb(onProgress)
+
+        expect(seen.every((p) => p.percent === null)).toBe(true)
+    })
+
+    it('terminates the worker when instantiation fails', async () => {
+        mocks.instantiate.mockRejectedValue(new Error('wasm exploded'))
+
+        await expect(setupDuckdb()).rejects.toThrow('wasm exploded')
+        // Retry-safety rests on this: without it a failed attempt leaves its
+        // worker running and the next attempt stacks a second one on top.
+        expect(mocks.terminate).toHaveBeenCalledTimes(1)
+    })
+
+    it('terminates the worker when the setup query fails', async () => {
+        mocks.query.mockRejectedValue(new Error('no excel extension'))
+
+        await expect(setupDuckdb()).rejects.toThrow('no excel extension')
+        expect(mocks.terminate).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns the connected database on success', async () => {
+        const conn = { query: mocks.query }
+        mocks.connect.mockResolvedValue(conn)
+
+        const app = await setupDuckdb()
+
+        expect(app.conn).toBe(conn)
+        expect(mocks.query).toHaveBeenCalledWith('INSTALL excel; LOAD excel;')
+        expect(mocks.terminate).not.toHaveBeenCalled()
+    })
+})

--- a/app/src/db/setupDB.ts
+++ b/app/src/db/setupDB.ts
@@ -9,6 +9,30 @@ export type DuckdbApp = {
     conn: duckdb.AsyncDuckDBConnection
 }
 
+/** Ordered steps of the DuckDB WASM boot sequence. */
+export type DuckdbInitStage =
+    'select' | 'instantiate' | 'connect' | 'extensions'
+
+/**
+ * `percent` is null whenever no byte-level progress is available: before the
+ * WASM download starts, or when the response carries no content-length. UIs
+ * should then show an indeterminate loader rather than a stuck bar.
+ */
+export type DuckdbInitProgress = {
+    stage: DuckdbInitStage
+    percent: number | null
+}
+
+export type DuckdbInitProgressHandler = (progress: DuckdbInitProgress) => void
+
+// The .wasm bundle is ~33 MB, so its download dominates boot time and owns most
+// of the bar. The remaining steps are near-instant once it lands.
+const INSTANTIATE_START_PERCENT = 5
+const INSTANTIATE_PERCENT_SPAN = 80
+const CONNECT_PERCENT = 90
+const EXTENSIONS_PERCENT = 95
+const COMPLETE_PERCENT = 100
+
 const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
     mvp: {
         mainModule: duckdb_wasm,
@@ -20,13 +44,96 @@ const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
     },
 }
 
-export async function setupDuckdb(): Promise<DuckdbApp> {
+/**
+ * Uncompressed byte size of each pinned bundle's .wasm.
+ *
+ * duckdb derives its own `bytesTotal` from the content-length header — the
+ * *compressed* size wherever the asset is served encoded, and GitHub Pages gzips
+ * .wasm — while `bytesLoaded` counts decompressed bytes off `response.body`.
+ * Dividing one by the other pins the bar at 100% after ~23% of the download.
+ * The bytes that actually arrive are always the uncompressed bundle, so its size
+ * on disk is the only honest denominator, whatever the transport encoding.
+ *
+ * Pinned to the shipped files by a test in setupDB.test.ts.
+ */
+export const WASM_BYTES = { mvp: 39_362_651, eh: 34_242_586 } as const
+
+const BUNDLE_BYTES = new Map([
+    [duckdb_wasm, WASM_BYTES.mvp],
+    [duckdb_wasm_eh, WASM_BYTES.eh],
+])
+
+/**
+ * `bytesTotal` is the uncompressed size of the bundle being downloaded, not the
+ * value duckdb reports — see WASM_BYTES. Pass 0 when it isn't known: the caller
+ * then gets null and shows an indeterminate loader, which beats dividing by a
+ * number known to be wrong.
+ */
+export function toInstantiatePercent(
+    { bytesLoaded }: Pick<duckdb.InstantiationProgress, 'bytesLoaded'>,
+    bytesTotal: number
+): number | null {
+    if (!bytesTotal) return null
+    // Clamped in case a WASM_BYTES constant ever drifts from the shipped file.
+    const ratio = Math.min(bytesLoaded / bytesTotal, 1)
+    return Math.round(
+        INSTANTIATE_START_PERCENT + INSTANTIATE_PERCENT_SPAN * ratio
+    )
+}
+
+export async function setupDuckdb(
+    onProgress?: DuckdbInitProgressHandler
+): Promise<DuckdbApp> {
+    onProgress?.({ stage: 'select', percent: null })
     const bundle = await duckdb.selectBundle(MANUAL_BUNDLES)
     const worker = new Worker(bundle.mainWorker!)
-    const logger = new duckdb.ConsoleLogger()
-    const db = new duckdb.AsyncDuckDB(logger, worker)
-    await db.instantiate(bundle.mainModule, bundle.pthreadWorker)
-    const conn = await db.connect()
-    await conn.query('INSTALL excel; LOAD excel;')
-    return { db, conn }
+
+    // Once the worker exists it must be torn down on any failure below, otherwise
+    // it outlives the error and a retry would stack a second one on top of it.
+    try {
+        const logger = new duckdb.ConsoleLogger()
+        const db = new duckdb.AsyncDuckDB(logger, worker)
+
+        // Report the stage before the download starts so the UI can name it even
+        // if the first byte-progress event is slow to arrive.
+        onProgress?.({ stage: 'instantiate', percent: null })
+        const bundleBytes = BUNDLE_BYTES.get(bundle.mainModule) ?? 0
+        let lastPercent: number | null = null
+        await db.instantiate(bundle.mainModule, bundle.pthreadWorker, (p) => {
+            const percent = toInstantiatePercent(p, bundleBytes)
+            // duckdb means to throttle these to one per 20ms but only advances
+            // its clock on the skip branch, so in practice it fires once per
+            // chunk — thousands of times for a 33 MB bundle, across at most 81
+            // distinct rounded values. Emit only when the bar would move.
+            if (percent === null || percent === lastPercent) return
+            lastPercent = percent
+            onProgress?.({ stage: 'instantiate', percent })
+        })
+        const sawByteProgress = lastPercent !== null
+
+        // Without byte progress the bar never appeared, so keep it away rather
+        // than popping it in at 90% for the last two near-instant steps.
+        onProgress?.({
+            stage: 'connect',
+            percent: sawByteProgress ? CONNECT_PERCENT : null,
+        })
+        const conn = await db.connect()
+
+        onProgress?.({
+            stage: 'extensions',
+            percent: sawByteProgress ? EXTENSIONS_PERCENT : null,
+        })
+        await conn.query('INSTALL excel; LOAD excel;')
+
+        // Close the sequence at 100 rather than leaving the bar at 95 as the
+        // loader unmounts.
+        if (sawByteProgress) {
+            onProgress?.({ stage: 'extensions', percent: COMPLETE_PERCENT })
+        }
+
+        return { db, conn }
+    } catch (error) {
+        worker.terminate()
+        throw error
+    }
 }

--- a/app/src/hooks/useDuckDBInit.test.ts
+++ b/app/src/hooks/useDuckDBInit.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useDuckDBInit } from './useDuckDBInit'
+import * as db from '../db/getDB'
+import type { DuckdbApp } from '../db/setupDB'
+
+type Resolved = Awaited<ReturnType<typeof db.getDB>>
+
+const fakeDb = () => ({ db: vi.fn(), conn: vi.fn() }) as unknown as Resolved
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+})
+
+describe('useDuckDBInit', () => {
+    it('exposes the database once initialization resolves', async () => {
+        vi.spyOn(db, 'getDB').mockResolvedValue(fakeDb())
+
+        const { result } = renderHook(() => useDuckDBInit())
+
+        expect(result.current.db).toBe(null)
+        await waitFor(() => expect(result.current.db).not.toBe(null))
+        expect(result.current.error).toBe(null)
+    })
+
+    it('surfaces stage and percent reported during initialization', async () => {
+        let release: (value: Resolved) => void = () => {}
+        const pending = new Promise<Resolved>((resolve) => {
+            release = resolve
+        })
+        vi.spyOn(db, 'getDB').mockImplementation((onProgress) => {
+            onProgress?.({ stage: 'instantiate', percent: 42 })
+            return pending
+        })
+
+        const { result } = renderHook(() => useDuckDBInit())
+
+        await waitFor(() => expect(result.current.stage).toBe('instantiate'))
+        expect(result.current.percent).toBe(42)
+        expect(result.current.db).toBe(null)
+
+        await act(async () => {
+            release(fakeDb())
+            await pending
+        })
+    })
+
+    it('keeps percent null when no byte progress is available', async () => {
+        vi.spyOn(db, 'getDB').mockImplementation((onProgress) => {
+            onProgress?.({ stage: 'select', percent: null })
+            return Promise.resolve(fakeDb())
+        })
+
+        const { result } = renderHook(() => useDuckDBInit())
+
+        await waitFor(() => expect(result.current.stage).toBe('select'))
+        expect(result.current.percent).toBe(null)
+    })
+
+    it('reports an error instead of hanging when initialization fails', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        vi.spyOn(db, 'getDB').mockRejectedValue(new Error('wasm exploded'))
+
+        const { result } = renderHook(() => useDuckDBInit())
+
+        await waitFor(() => expect(result.current.error).not.toBe(null))
+        expect(result.current.error?.message).toBe('wasm exploded')
+        expect(result.current.db).toBe(null)
+    })
+
+    it('wraps non-Error rejections', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        vi.spyOn(db, 'getDB').mockRejectedValue('just a string')
+
+        const { result } = renderHook(() => useDuckDBInit())
+
+        await waitFor(() => expect(result.current.error).not.toBe(null))
+        expect(result.current.error?.message).toBe('just a string')
+    })
+
+    it('retries initialization and clears the previous error', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        const getDB = vi
+            .spyOn(db, 'getDB')
+            .mockRejectedValueOnce(new Error('wasm exploded'))
+            .mockResolvedValueOnce(fakeDb())
+
+        const { result } = renderHook(() => useDuckDBInit())
+        await waitFor(() => expect(result.current.error).not.toBe(null))
+
+        act(() => result.current.retry())
+
+        await waitFor(() => expect(result.current.db).not.toBe(null))
+        expect(result.current.error).toBe(null)
+        expect(getDB).toHaveBeenCalledTimes(2)
+    })
+
+    it('skips initialization when a database is supplied', () => {
+        const getDB = vi.spyOn(db, 'getDB').mockResolvedValue(fakeDb())
+        const initialDb = fakeDb() as unknown as DuckdbApp
+
+        const { result } = renderHook(() => useDuckDBInit({ initialDb }))
+
+        expect(result.current.db).toBe(initialDb)
+        expect(getDB).not.toHaveBeenCalled()
+    })
+})

--- a/app/src/hooks/useDuckDBInit.ts
+++ b/app/src/hooks/useDuckDBInit.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from 'react'
+import { getDB } from '../db/getDB'
+import type { DuckdbApp, DuckdbInitProgress } from '../db/setupDB'
+
+type UseDuckDBInitOptions = {
+    /** Test seam: skip initialization by supplying an already-booted instance. */
+    initialDb?: DuckdbApp | null
+}
+
+/**
+ * Boots DuckDB WASM once and exposes its progress so the UI can show a real
+ * loader instead of a static message. Booting is the slowest thing the app does
+ * on a cold visit — the .wasm bundle is ~33 MB.
+ */
+export function useDuckDBInit({ initialDb = null }: UseDuckDBInitOptions = {}) {
+    const [db, setDb] = useState<DuckdbApp | null>(initialDb)
+    const [progress, setProgress] = useState<DuckdbInitProgress | null>(null)
+    const [error, setError] = useState<Error | null>(null)
+    const [attempt, setAttempt] = useState(0)
+
+    useEffect(() => {
+        if (initialDb) return
+
+        // Guards every setState below: without it a failure that resolves after
+        // unmount would warn, and a retry could be overwritten by its predecessor.
+        let active = true
+
+        setError(null)
+        setProgress(null)
+
+        getDB((next) => {
+            if (active) setProgress(next)
+        })
+            .then((instance) => {
+                if (active) setDb(instance)
+            })
+            .catch((cause: unknown) => {
+                if (!active) return
+                console.error('Failed to initialize DuckDB:', cause)
+                setError(
+                    cause instanceof Error ? cause : new Error(String(cause))
+                )
+            })
+
+        return () => {
+            active = false
+        }
+    }, [initialDb, attempt])
+
+    const retry = useCallback(() => setAttempt((n) => n + 1), [])
+
+    return {
+        db,
+        stage: progress?.stage ?? null,
+        percent: progress?.percent ?? null,
+        error,
+        retry,
+    }
+}

--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -39,6 +39,15 @@
     --animate-scale-in: scaleIn 0.3s ease-out;
     --animate-vibe-pulse: vibePulse 2.8s ease-in-out forwards;
 
+    /* Duck loader — the only looping animations in the app, and both are guarded
+       for reduced motion. The duck takes motion-reduce:animate-none: duckBob
+       rests at translateY(0), so stopping it just holds the duck still. The
+       ripples take motion-reduce:hidden instead, because duckRipple has no
+       resting state — unanimated they sit at scale(1) and full opacity, which
+       is an opaque ring rather than a faded-out one. */
+    --animate-duck-bob: duckBob 2.4s ease-in-out infinite;
+    --animate-duck-ripple: duckRipple 2.4s ease-out infinite;
+
     @keyframes fadeIn {
         from {
             opacity: 0;
@@ -86,6 +95,27 @@
         100% {
             opacity: 0;
             transform: translateY(-4px);
+        }
+    }
+
+    @keyframes duckBob {
+        0%,
+        100% {
+            transform: translateY(0);
+        }
+        50% {
+            transform: translateY(-3px);
+        }
+    }
+
+    @keyframes duckRipple {
+        0% {
+            transform: scale(0.6);
+            opacity: 0.7;
+        }
+        100% {
+            transform: scale(1.4);
+            opacity: 0;
         }
     }
 }


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [x] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The first thing anyone sees when opening Tracksy is an unstyled line of text — `Initializing the database engine (DuckDB-WASM)...` — and it stays there for as long as it takes to download a ~33 MB WebAssembly bundle. Nothing moves, nothing reports progress, and there is no sign the app is doing anything at all.

If that download fails, it gets worse. Initialization was kicked off by a promise nobody was catching, so a rejection went unhandled and the message simply stayed on screen forever, with no explanation and no way out other than guessing that a reload might help.

## 🎹 Proposal

A duck now bobs over expanding ripples while the engine boots. Beneath it, a caption names the step currently running, and a bar tracks the bytes actually arriving — DuckDB's WASM loader already reported download progress, it just wasn't being listened to. When there is nothing honest to show, the bar stays hidden rather than sitting frozen at some meaningless value.

The bar divides by the bundle's own byte size rather than by the total DuckDB reports. DuckDB takes that total from the `content-length` header, which is the **compressed** size wherever the asset is served encoded — and GitHub Pages gzips `.wasm`, 34.2 MB down to 7.8 MB. Meanwhile the bytes it counts come off `response.body`, already decompressed. Dividing one by the other pins the bar at 100% less than a quarter of the way into the download, which is precisely the stuck bar this PR set out to remove. The bytes that arrive are always the uncompressed bundle, so its size on disk is the only denominator that holds regardless of transport encoding. A test pins the constants to the shipped files, so a DuckDB bump fails CI instead of quietly skewing the bar again.

When the boot fails, the duck settles: still and grey. The caption gives way to an explanation, the underlying error message tucked into a `<details>` — the app has no telemetry, so otherwise someone reporting "it won't load" has nothing to paste — and a Retry button that starts the engine over. That is safe because a failed boot never leaves a half-built database cached behind it. A failed attempt also shuts down its worker now, so retrying doesn't quietly stack a second one on top of the first.

`getDB` now caches the boot *promise* rather than the resolved value. The value is only written once the engine is up, so any callers overlapping before then each started their own worker and downloaded the bundle again. Nothing in the app triggers that today, but `retry()` adds a second entry point into a path that already had ten callers.

The progress bar picked up some accessibility work along the way, which also benefits the upload and demo flows that were already using it. The loading caption is announced politely as it changes, while the percentage deliberately is not — it updates constantly and would talk over everything else. The duck is decorative and hidden from screen readers, which would otherwise announce it as "duck" on top of the status beside it. Under reduced motion the duck holds still and the bar keeps filling; the ripples are hidden outright, because their keyframes have no resting state and an unanimated ripple is not a faded-out one but an opaque ring at full scale.

### Loading

<img width="1457" height="812" alt="duck-loader-light" src="https://github.com/user-attachments/assets/41d9cff7-2a27-4af3-a86b-f66426428613" />


### Dark mode

<img width="1457" height="812" alt="duck-loader-dark" src="https://github.com/user-attachments/assets/2f2753bd-162d-4a4d-b90e-a04cb34a4342" />


### When it fails
<img width="1457" height="812" alt="duck-loader-error" src="https://github.com/user-attachments/assets/8412ddc2-3be0-46e4-aa1d-8d9ffacc32af" />



## 🎶 Comments

The duck is an emoji, so it renders as whatever mallard the reader's platform ships — brown and green on macOS, not yellow. Colour can't be applied to an emoji glyph. A hand-drawn yellow SVG came first and looked worse than the emoji at every size, so it went in the bin.

While testing the failure path I ran into an upstream bug in `@duckdb/duckdb-wasm`. In `instantiateWasm`, the worker calls `WebAssembly.instantiateStreaming(...).then(...)` with no `.catch()` and discards the resulting promise. If the `.wasm` request fails, that rejection is swallowed and instantiation never settles — it neither resolves nor rejects.

This is **not** specific to subscribing to progress, as I first thought. `instantiateWasm` reads `this.onInstantiationProgress` unconditionally and branches on whether `TransformStream` exists, not on whether a handler is registered, so the un-`catch`ed call is the default path in every modern browser. The hang is therefore already live on `main` today, and listening for progress opts into nothing new. The retry UI here covers failures that actually propagate — a failing setup query, a failed connection — and a failed `.wasm` download still hangs, exactly as it does now. Worth reporting upstream; deliberately out of scope for this PR.

`setupDB.test.ts` carries the repo's first `eslint-disable` for the `vi.mock` ban, and I'd rather flag it than have it found. The rule points at `vi.spyOn`, which works because Vite transforms our own modules into redefinable bindings. `@duckdb/duckdb-wasm` is an external dependency and its namespace exports are not configurable — `vi.spyOn(duckdb, 'AsyncDuckDB')` throws `Cannot redefine property`. Replacing the module is the only way to reach `setupDuckdb`'s failure paths without reshaping the production code to suit the test. Happy to take the injection route instead if you'd prefer the rule to stay absolute.

One note for anyone running the suite on a French-locale machine: a handful of date and number formatting tests fail there for locale reasons unrelated to this change. Verified by running them on a clean `main` — same failures, same tests.

## 🎤 Test

Booting is too fast on localhost to actually see the loader, so to observe it properly:

1. `moon run app:build`
2. Serve `app/dist` with the `.wasm` response deliberately slowed — write it out in chunks with a short sleep between each — then open `/tracksy`.
3. The duck bobs, the caption walks through the boot steps, the bar climbs to 100%, and the dropzone fades in.
4. **Serve the same `.wasm` gzipped** — `Content-Encoding: gzip` with the compressed `Content-Length`, as GitHub Pages does. The bar must climb at the same rate as in step 3 rather than racing to 85% and stalling there. Serving `app/dist` uncompressed is why this was missed the first time round; on the deployed site the encoded response is the only one anyone gets.
5. Switch to dark mode mid-load: the duck and the ripples both stay legible.
6. Turn on "Reduce motion" in the OS: the duck holds still and the bar still fills, with no ripples left frozen at full scale.
7. For the failure path, break the setup query or serve a broken `.wasm` — the alert, the `<details>` message and the Retry button appear, and Retry genuinely re-runs the boot.

Checks:

```
moon run app:format-check
moon run app:lint
moon run app:typecheck
moon run app:test
```

Formatting, lint and typecheck are clean. The test suite is green — `1002 passed` — with the French-locale caveat above; under `LC_ALL=en_US.UTF-8 TZ=UTC` it passes end to end locally too. Every commit here was checked independently, so the history bisects cleanly.

`setupDB.ts` now has its own test file, since every number in this feature is computed there: the 5–85 mapping and its clamp, the indeterminate branch, the emit-only-when-the-bar-moves gate, and `worker.terminate()` on both failure paths. One test feeds it a compressed `content-length` alongside decompressed byte counts and asserts the bar reads 24% rather than 85% — the regression that prompted all of this. A second pins `WASM_BYTES` to the sizes of the shipped `.wasm` files. `getDB.ts` is covered too, including that a rejected boot isn't left cached where it would make Retry replay the same failure forever.

