### PR TITLE
chore(synthetic-datasets): declare rich, remove dead code and stale tests

### DIFF
--- a/synthetic-datasets/pyproject.toml
+++ b/synthetic-datasets/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "numpy==2.5.1",
     "openpyxl==3.1.5",
     "pydantic==2.13.4",
+    "rich==15.0.0",
     "typer==0.27.0",
 ]
 

--- a/synthetic-datasets/synthetic_datasets/factories/base.py
+++ b/synthetic-datasets/synthetic_datasets/factories/base.py
@@ -231,10 +231,7 @@ class BaseFactory(ABC, Generic[RecordT]):
         for chapter in self._chapters:
             if chapter.persona is None:
                 continue
-            label = chapter.persona.name
             chapter_events = self._generate_events_for_chapter(chapter)
-            for _ in track(range(len(chapter_events)), description=f" - {chapter.year} ({label})"):
-                pass
             events.extend(chapter_events)
         return sorted(events, key=lambda e: e.timestamp)
 

--- a/synthetic-datasets/synthetic_datasets/factories/deezer.py
+++ b/synthetic-datasets/synthetic_datasets/factories/deezer.py
@@ -2,14 +2,12 @@ import string
 from dataclasses import dataclass
 from ipaddress import ip_address
 
-from rich import get_console, print
+from rich import print
 
 from ..config import GenerationConfig
 from ..models.base import BaseEvent
 from ..models.deezer import DeezerStreaming
 from .base import BaseFactory
-
-_console = get_console()
 
 
 @dataclass

--- a/synthetic-datasets/synthetic_datasets/factories/spotify.py
+++ b/synthetic-datasets/synthetic_datasets/factories/spotify.py
@@ -2,14 +2,12 @@ from datetime import timedelta
 from ipaddress import ip_address
 from typing import ClassVar
 
-from rich import get_console, print
+from rich import print
 
 from ..config import GenerationConfig
 from ..models.base import BaseEvent
 from ..models.spotify import Album, Artist, ReasonEndEnum, ReasonStartEnum, Streaming, Track
 from .base import BaseFactory
-
-_console = get_console()
 
 
 class SpotifyFactory(BaseFactory[Streaming]):

--- a/synthetic-datasets/tests/factories/test_base_factory.py
+++ b/synthetic-datasets/tests/factories/test_base_factory.py
@@ -228,24 +228,6 @@ class TestPersonaDrivenGeneration:
         for event in events:
             assert event.timestamp <= factory.now
 
-    def test_skip_chance_constants_removed(self):
-        assert not hasattr(ConcreteFactory, "SKIP_CHANCE_MIN")
-        assert not hasattr(ConcreteFactory, "SKIP_CHANCE_MAX")
-
-    def test_skip_chance_trend_not_on_instance(self, config):
-        factory = ConcreteFactory(num_records=10, config=config)
-        assert not hasattr(factory, "skip_chance_trend")
-
-    def test_class_level_month_weights_removed(self):
-        assert not hasattr(ConcreteFactory, "month_weights")
-
-    def test_class_level_hour_weights_removed(self):
-        assert not hasattr(ConcreteFactory, "hour_weights")
-
-    def test_get_random_datetime_for_year_removed(self, config):
-        factory = ConcreteFactory(num_records=10, config=config)
-        assert not hasattr(factory, "_get_random_datetime_for_year")
-
     def test_day_distribution_per_chapter_exists(self, config):
         factory = ConcreteFactory(num_records=50, config=config)
         assert hasattr(factory, "_day_distribution_per_chapter")

--- a/synthetic-datasets/uv.lock
+++ b/synthetic-datasets/uv.lock
@@ -281,6 +281,7 @@ dependencies = [
     { name = "numpy" },
     { name = "openpyxl" },
     { name = "pydantic" },
+    { name = "rich" },
     { name = "typer" },
 ]
 
@@ -297,6 +298,7 @@ requires-dist = [
     { name = "numpy", specifier = "==2.5.1" },
     { name = "openpyxl", specifier = "==3.1.5" },
     { name = "pydantic", specifier = "==2.13.4" },
+    { name = "rich", specifier = "==15.0.0" },
     { name = "typer", specifier = "==0.27.0" },
 ]
 


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The `synthetic-datasets` project had accumulated some small maintenance debts:

- `rich` is imported across roughly a dozen modules, yet it was never declared as a direct dependency — it only happened to be installed transitively through `typer`. If `typer` ever dropped or changed that dependency, the imports would break.
- `factories/base.py` contained a no-op progress loop (`for _ in track(range(...)): pass`) that iterated purely to feed a progress bar whose result was discarded, along with a `label` variable that existed only to describe that bar.
- `factories/spotify.py` and `factories/deezer.py` each created a `_console = get_console()` binding that was never used.
- `tests/factories/test_base_factory.py` held five tests asserting the *absence* of attributes that were removed in a past refactor, guarding against code that no longer exists.

## 🎹 Proposal

Declare `rich` explicitly in `[project].dependencies`, pinned to the exact version already resolved in the lockfile (`15.0.0`) to match the project's exact-pin convention, and refresh `uv.lock` accordingly. This makes the dependency graph honest without changing any resolved versions.

Remove the dead code: the no-op progress loop and its now-orphaned `label` in `base.py` (the `track` import stays, as it is still used by `create_streaming_history`), and the unused `_console`/`get_console` bindings in the Spotify and Deezer factories.

Drop the five attribute-absence regression tests, which no longer earn their keep now that the attributes they reference are long gone.

## 🎶 Comments

No behavioural change to dataset generation. Removing the no-op loop also removes a per-chapter progress bar that displayed no meaningful output.

## 🎤 Test

All quality gates pass via Moon:

- `moon run synthetic-datasets:format-check`
- `moon run synthetic-datasets:lint`
- `moon run synthetic-datasets:typecheck`
- `moon run synthetic-datasets:test` — 405 passed (5 stale tests removed from the previous 410)
