### PR TITLE
fix(deezer): guard required columns in transform

### DIFF
--- a/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.test.ts
+++ b/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.test.ts
@@ -124,6 +124,65 @@ describe('DeezerStreamProvider', () => {
             const result = provider.transform([RAW_RECORD])
             expect(result[0].track_uri).toBe('GBAYE8800243')
         })
+
+        it('should skip a row with a missing Date without throwing', () => {
+            const raw = { ...RAW_RECORD }
+            delete (raw as Partial<DeezerRawStreamRecord>).Date
+
+            expect(() =>
+                provider.transform([raw as DeezerRawStreamRecord])
+            ).not.toThrow()
+            expect(provider.transform([raw as DeezerRawStreamRecord])).toEqual(
+                []
+            )
+        })
+
+        it('should skip a row with a missing ISRC without throwing', () => {
+            const raw = { ...RAW_RECORD }
+            delete (raw as Partial<DeezerRawStreamRecord>).ISRC
+
+            expect(() =>
+                provider.transform([raw as DeezerRawStreamRecord])
+            ).not.toThrow()
+            expect(provider.transform([raw as DeezerRawStreamRecord])).toEqual(
+                []
+            )
+        })
+
+        it('should default optional fields when columns are missing', () => {
+            const raw = { ...RAW_RECORD }
+            delete (raw as Partial<DeezerRawStreamRecord>)['Song Title']
+            delete (raw as Partial<DeezerRawStreamRecord>).Artist
+            delete (raw as Partial<DeezerRawStreamRecord>)['Album Title']
+            delete (raw as Partial<DeezerRawStreamRecord>)['Platform Name']
+            delete (raw as Partial<DeezerRawStreamRecord>)['IP Address']
+
+            const result = provider.transform([raw as DeezerRawStreamRecord])
+
+            expect(result).toHaveLength(1)
+            expect(result[0]).toMatchObject({
+                track_uri: 'GBAYE8800243',
+                track_name: 'Unknown Track',
+                artist_name: 'Unknown Artist',
+                album_name: 'Unknown Album',
+                platform: 'Unknown Device',
+                ip_addr: '',
+                ts: '2024-10-24T23:00:00Z',
+            })
+        })
+
+        it('should skip only the malformed rows and keep valid ones', () => {
+            const badRow = { ...RAW_RECORD }
+            delete (badRow as Partial<DeezerRawStreamRecord>).Date
+
+            const result = provider.transform([
+                RAW_RECORD,
+                badRow as DeezerRawStreamRecord,
+            ])
+
+            expect(result).toHaveLength(1)
+            expect(result[0].track_uri).toBe('GBAYE8800243')
+        })
     })
 
     describe('readFile', () => {

--- a/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.ts
+++ b/app/src/streamProvider/DeezerStreamProvider/DeezerStreamProvider.ts
@@ -38,19 +38,26 @@ export class DeezerStreamProvider extends StreamProvider<DeezerRawStreamRecord> 
     }
 
     transform(rawData: DeezerRawStreamRecord[]): StreamRecord[] {
-        return rawData.map((raw) => {
+        return rawData.flatMap((raw) => {
+            const date = raw['Date'] != null ? String(raw['Date']) : undefined
+            const track_uri =
+                raw['ISRC'] != null ? String(raw['ISRC']) : undefined
+            if (date === undefined || track_uri === undefined) return []
+
             const listeningTime = Number(raw['Listening Time']) || 0
             const msPlayed = listeningTime > 0 ? listeningTime * 1000 : 0
-            return {
-                track_uri: raw['ISRC'],
-                track_name: raw['Song Title'],
-                artist_name: raw['Artist'],
-                album_name: raw['Album Title'],
-                ts: raw['Date'].replace(' ', 'T') + 'Z',
-                ms_played: msPlayed,
-                ip_addr: raw['IP Address'],
-                platform: raw['Platform Name'],
-            }
+            return [
+                {
+                    track_uri,
+                    track_name: String(raw['Song Title'] ?? 'Unknown Track'),
+                    artist_name: String(raw['Artist'] ?? 'Unknown Artist'),
+                    album_name: String(raw['Album Title'] ?? 'Unknown Album'),
+                    ts: date.replace(' ', 'T') + 'Z',
+                    ms_played: msPlayed,
+                    ip_addr: String(raw['IP Address'] ?? ''),
+                    platform: String(raw['Platform Name'] ?? 'Unknown Device'),
+                },
+            ]
         })
     }
 }


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

`DeezerStreamProvider.transform()` dereferenced raw spreadsheet columns directly — `raw['Date'].replace(...)`, `raw['ISRC']`, and others — with no null guards. A Deezer export that is missing or has a renamed column (e.g. no `Date` column) caused a `TypeError` to be thrown mid-`map`, aborting the whole import instead of degrading gracefully. The sibling `CustomStreamProvider` already guards every field, so behavior between providers was inconsistent.

## 🎹 Proposal

Make Deezer's `transform()` defensive, mirroring the existing `CustomStreamProvider` approach:

- Treat `Date` (→ `ts`) and `ISRC` (→ `track_uri`) as required. When either is missing/null, the row is skipped (`flatMap` returning `[]`) rather than throwing.
- Default the remaining optional fields to sensible placeholders (`Unknown Track`, `Unknown Artist`, `Unknown Album`, `Unknown Device`, empty `ip_addr`) when their columns are absent.

The happy-path output shape is unchanged; valid rows map exactly as before. A malformed export now imports its valid rows and silently drops the unusable ones instead of crashing.

## 🎶 Comments

No new error-handling paradigm was introduced — this reuses the same guard-and-skip / default pattern already established in `CustomStreamProvider.transform()`.

## 🎤 Test

Added unit tests to `DeezerStreamProvider.test.ts`:

- A row missing `Date` does not throw and yields `[]`.
- A row missing `ISRC` does not throw and yields `[]`.
- A row missing optional columns defaults them (and keeps `track_uri`/`ts`).
- A mix of valid and malformed rows keeps only the valid rows.

Run locally via Moon:

```bash
moon run app:format-check
moon run app:lint
moon run app:typecheck
moon run app:test
```

All 970 app tests pass.
