### PR TITLE
chore(app): type PUBLIC_DEMO_JSON_URL and document BASE_PATH

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,2 +1,6 @@
 # Tracksy Configuration
 PUBLIC_DEMO_JSON_URL=https://huggingface.co/datasets/tracksy/synthetic-datasets/resolve/main/datasets/spotify/Streaming_History_Audio_2006_25000.json
+
+# Base path the app is deployed under (drives Astro's `base`, see astro.config.mjs).
+# Defaults to "/tracksy" when unset. Set to "/" for a root deployment.
+# BASE_PATH=/tracksy

--- a/app/astro.config.mjs
+++ b/app/astro.config.mjs
@@ -65,6 +65,7 @@ function duckdbWasmWorkerSourcemapFix() {
 // https://astro.build/config
 export default defineConfig({
     site: 'https://gudsfile.github.io',
+    // Deploy base path (see app/.env.example). Defaults to "/tracksy" when BASE_PATH is unset.
     base: process.env.BASE_PATH || '/tracksy',
     trailingSlash: 'never',
     output: 'static',

--- a/app/src/env.d.ts
+++ b/app/src/env.d.ts
@@ -1,6 +1,16 @@
 /* eslint-disable @typescript-eslint/triple-slash-reference */
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+
+interface ImportMetaEnv {
+    /** URL of the demo streaming-history JSON loaded by the "Try demo" flow. */
+    readonly PUBLIC_DEMO_JSON_URL?: string
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv
+}
+
 declare module '*.astro' {
     import { Component } from 'astro'
     const component: Component


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Two small typing/documentation gaps around environment configuration in `app/`:

- The public env var `PUBLIC_DEMO_JSON_URL`, read in `app/src/hooks/useDemo.ts` via `import.meta.env.PUBLIC_DEMO_JSON_URL`, had no type declaration, so `import.meta.env` fell back to the generic Astro type with no autocompletion or narrowing for this key.
- The build reads `process.env.BASE_PATH` in `app/astro.config.mjs` to set Astro's `base`, but this variable was undocumented, so contributors had no discoverable way to know it exists or what it controls.

## 🎹 Proposal

`PUBLIC_DEMO_JSON_URL` is now typed by augmenting `ImportMetaEnv` (with the matching `ImportMeta` interface) in `app/src/env.d.ts`, following Astro's convention alongside the existing triple-slash client references. It is declared optional (`?: string`) to reflect that the demo flow already handles its absence gracefully.

`BASE_PATH` is now documented as a commented entry in `app/.env.example`, explaining that it drives the deploy base path and defaults to `/tracksy`, with a matching one-line comment near its use in `astro.config.mjs`.

No runtime behavior changes.

## 🎶 Comments

The existing triple-slash `/// <reference .../>` directives are preserved, and the new interfaces are placed after them so Astro's generated types still load.

## 🎤 Test

