### PR TITLE
feat(chat): adapt the shortcut chips to what the user is typing

### DIFF
--- a/app/src/components/Charts/ChatView.tsx
+++ b/app/src/components/Charts/ChatView.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { DATA_LOADED_EVENT } from '../../db/dataSignal'
 import { useChatEngine } from '../../hooks/useChatEngine'
+import { useChatSuggestions } from '../../hooks/useChatSuggestions'
 import type { ChatMessage, AssistantPayload } from '../../llm/types'
 import type { DBRow } from '../../llm/inferChartType'
 import type { ChartConfig } from '../../llm/askChartConfig'
@@ -39,6 +40,7 @@ export function ChatView() {
     const [pendingQuestion, setPendingQuestion] = useState<string | null>(null)
     const [streamingNarrative, setStreamingNarrative] = useState('')
     const [settingsOpen, setSettingsOpen] = useState(false)
+    const [draft, setDraft] = useState('')
     const streamingMsgIdRef = useRef<string | null>(null)
     const messagesRef = useRef(messages)
     const bottomRef = useRef<HTMLDivElement>(null)
@@ -50,6 +52,7 @@ export function ChatView() {
         enableWith,
         applyConfig,
         ask,
+        suggest,
         cancel,
     } = useChatEngine()
 
@@ -173,6 +176,24 @@ export function ChatView() {
     const isReady = state.kind === 'ready'
     const isLoading = state.kind === 'loading' || isAsking
 
+    const { suggestions, isGenerating } = useChatSuggestions({
+        draft,
+        enabled: isReady,
+        busy: isLoading,
+        suggest,
+    })
+
+    // A chip always sends straight away. Clearing the draft empties the input
+    // too, so a half-typed question doesn't linger behind the answer it
+    // replaced.
+    const handleShortcut = useCallback(
+        (question: string) => {
+            setDraft('')
+            handleSubmit(question)
+        },
+        [handleSubmit]
+    )
+
     return (
         <div className="flex flex-col gap-4 py-4">
             <MemoryNotice />
@@ -222,8 +243,10 @@ export function ChatView() {
                         <div ref={bottomRef} />
                     </div>
                     <ChatShortcuts
-                        onSelect={handleSubmit}
+                        onSelect={handleShortcut}
                         disabled={isLoading}
+                        suggestions={suggestions}
+                        isGenerating={isGenerating}
                     />
                     {isAsking && <ChatThinkingIndicator />}
                     <ChatInput
@@ -236,6 +259,8 @@ export function ChatView() {
                         }
                         onSubmit={handleSubmit}
                         onCancel={cancel}
+                        value={draft}
+                        onChange={setDraft}
                     />
                 </div>
             )}

--- a/app/src/components/Chat/AssistantSettings.tsx
+++ b/app/src/components/Chat/AssistantSettings.tsx
@@ -10,11 +10,12 @@ import {
     type ChartMode,
     type NarrativeMode,
     type PresetName,
+    type SuggestMode,
 } from '../../llm/assistantConfig'
 import type { ModelInfo } from '../../llm/engine'
 import { recommendPreset } from '../../llm/recommendPreset'
 
-type Axes = Pick<AssistantConfig, 'modelId' | 'chart' | 'narrative'>
+type Axes = Pick<AssistantConfig, 'modelId' | 'chart' | 'narrative' | 'suggest'>
 
 type Props = {
     mode: 'onboarding' | 'settings'
@@ -37,6 +38,11 @@ const NARRATIVE_LABELS: Record<NarrativeMode, string> = {
     static: 'Plain summary',
 }
 
+const SUGGEST_LABELS: Record<SuggestMode, string> = {
+    llm: 'Adapt as I type (AI)',
+    off: 'Fixed shortcuts',
+}
+
 function formatSize(vramMB?: number): string {
     if (!vramMB) return ''
     return vramMB >= 1024
@@ -55,6 +61,7 @@ export function AssistantSettings({
               modelId: initialConfig.modelId,
               chart: initialConfig.chart,
               narrative: initialConfig.narrative,
+              suggest: initialConfig.suggest,
           }
         : PRESETS.balanced
 
@@ -266,6 +273,28 @@ export function AssistantSettings({
                                     </option>
                                 )
                             )}
+                        </select>
+                    </label>
+
+                    <label className="block text-sm">
+                        <span className="block mb-1 text-gray-600 dark:text-gray-400">
+                            Shortcuts
+                        </span>
+                        <select
+                            className="w-full p-2 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-sm"
+                            value={axes.suggest}
+                            onChange={(e) =>
+                                updateAxis(
+                                    'suggest',
+                                    e.target.value as SuggestMode
+                                )
+                            }
+                        >
+                            {(['llm', 'off'] as SuggestMode[]).map((s) => (
+                                <option key={s} value={s}>
+                                    {SUGGEST_LABELS[s]}
+                                </option>
+                            ))}
                         </select>
                     </label>
 

--- a/app/src/components/Chat/ChatInput.test.tsx
+++ b/app/src/components/Chat/ChatInput.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ChatInput } from './ChatInput'
+
+/** Wires the controlled value up the way ChatView does. */
+function Harness({
+    onSubmit,
+    onChange,
+}: {
+    onSubmit: (text: string) => void
+    onChange?: (text: string) => void
+}) {
+    const [value, setValue] = useState('')
+    return (
+        <ChatInput
+            value={value}
+            onChange={(next) => {
+                setValue(next)
+                onChange?.(next)
+            }}
+            onSubmit={onSubmit}
+        />
+    )
+}
+
+function typeInto(text: string) {
+    const textarea = screen.getByLabelText('Ask the assistant')
+    fireEvent.change(textarea, { target: { value: text } })
+    return textarea as HTMLTextAreaElement
+}
+
+describe('ChatInput', () => {
+    it('reports the draft on every change', () => {
+        const onChange = vi.fn()
+        render(<Harness onSubmit={vi.fn()} onChange={onChange} />)
+
+        typeInto('what do i')
+        expect(onChange).toHaveBeenLastCalledWith('what do i')
+
+        typeInto('what do i listen to')
+        expect(onChange).toHaveBeenLastCalledWith('what do i listen to')
+    })
+
+    it('clears the textarea after submitting', () => {
+        const onSubmit = vi.fn()
+        const onChange = vi.fn()
+        render(<Harness onSubmit={onSubmit} onChange={onChange} />)
+
+        const textarea = typeInto('top artists')
+        fireEvent.keyDown(textarea, { key: 'Enter' })
+
+        expect(onSubmit).toHaveBeenCalledWith('top artists')
+        expect(onChange).toHaveBeenLastCalledWith('')
+        expect(textarea.value).toBe('')
+    })
+
+    it('does not report a reset when an empty submit is ignored', () => {
+        const onChange = vi.fn()
+        render(<Harness onSubmit={vi.fn()} onChange={onChange} />)
+
+        const textarea = typeInto('   ')
+        onChange.mockClear()
+        fireEvent.keyDown(textarea, { key: 'Enter' })
+
+        expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('renders whatever value the parent owns', () => {
+        const onChange = vi.fn()
+        render(
+            <ChatInput
+                value="set from above"
+                onChange={onChange}
+                onSubmit={vi.fn()}
+            />
+        )
+
+        const textarea = screen.getByLabelText(
+            'Ask the assistant'
+        ) as HTMLTextAreaElement
+        expect(textarea.value).toBe('set from above')
+    })
+})

--- a/app/src/components/Chat/ChatInput.tsx
+++ b/app/src/components/Chat/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { useState, type KeyboardEvent } from 'react'
+import type { KeyboardEvent } from 'react'
 
 type ChatInputProps = {
     disabled?: boolean
@@ -6,6 +6,12 @@ type ChatInputProps = {
     placeholder?: string
     onSubmit: (text: string) => void
     onCancel?: () => void
+    /**
+     * The in-progress draft. Owned by the parent because the shortcut chips
+     * read it to adapt themselves, and clicking a chip has to clear it.
+     */
+    value: string
+    onChange: (text: string) => void
 }
 
 export function ChatInput({
@@ -14,14 +20,14 @@ export function ChatInput({
     placeholder,
     onSubmit,
     onCancel,
+    value,
+    onChange,
 }: ChatInputProps) {
-    const [value, setValue] = useState('')
-
     const submit = () => {
         const trimmed = value.trim()
         if (!trimmed) return
         onSubmit(trimmed)
-        setValue('')
+        onChange('')
     }
 
     const handleSubmit = (e: { preventDefault(): void }) => {
@@ -44,7 +50,7 @@ export function ChatInput({
             <textarea
                 aria-label="Ask the assistant"
                 value={value}
-                onChange={(e) => setValue(e.target.value)}
+                onChange={(e) => onChange(e.target.value)}
                 onKeyDown={handleKey}
                 disabled={disabled}
                 rows={2}

--- a/app/src/components/Chat/ChatShortcuts.test.tsx
+++ b/app/src/components/Chat/ChatShortcuts.test.tsx
@@ -2,6 +2,14 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ChatShortcuts } from './ChatShortcuts'
 
+const GENERATED = [
+    { label: 'After midnight', question: 'What do I play after 1am?' },
+    {
+        label: 'Sunday mornings',
+        question: 'What do I play on Sunday mornings?',
+    },
+]
+
 describe('ChatShortcuts', () => {
     it('renders all 6 shortcut chips', () => {
         render(<ChatShortcuts onSelect={vi.fn()} />)
@@ -39,5 +47,40 @@ describe('ChatShortcuts', () => {
 
         fireEvent.click(screen.getByText('Top artists'))
         expect(onSelect).not.toHaveBeenCalled()
+    })
+
+    it('renders generated suggestions in place of the static chips', () => {
+        render(<ChatShortcuts onSelect={vi.fn()} suggestions={GENERATED} />)
+
+        expect(screen.getByText('After midnight')).toBeTruthy()
+        expect(screen.getByText('Sunday mornings')).toBeTruthy()
+        expect(screen.queryByText('Top artists')).toBeNull()
+        expect(screen.getAllByRole('button')).toHaveLength(2)
+    })
+
+    it('submits the full generated question, not the short label', () => {
+        const onSelect = vi.fn()
+        render(<ChatShortcuts onSelect={onSelect} suggestions={GENERATED} />)
+
+        fireEvent.click(screen.getByText('After midnight'))
+        expect(onSelect).toHaveBeenCalledWith('What do I play after 1am?')
+    })
+
+    it('falls back to the static chips when suggestions are empty', () => {
+        render(<ChatShortcuts onSelect={vi.fn()} suggestions={[]} />)
+        expect(screen.getByText('Top artists')).toBeTruthy()
+        expect(screen.getAllByRole('button')).toHaveLength(6)
+    })
+
+    it('still renders chips while a new set is generating', () => {
+        render(
+            <ChatShortcuts
+                onSelect={vi.fn()}
+                suggestions={GENERATED}
+                isGenerating
+            />
+        )
+        // The row must never go blank mid-generation — it would shift layout.
+        expect(screen.getAllByRole('button')).toHaveLength(2)
     })
 })

--- a/app/src/components/Chat/ChatShortcuts.tsx
+++ b/app/src/components/Chat/ChatShortcuts.tsx
@@ -1,58 +1,61 @@
-type Shortcut = { emoji: string; label: string; question: string }
-
-const SHORTCUTS: Shortcut[] = [
-    {
-        emoji: '🎵',
-        label: 'Top artists',
-        question: 'Who are my top 5 most listened to artists?',
-    },
-    {
-        emoji: '🌙',
-        label: 'Late night',
-        question: 'What do I listen to after midnight?',
-    },
-    {
-        emoji: '☀️',
-        label: 'Season trends',
-        question: 'How does my listening change by season?',
-    },
-    {
-        emoji: '🔁',
-        label: 'Most replayed',
-        question: 'What is my most replayed track?',
-    },
-    {
-        emoji: '📅',
-        label: 'Peak day',
-        question: 'Which day of the week do I listen most?',
-    },
-    {
-        emoji: '🆕',
-        label: 'Discovery',
-        question: 'Which artists did I discover this year?',
-    },
-]
+import { SHORTCUTS, SUGGESTION_EMOJI } from '../../llm/shortcuts'
+import type { Suggestion } from '../../llm/types'
 
 type ChatShortcutsProps = {
     onSelect: (question: string) => void
     disabled?: boolean
+    /**
+     * Model-generated chips reflecting what the user is typing. When empty —
+     * no draft, suggestions turned off, or a failed run — the built-in
+     * `SHORTCUTS` are shown instead, so the row is never blank.
+     */
+    suggestions?: Suggestion[]
+    /** Dim the row while a fresh set is being generated. */
+    isGenerating?: boolean
 }
 
-export function ChatShortcuts({ onSelect, disabled }: ChatShortcutsProps) {
+export function ChatShortcuts({
+    onSelect,
+    disabled,
+    suggestions,
+    isGenerating,
+}: ChatShortcutsProps) {
+    const generated = suggestions !== undefined && suggestions.length > 0
+    const chips: (Suggestion & { emoji: string })[] = generated
+        ? suggestions.map((s) => ({ ...s, emoji: SUGGESTION_EMOJI }))
+        : SHORTCUTS
+
     return (
-        <div className="flex gap-2 overflow-x-auto pb-1 md:flex-wrap scrollbar-none">
-            {SHORTCUTS.map((s) => (
-                <button
-                    key={s.label}
-                    type="button"
-                    disabled={disabled}
-                    onClick={() => onSelect(s.question)}
-                    className="flex-none flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/60 dark:bg-slate-800/50 backdrop-blur-md border border-gray-300/60 dark:border-slate-700/50 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:border-gray-400/60 dark:hover:border-slate-600/50 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap shadow-sm"
-                >
-                    <span aria-hidden="true">{s.emoji}</span>
-                    <span>{s.label}</span>
-                </button>
-            ))}
-        </div>
+        <>
+            {/*
+             * A summary rather than `aria-live` on the row itself: a live
+             * region wrapping the buttons re-announces all four chips on every
+             * typing pause, which is unusable while composing a question.
+             */}
+            <p className="sr-only" role="status">
+                {generated
+                    ? `${chips.length} suggestions for what you're typing`
+                    : ''}
+            </p>
+            <div
+                className={`flex gap-2 overflow-x-auto pb-1 md:flex-wrap scrollbar-none transition-opacity duration-200 ${
+                    isGenerating ? 'opacity-60' : 'opacity-100'
+                }`}
+            >
+                {chips.map((s) => (
+                    <button
+                        key={s.question}
+                        type="button"
+                        disabled={disabled}
+                        onClick={() => onSelect(s.question)}
+                        title={s.question}
+                        className="flex-none flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/60 dark:bg-slate-800/50 backdrop-blur-md border border-gray-300/60 dark:border-slate-700/50 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:border-gray-400/60 dark:hover:border-slate-600/50 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap shadow-sm"
+                    >
+                        <span aria-hidden="true">{s.emoji}</span>
+                        <span>{s.label}</span>
+                    </button>
+                ))}
+            </div>
+        </>
     )
 }

--- a/app/src/devToolbar/devBus.ts
+++ b/app/src/devToolbar/devBus.ts
@@ -11,6 +11,8 @@ type DevBusEventMap = {
         model: string
         durationMs: number
         tokensPerSec: number
+        /** Which call made this run. Defaults to the answer path when absent. */
+        kind?: 'answer' | 'chart' | 'narrative' | 'suggestions'
     }
     'stream:parsed': {
         provider: string

--- a/app/src/devToolbar/tracksyToolbar.ts
+++ b/app/src/devToolbar/tracksyToolbar.ts
@@ -90,7 +90,9 @@ export default defineToolbarApp({
             const model = loadState?.model ?? lastInference?.model ?? '—'
             const pct = loadState ? Math.round(loadState.progress * 100) : 100
             const loadText = loadState?.text ?? 'Ready'
-            const latency = lastInference ? fmt(lastInference.durationMs) : '—'
+            const latency = lastInference
+                ? `${fmt(lastInference.durationMs)} (${lastInference.kind ?? 'answer'})`
+                : '—'
             const tps = lastInference
                 ? `${lastInference.tokensPerSec.toFixed(1)} tok/s`
                 : '—'

--- a/app/src/hooks/useChatEngine.test.ts
+++ b/app/src/hooks/useChatEngine.test.ts
@@ -223,3 +223,63 @@ describe('useChatEngine.ask (unified SQL path)', () => {
         expect(querySpy).not.toHaveBeenCalled()
     })
 })
+
+describe('useChatEngine — suggest', () => {
+    it('never loads or swaps a model: it uses the already-loaded engine only', async () => {
+        const askSuggestionsModule = await import('../llm/askSuggestions')
+        vi.spyOn(askSuggestionsModule, 'askSuggestions').mockResolvedValue([
+            { label: 'Late night', question: 'What do I play after 1am?' },
+        ])
+        vi.spyOn(engineModule, 'peekEngine').mockReturnValue(
+            Promise.resolve(mockEngine)
+        )
+        const hook = await loadedHook('rich')
+        const getEngineSpy = vi.mocked(engineModule.getEngine)
+        getEngineSpy.mockClear()
+
+        let out
+        await act(async () => {
+            out = await hook.result.current.suggest('what do i listen to')
+        })
+
+        expect(out).toEqual([
+            { label: 'Late night', question: 'What do I play after 1am?' },
+        ])
+        // getEngine can create or tear down a model; the suggestion path must
+        // never touch it.
+        expect(getEngineSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns nothing when no engine is loaded', async () => {
+        const askSuggestionsModule = await import('../llm/askSuggestions')
+        const askSpy = vi.spyOn(askSuggestionsModule, 'askSuggestions')
+        vi.spyOn(engineModule, 'peekEngine').mockReturnValue(null)
+        const hook = await loadedHook('rich')
+
+        let out
+        await act(async () => {
+            out = await hook.result.current.suggest('what do i listen to')
+        })
+
+        expect(out).toEqual([])
+        expect(askSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns nothing when the config has suggestions off', async () => {
+        const askSuggestionsModule = await import('../llm/askSuggestions')
+        const askSpy = vi.spyOn(askSuggestionsModule, 'askSuggestions')
+        const peekSpy = vi
+            .spyOn(engineModule, 'peekEngine')
+            .mockReturnValue(Promise.resolve(mockEngine))
+        const hook = await loadedHook('lite')
+
+        let out
+        await act(async () => {
+            out = await hook.result.current.suggest('what do i listen to')
+        })
+
+        expect(out).toEqual([])
+        expect(askSpy).not.toHaveBeenCalled()
+        expect(peekSpy).not.toHaveBeenCalled()
+    })
+})

--- a/app/src/hooks/useChatEngine.ts
+++ b/app/src/hooks/useChatEngine.ts
@@ -12,6 +12,7 @@ import {
     type AssistantPayload,
     type ChatMessage,
     type EngineState,
+    type Suggestion,
 } from '../llm/types'
 import type { ChartConfig } from '../llm/askChartConfig'
 
@@ -307,6 +308,37 @@ export function useChatEngine() {
         []
     )
 
+    /**
+     * Shortcut chips that continue the user's partial input.
+     *
+     * Strictly best-effort and strictly lowest priority: it uses `peekEngine`,
+     * which hands back the already-loaded engine or nothing at all, so
+     * suggestions can never start a download or swap the running model. Any
+     * failure returns `[]` and the caller falls back to the static chips.
+     */
+    const suggest = useCallback(
+        async (draft: string, signal?: AbortSignal): Promise<Suggestion[]> => {
+            const cfg = configRef.current
+            if (!cfg || cfg.suggest !== 'llm') return []
+            if (!moduleRef.current) return []
+            const enginePromise = moduleRef.current.peekEngine()
+            if (!enginePromise) return []
+            try {
+                const engine = await enginePromise
+                const [{ askSuggestions }, { getSuggestionContext }] =
+                    await Promise.all([
+                        import('../llm/askSuggestions'),
+                        import('../llm/suggestionContext'),
+                    ])
+                const context = await getSuggestionContext()
+                return await askSuggestions(engine, draft, context, signal)
+            } catch {
+                return []
+            }
+        },
+        []
+    )
+
     const cancel = useCallback(() => {
         abortRef.current?.abort()
     }, [])
@@ -330,6 +362,7 @@ export function useChatEngine() {
         enableWith,
         applyConfig,
         ask,
+        suggest,
         cancel,
     }
 }

--- a/app/src/hooks/useChatSuggestions.test.ts
+++ b/app/src/hooks/useChatSuggestions.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useChatSuggestions } from './useChatSuggestions'
+import type { Suggestion } from '../llm/types'
+
+const CHIPS: Suggestion[] = [{ label: 'Late night', question: 'After 1am?' }]
+
+beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+})
+
+afterEach(() => {
+    vi.useRealTimers()
+})
+
+/** Push past the hook's debounce window. */
+async function settle() {
+    await act(async () => {
+        vi.advanceTimersByTime(600)
+    })
+}
+
+type SuggestFn = (draft: string, signal?: AbortSignal) => Promise<Suggestion[]>
+
+function setup(suggest: SuggestFn, draft = '') {
+    return renderHook(
+        (props: { draft: string; busy: boolean }) =>
+            useChatSuggestions({
+                draft: props.draft,
+                enabled: true,
+                busy: props.busy,
+                suggest,
+            }),
+        { initialProps: { draft, busy: false } }
+    )
+}
+
+describe('useChatSuggestions', () => {
+    it('does not generate for a draft below the length threshold', async () => {
+        const suggest = vi.fn().mockResolvedValue(CHIPS)
+        const { result } = setup(suggest, 'top')
+        await settle()
+
+        expect(suggest).not.toHaveBeenCalled()
+        expect(result.current.suggestions).toEqual([])
+    })
+
+    it('generates once after typing pauses, not per keystroke', async () => {
+        const suggest = vi.fn().mockResolvedValue(CHIPS)
+        const { rerender, result } = setup(suggest, '')
+
+        for (const draft of [
+            'what do i',
+            'what do i listen',
+            'what do i listen to late',
+        ]) {
+            rerender({ draft, busy: false })
+            await act(async () => {
+                vi.advanceTimersByTime(100)
+            })
+        }
+        await settle()
+
+        expect(suggest).toHaveBeenCalledTimes(1)
+        expect(suggest).toHaveBeenCalledWith(
+            'what do i listen to late',
+            expect.any(AbortSignal)
+        )
+        await waitFor(() => expect(result.current.suggestions).toEqual(CHIPS))
+    })
+
+    it('does not generate while a real answer is loading', async () => {
+        const suggest = vi.fn().mockResolvedValue(CHIPS)
+        const { rerender } = setup(suggest, '')
+        rerender({ draft: 'what do i listen to', busy: true })
+        await settle()
+
+        expect(suggest).not.toHaveBeenCalled()
+    })
+
+    it('aborts an in-flight generation when a real answer starts', async () => {
+        let capturedSignal: AbortSignal | undefined
+        const suggest = vi.fn((_draft: string, signal?: AbortSignal) => {
+            capturedSignal = signal
+            return new Promise<Suggestion[]>(() => {})
+        })
+        const { rerender } = setup(suggest, 'what do i listen to')
+        await settle()
+        expect(capturedSignal?.aborted).toBe(false)
+
+        rerender({ draft: 'what do i listen to', busy: true })
+        expect(capturedSignal?.aborted).toBe(true)
+    })
+
+    it('keeps the previous chips on screen while regenerating', async () => {
+        const suggest = vi
+            .fn()
+            .mockResolvedValueOnce(CHIPS)
+            .mockImplementationOnce(() => new Promise<Suggestion[]>(() => {}))
+        const { rerender, result } = setup(suggest, 'what do i listen to')
+        await settle()
+        await waitFor(() => expect(result.current.suggestions).toEqual(CHIPS))
+
+        rerender({ draft: 'what do i listen to on sundays', busy: false })
+        await settle()
+
+        expect(suggest).toHaveBeenCalledTimes(2)
+        expect(result.current.suggestions).toEqual(CHIPS)
+        expect(result.current.isGenerating).toBe(true)
+    })
+
+    it('keeps the previous chips when a generation returns nothing', async () => {
+        const suggest = vi
+            .fn()
+            .mockResolvedValueOnce(CHIPS)
+            .mockResolvedValueOnce([])
+        const { rerender, result } = setup(suggest, 'what do i listen to')
+        await settle()
+        await waitFor(() => expect(result.current.suggestions).toEqual(CHIPS))
+
+        rerender({ draft: 'what do i listen to on sundays', busy: false })
+        await settle()
+
+        expect(result.current.suggestions).toEqual(CHIPS)
+    })
+
+    it('falls back to nothing once the input is cleared', async () => {
+        const suggest = vi.fn().mockResolvedValue(CHIPS)
+        const { rerender, result } = setup(suggest, 'what do i listen to')
+        await settle()
+        await waitFor(() => expect(result.current.suggestions).toEqual(CHIPS))
+
+        rerender({ draft: '', busy: false })
+        await waitFor(() => expect(result.current.suggestions).toEqual([]))
+        expect(result.current.isGenerating).toBe(false)
+    })
+
+    it('stops reporting generation when the draft shrinks mid-flight', async () => {
+        // The cancelled run's `finally` is suppressed, so nothing else would
+        // clear the flag — and the chip row would stay dimmed forever.
+        const suggest = vi
+            .fn()
+            .mockImplementation(() => new Promise<Suggestion[]>(() => {}))
+        const { rerender, result } = setup(suggest, 'what do i listen to')
+        await settle()
+        expect(result.current.isGenerating).toBe(true)
+
+        rerender({ draft: 'top', busy: false })
+        await settle()
+
+        await waitFor(() => expect(result.current.isGenerating).toBe(false))
+    })
+
+    it('does not regenerate for an unchanged draft', async () => {
+        const suggest = vi.fn().mockResolvedValue(CHIPS)
+        const { rerender } = setup(suggest, 'what do i listen to')
+        await settle()
+        rerender({ draft: 'what do i listen to', busy: false })
+        await settle()
+
+        expect(suggest).toHaveBeenCalledTimes(1)
+    })
+
+    it('survives a rejected generation', async () => {
+        const suggest = vi.fn().mockRejectedValue(new Error('nope'))
+        const { result } = setup(suggest, 'what do i listen to')
+        await settle()
+
+        expect(result.current.suggestions).toEqual([])
+        await waitFor(() => expect(result.current.isGenerating).toBe(false))
+    })
+})
+
+describe('useChatSuggestions when disabled', () => {
+    it('never calls the engine', async () => {
+        const suggest = vi.fn().mockResolvedValue(CHIPS)
+        renderHook(() =>
+            useChatSuggestions({
+                draft: 'what do i listen to',
+                enabled: false,
+                busy: false,
+                suggest,
+            })
+        )
+        await act(async () => {
+            vi.advanceTimersByTime(600)
+        })
+
+        expect(suggest).not.toHaveBeenCalled()
+    })
+})

--- a/app/src/hooks/useChatSuggestions.ts
+++ b/app/src/hooks/useChatSuggestions.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from 'react'
+import { useDebouncedValue } from './useDebouncedValue'
+import type { Suggestion } from '../llm/types'
+
+/** Wait for a real pause in typing — a full completion per keystroke is not viable. */
+const DEBOUNCE_MS = 500
+/** Below this, the draft carries too little intent to suggest anything useful. */
+const MIN_DRAFT_LENGTH = 8
+
+type Options = {
+    /** The in-progress text from the chat input. */
+    draft: string
+    /** False when suggestions are configured off or the engine isn't ready. */
+    enabled: boolean
+    /** True while a real answer is loading — suggestions must yield to it. */
+    busy: boolean
+    suggest: (draft: string, signal?: AbortSignal) => Promise<Suggestion[]>
+}
+
+/**
+ * Model-generated shortcut chips for the current draft.
+ *
+ * Returns `[]` whenever there is nothing to show, which the chip row reads as
+ * "fall back to the static shortcuts". The previous set is deliberately kept on
+ * screen while a new one generates, so the row never blinks empty and shifts
+ * the layout under the user's cursor.
+ */
+export function useChatSuggestions({ draft, enabled, busy, suggest }: Options) {
+    const [suggestions, setSuggestions] = useState<Suggestion[]>([])
+    const [isGenerating, setIsGenerating] = useState(false)
+    const abortRef = useRef<AbortController | null>(null)
+    // The draft the current `suggestions` were generated for, so an unrelated
+    // re-render (or a round-trip back to the same text) doesn't re-run.
+    const generatedForRef = useRef<string | null>(null)
+
+    const debouncedDraft = useDebouncedValue(draft, DEBOUNCE_MS)
+    const trimmed = debouncedDraft.trim()
+    const shouldGenerate =
+        enabled && !busy && trimmed.length >= MIN_DRAFT_LENGTH
+
+    // Answers always win: abort any in-flight suggestion the moment a real
+    // question starts. `askSuggestions` interrupts the running generation on
+    // abort, which releases web-llm's per-model lock so the answer isn't left
+    // queued behind a suggestion that no one will ever see.
+    useEffect(() => {
+        if (busy) {
+            abortRef.current?.abort()
+            abortRef.current = null
+            setIsGenerating(false)
+        }
+    }, [busy])
+
+    // Clear once the user empties the input, so the static chips come back.
+    useEffect(() => {
+        if (draft.trim().length === 0) {
+            generatedForRef.current = null
+            setSuggestions([])
+        }
+    }, [draft])
+
+    useEffect(() => {
+        if (!shouldGenerate) {
+            // The run that set this flag was cancelled by the very change that
+            // turned `shouldGenerate` off, so its `finally` is suppressed —
+            // clear it here or the chip row stays dimmed forever.
+            setIsGenerating(false)
+            return
+        }
+        if (generatedForRef.current === trimmed) return
+
+        const controller = new AbortController()
+        abortRef.current?.abort()
+        abortRef.current = controller
+        setIsGenerating(true)
+
+        let cancelled = false
+        suggest(trimmed, controller.signal)
+            .then((next) => {
+                if (cancelled || controller.signal.aborted) return
+                generatedForRef.current = trimmed
+                // Keep the previous chips on an empty result rather than
+                // dropping back to the statics mid-sentence.
+                if (next.length > 0) setSuggestions(next)
+            })
+            .catch(() => {
+                // Suggestions are cosmetic — leave whatever is on screen.
+            })
+            .finally(() => {
+                if (!cancelled) setIsGenerating(false)
+            })
+
+        return () => {
+            cancelled = true
+            controller.abort()
+        }
+    }, [shouldGenerate, trimmed, suggest])
+
+    useEffect(() => () => abortRef.current?.abort(), [])
+
+    return { suggestions, isGenerating }
+}

--- a/app/src/llm/askLLM.test.ts
+++ b/app/src/llm/askLLM.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { extractJsonObject, parseChatAnswer } from './askLLM'
+import { parseChatAnswer } from './askLLM'
 import { SYSTEM_PROMPT, FEW_SHOTS } from './prompt'
 import { LLMError } from './types'
 
@@ -16,42 +16,6 @@ describe('prompt date context', () => {
         )
         expect(shot).toBeDefined()
         expect(shot!.assistant).toContain(String(currentYear))
-    })
-})
-
-describe('extractJsonObject', () => {
-    it('returns the object as-is when not wrapped', () => {
-        const out = extractJsonObject('{"intent":"top_artists","params":{}}')
-        expect(JSON.parse(out)).toEqual({ intent: 'top_artists', params: {} })
-    })
-
-    it('strips ```json fences', () => {
-        const out = extractJsonObject(
-            '```json\n{"intent":"top_artists","params":{}}\n```'
-        )
-        expect(JSON.parse(out).intent).toBe('top_artists')
-    })
-
-    it('strips bare ``` fences', () => {
-        const out = extractJsonObject(
-            '```\n{"intent":"top_artists","params":{}}\n```'
-        )
-        expect(JSON.parse(out).intent).toBe('top_artists')
-    })
-
-    it('extracts a balanced object out of surrounding prose', () => {
-        const out = extractJsonObject(
-            'Here is the JSON: {"a": "{nested}", "b": 1} thanks!'
-        )
-        expect(JSON.parse(out)).toEqual({ a: '{nested}', b: 1 })
-    })
-
-    it('throws LLMError(parse) when no object is present', () => {
-        expect(() => extractJsonObject('no json here')).toThrow(LLMError)
-    })
-
-    it('throws LLMError(parse) on unbalanced braces', () => {
-        expect(() => extractJsonObject('{"a": 1')).toThrow(LLMError)
     })
 })
 

--- a/app/src/llm/askLLM.ts
+++ b/app/src/llm/askLLM.ts
@@ -3,6 +3,7 @@ import type {
     ChatCompletionMessageParam,
     MLCEngineInterface,
 } from '@mlc-ai/web-llm'
+import { extractJsonObject } from './extractJson'
 import { isIntentName } from './intents'
 import { SYSTEM_PROMPT, FEW_SHOTS, CURRENT_DATE } from './prompt'
 import { resolveYear } from './resolveYear'
@@ -38,45 +39,6 @@ function buildMessages(
         content: `[Today is ${CURRENT_DATE}.${yearClause}] ${userText}`,
     })
     return messages
-}
-
-export function extractJsonObject(raw: string): string {
-    // Strip markdown code fences if the model added them
-    const fenceMatch = raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)
-    const candidate = fenceMatch ? fenceMatch[1] : raw
-
-    // Find the first { and the matching } via brace counting
-    const start = candidate.indexOf('{')
-    if (start === -1) {
-        throw new LLMError('No JSON object found in model output.', 'parse')
-    }
-    let depth = 0
-    let inString = false
-    let escape = false
-    for (let i = start; i < candidate.length; i++) {
-        const c = candidate[i]
-        if (escape) {
-            escape = false
-            continue
-        }
-        if (c === '\\') {
-            escape = true
-            continue
-        }
-        if (c === '"') {
-            inString = !inString
-            continue
-        }
-        if (inString) continue
-        if (c === '{') depth++
-        else if (c === '}') {
-            depth--
-            if (depth === 0) {
-                return candidate.slice(start, i + 1)
-            }
-        }
-    }
-    throw new LLMError('Unbalanced JSON braces in model output.', 'parse')
 }
 
 export function parseChatAnswer(raw: string): ChatAnswer {

--- a/app/src/llm/askSuggestions.test.ts
+++ b/app/src/llm/askSuggestions.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { MLCEngineInterface } from '@mlc-ai/web-llm'
+import { askSuggestions, parseSuggestions } from './askSuggestions'
+
+function fakeEngine(content: string) {
+    const create = vi.fn().mockResolvedValue({
+        choices: [{ message: { content } }],
+        usage: { completion_tokens: 12 },
+    })
+    const interruptGenerate = vi.fn()
+    return {
+        engine: {
+            chat: { completions: { create } },
+            interruptGenerate,
+        } as unknown as MLCEngineInterface,
+        create,
+        interruptGenerate,
+    }
+}
+
+/** An engine whose generation never finishes on its own. */
+function pendingEngine() {
+    const create = vi.fn().mockImplementation(() => new Promise(() => {}))
+    const interruptGenerate = vi.fn()
+    return {
+        engine: {
+            chat: { completions: { create } },
+            interruptGenerate,
+        } as unknown as MLCEngineInterface,
+        create,
+        interruptGenerate,
+    }
+}
+
+describe('parseSuggestions', () => {
+    it('parses a well-formed array', () => {
+        expect(
+            parseSuggestions(
+                '[{"label":"Top artists","question":"Who are my top artists?"}]'
+            )
+        ).toEqual([
+            { label: 'Top artists', question: 'Who are my top artists?' },
+        ])
+    })
+
+    it('tolerates code fences and trailing prose', () => {
+        const raw =
+            'Sure!\n```json\n[{"label":"A","question":"Q1?"}]\n```\nHope that helps.'
+        expect(parseSuggestions(raw)).toEqual([{ label: 'A', question: 'Q1?' }])
+    })
+
+    it('returns an empty list for malformed JSON', () => {
+        expect(parseSuggestions('[{"label": broken')).toEqual([])
+        expect(parseSuggestions('no json at all')).toEqual([])
+    })
+
+    it('returns an empty list when the payload is not an array', () => {
+        expect(parseSuggestions('{"label":"A","question":"Q?"}')).toEqual([])
+    })
+
+    it('drops entries with missing or non-string fields', () => {
+        const raw = JSON.stringify([
+            { label: 'Good', question: 'Real question?' },
+            { label: 'No question' },
+            { question: 'No label?' },
+            { label: 42, question: 'Wrong type?' },
+            null,
+            'a string',
+            { label: '   ', question: 'Blank label?' },
+        ])
+        expect(parseSuggestions(raw)).toEqual([
+            { label: 'Good', question: 'Real question?' },
+        ])
+    })
+
+    it('de-duplicates repeated questions', () => {
+        const raw = JSON.stringify([
+            { label: 'One', question: 'Same?' },
+            { label: 'Two', question: 'Same?' },
+        ])
+        expect(parseSuggestions(raw)).toHaveLength(1)
+    })
+
+    it('caps the result at four chips', () => {
+        const raw = JSON.stringify(
+            Array.from({ length: 9 }, (_, i) => ({
+                label: `L${i}`,
+                question: `Q${i}?`,
+            }))
+        )
+        expect(parseSuggestions(raw)).toHaveLength(4)
+    })
+
+    it('truncates over-long labels', () => {
+        const raw = JSON.stringify([{ label: 'x'.repeat(80), question: 'Q?' }])
+        expect(parseSuggestions(raw)[0].label.length).toBe(24)
+    })
+})
+
+describe('askSuggestions', () => {
+    it('returns parsed suggestions from the engine', async () => {
+        const { engine } = fakeEngine('[{"label":"A","question":"Q?"}]')
+        await expect(askSuggestions(engine, 'top art')).resolves.toEqual([
+            { label: 'A', question: 'Q?' },
+        ])
+    })
+
+    it('includes the draft and data context in the prompt', async () => {
+        const { engine, create } = fakeEngine('[]')
+        await askSuggestions(engine, 'late night', 'Top artists: Radiohead.')
+
+        const { messages } = create.mock.calls[0][0]
+        expect(messages[1].content).toContain('late night')
+        expect(messages[1].content).toContain('Radiohead')
+    })
+
+    it('returns an empty list when the engine throws', async () => {
+        const create = vi.fn().mockRejectedValue(new Error('GPU exploded'))
+        const engine = {
+            chat: { completions: { create } },
+        } as unknown as MLCEngineInterface
+        await expect(askSuggestions(engine, 'top art')).resolves.toEqual([])
+    })
+
+    it('returns an empty list when the response has no content', async () => {
+        const create = vi.fn().mockResolvedValue({ choices: [] })
+        const engine = {
+            chat: { completions: { create } },
+        } as unknown as MLCEngineInterface
+        await expect(askSuggestions(engine, 'top art')).resolves.toEqual([])
+    })
+
+    it('resolves empty when the signal is already aborted', async () => {
+        const { engine, create } = fakeEngine('[{"label":"A","question":"Q?"}]')
+        const controller = new AbortController()
+        controller.abort()
+        await expect(
+            askSuggestions(engine, 'top art', undefined, controller.signal)
+        ).resolves.toEqual([])
+        expect(create).not.toHaveBeenCalled()
+    })
+
+    it('resolves empty when aborted mid-flight', async () => {
+        const { engine } = pendingEngine()
+        const controller = new AbortController()
+        const promise = askSuggestions(
+            engine,
+            'top art',
+            undefined,
+            controller.signal
+        )
+        controller.abort()
+        await expect(promise).resolves.toEqual([])
+    })
+
+    it('interrupts generation on abort so the engine lock is released', async () => {
+        // web-llm queues every request behind a per-model lock. Without the
+        // interrupt, a user's question waits out the whole suggestion decode.
+        const { engine, interruptGenerate } = pendingEngine()
+        const controller = new AbortController()
+        const promise = askSuggestions(
+            engine,
+            'top art',
+            undefined,
+            controller.signal
+        )
+        expect(interruptGenerate).not.toHaveBeenCalled()
+
+        controller.abort()
+        await promise
+        expect(interruptGenerate).toHaveBeenCalledTimes(1)
+    })
+})

--- a/app/src/llm/askSuggestions.ts
+++ b/app/src/llm/askSuggestions.ts
@@ -1,0 +1,138 @@
+import type { ChatCompletion, MLCEngineInterface } from '@mlc-ai/web-llm'
+import { SCHEMA_DESCRIPTION, CURRENT_DATE } from './prompt'
+import { SHORTCUTS } from './shortcuts'
+import { extractJsonArray } from './extractJson'
+import { LLMError, type Suggestion } from './types'
+import { devBus } from '../devToolbar/devBus'
+import { getLoadedModelId } from './modelState'
+
+/** Never show more than this many generated chips — the row must stay scannable. */
+const MAX_SUGGESTIONS = 4
+/** Longer labels blow out the pill width, especially on mobile. */
+const MAX_LABEL_LENGTH = 24
+
+const EXAMPLE_QUESTIONS = SHORTCUTS.map((s) => `  - ${s.question}`).join('\n')
+
+const SUGGESTIONS_SYSTEM_PROMPT = `\
+You help someone explore their own music listening history. They are part-way through typing a question. Propose ${MAX_SUGGESTIONS} complete questions they might have meant, so they can click one instead of finishing the sentence.
+
+${SCHEMA_DESCRIPTION}
+
+Style examples (match this tone and length):
+${EXAMPLE_QUESTIONS}
+
+Rules:
+- Every question must be answerable from the schema above. Never ask about genres, lyrics, moods, friends, or anything not present in the data.
+- Continue the user's partial input — stay on the subject they started. Do not drift to unrelated topics.
+- Write questions in the user's own voice, using "my" and "I".
+- Make the ${MAX_SUGGESTIONS} questions meaningfully different from each other, not four rewordings of one idea.
+- Each label is a short chip caption, at most ${MAX_LABEL_LENGTH} characters, no trailing punctuation.
+- If real artist names are provided below, feel free to use them.
+
+Respond with ONLY a JSON array, no prose and no code fences:
+[{"label": "Top artists", "question": "Who are my top 5 most listened to artists?"}]`
+
+/**
+ * Parse and sanitize the model's suggestion array.
+ *
+ * Suggestions are cosmetic, so this is deliberately forgiving: malformed
+ * entries are dropped rather than failing the batch, and anything
+ * unrecoverable yields an empty list so the caller falls back to the static
+ * shortcuts.
+ */
+export function parseSuggestions(raw: string): Suggestion[] {
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(extractJsonArray(raw))
+    } catch {
+        return []
+    }
+    if (!Array.isArray(parsed)) return []
+
+    const out: Suggestion[] = []
+    const seen = new Set<string>()
+    for (const entry of parsed) {
+        if (typeof entry !== 'object' || entry === null) continue
+        const { label, question } = entry as Record<string, unknown>
+        if (typeof label !== 'string' || typeof question !== 'string') continue
+        const trimmedLabel = label.trim()
+        const trimmedQuestion = question.trim()
+        if (!trimmedLabel || !trimmedQuestion) continue
+        if (seen.has(trimmedQuestion)) continue
+        seen.add(trimmedQuestion)
+        out.push({
+            label: trimmedLabel.slice(0, MAX_LABEL_LENGTH),
+            question: trimmedQuestion,
+        })
+        if (out.length === MAX_SUGGESTIONS) break
+    }
+    return out
+}
+
+/**
+ * Ask the model for shortcut chips that continue the user's partial input.
+ *
+ * Runs on the engine passed in — always the one already loaded — and never
+ * throws: any failure returns `[]` so the UI keeps showing the static chips.
+ */
+export async function askSuggestions(
+    engine: MLCEngineInterface,
+    draft: string,
+    dataContext?: string,
+    signal?: AbortSignal
+): Promise<Suggestion[]> {
+    // Superseded before we started — don't occupy the engine at all.
+    if (signal?.aborted) return []
+
+    const context = dataContext ? `\n\n${dataContext}` : ''
+    const messages = [
+        { role: 'system' as const, content: SUGGESTIONS_SYSTEM_PROMPT },
+        {
+            role: 'user' as const,
+            content: `[Today is ${CURRENT_DATE}.]${context}\n\nPartial input: "${draft}"`,
+        },
+    ]
+
+    const start = performance.now()
+    let response: ChatCompletion
+    try {
+        const completionPromise = engine.chat.completions.create({
+            messages,
+            temperature: 0.4,
+            max_tokens: 200,
+        }) as Promise<ChatCompletion>
+        if (signal) {
+            const abortPromise = new Promise<never>((_, reject) => {
+                signal.addEventListener('abort', () => {
+                    // web-llm serializes requests per model behind a lock, so
+                    // dropping our promise is not enough: the pipeline keeps
+                    // decoding and the user's real question queues behind it.
+                    // Interrupting stops generation at the next token and
+                    // releases the lock, which is the whole point of yielding.
+                    engine.interruptGenerate()
+                    reject(new LLMError('Cancelled', 'aborted'))
+                })
+            })
+            response = await Promise.race([completionPromise, abortPromise])
+        } else {
+            response = await completionPromise
+        }
+    } catch {
+        return []
+    }
+
+    const durationMs = performance.now() - start
+    const tokens = response.usage?.completion_tokens ?? 0
+    devBus.emit('webllm:inference', {
+        model: getLoadedModelId(),
+        durationMs,
+        tokensPerSec: durationMs > 0 ? tokens / (durationMs / 1000) : 0,
+        // Tagged so short suggestion runs don't read as answer latency in the
+        // dev toolbar.
+        kind: 'suggestions',
+    })
+
+    const content = response.choices?.[0]?.message?.content
+    if (!content) return []
+    return parseSuggestions(content)
+}

--- a/app/src/llm/assistantConfig.test.ts
+++ b/app/src/llm/assistantConfig.test.ts
@@ -21,12 +21,14 @@ describe('configFromPreset', () => {
             modelId: MODEL_LARGE,
             chart: 'llm',
             narrative: 'stream',
+            suggest: 'llm',
         })
         expect(configFromPreset('minimal')).toEqual({
             preset: 'minimal',
             modelId: MODEL_SMALL,
             chart: 'off',
             narrative: 'static',
+            suggest: 'off',
         })
     })
 })
@@ -45,8 +47,15 @@ describe('matchPreset', () => {
                 modelId: MODEL_SMALL,
                 chart: 'llm',
                 narrative: 'stream',
+                suggest: 'llm',
             })
         ).toBe('custom')
+    })
+
+    it('treats the suggest axis as preset-defining', () => {
+        expect(matchPreset({ ...PRESETS.balanced, suggest: 'off' })).toBe(
+            'custom'
+        )
     })
 })
 
@@ -72,6 +81,7 @@ describe('saveConfig / getStoredConfig', () => {
             modelId: MODEL_SMALL,
             chart: 'llm',
             narrative: 'stream',
+            suggest: 'llm',
         })
         expect(getStoredConfig()?.preset).toBe('custom')
     })
@@ -83,8 +93,23 @@ describe('saveConfig / getStoredConfig', () => {
                 modelId: MODEL_LARGE,
                 chart: 'llm',
                 narrative: 'static',
+                suggest: 'llm',
             })
         )
         expect(getStoredConfig()?.preset).toBe('balanced')
+    })
+
+    it('defaults suggest to off for configs stored before the axis existed', () => {
+        localStorage.setItem(
+            ASSISTANT_CONFIG_KEY,
+            JSON.stringify({
+                modelId: MODEL_LARGE,
+                chart: 'llm',
+                narrative: 'static',
+            })
+        )
+        // An upgrade must never silently opt an existing user into extra
+        // inference on every typing pause.
+        expect(getStoredConfig()?.suggest).toBe('off')
     })
 })

--- a/app/src/llm/assistantConfig.ts
+++ b/app/src/llm/assistantConfig.ts
@@ -26,6 +26,14 @@ export type ChartMode = 'llm' | 'infer' | 'off'
  */
 export type NarrativeMode = 'stream' | 'static'
 
+/**
+ * Whether the shortcut chips adapt to what the user is typing:
+ * - `llm` — SuggestionAgent (`askSuggestions`) rewrites the chips on a typing
+ *   pause, running on the already-loaded engine.
+ * - `off` — show the fixed built-in shortcuts only, no inference.
+ */
+export type SuggestMode = 'llm' | 'off'
+
 export const PRESET_NAMES = ['rich', 'balanced', 'lite', 'minimal'] as const
 export type PresetName = (typeof PRESET_NAMES)[number]
 /** A preset name, or `custom` when the axes don't match any preset. */
@@ -36,15 +44,36 @@ export type AssistantConfig = {
     modelId: string
     chart: ChartMode
     narrative: NarrativeMode
+    suggest: SuggestMode
 }
 
 type PresetAxes = Omit<AssistantConfig, 'preset'>
 
 export const PRESETS: Record<PresetName, PresetAxes> = {
-    rich: { modelId: MODEL_LARGE, chart: 'llm', narrative: 'stream' },
-    balanced: { modelId: MODEL_LARGE, chart: 'llm', narrative: 'static' },
-    lite: { modelId: MODEL_SMALL, chart: 'infer', narrative: 'static' },
-    minimal: { modelId: MODEL_SMALL, chart: 'off', narrative: 'static' },
+    rich: {
+        modelId: MODEL_LARGE,
+        chart: 'llm',
+        narrative: 'stream',
+        suggest: 'llm',
+    },
+    balanced: {
+        modelId: MODEL_LARGE,
+        chart: 'llm',
+        narrative: 'static',
+        suggest: 'llm',
+    },
+    lite: {
+        modelId: MODEL_SMALL,
+        chart: 'infer',
+        narrative: 'static',
+        suggest: 'off',
+    },
+    minimal: {
+        modelId: MODEL_SMALL,
+        chart: 'off',
+        narrative: 'static',
+        suggest: 'off',
+    },
 }
 
 export const PRESET_LABELS: Record<
@@ -83,7 +112,8 @@ export function matchPreset(axes: PresetAxes): AssistantPreset {
         if (
             p.modelId === axes.modelId &&
             p.chart === axes.chart &&
-            p.narrative === axes.narrative
+            p.narrative === axes.narrative &&
+            p.suggest === axes.suggest
         ) {
             return name
         }
@@ -107,6 +137,9 @@ export function getStoredConfig(): AssistantConfig | null {
             modelId: parsed.modelId,
             chart: isChartMode(parsed.chart) ? parsed.chart : 'infer',
             narrative: parsed.narrative === 'stream' ? 'stream' : 'static',
+            // Absent on configs stored before live suggestions existed. Default
+            // off so an upgrade never silently opts a user into extra inference.
+            suggest: parsed.suggest === 'llm' ? 'llm' : 'off',
         }
         return { ...axes, preset: matchPreset(axes) }
     } catch {
@@ -121,6 +154,7 @@ export function saveConfig(config: AssistantConfig): void {
         modelId: config.modelId,
         chart: config.chart,
         narrative: config.narrative,
+        suggest: config.suggest,
     }
     const normalized: AssistantConfig = { ...axes, preset: matchPreset(axes) }
     localStorage.setItem(ASSISTANT_CONFIG_KEY, JSON.stringify(normalized))

--- a/app/src/llm/engine.ts
+++ b/app/src/llm/engine.ts
@@ -79,6 +79,18 @@ export async function getEngine(
     return enginePromise
 }
 
+/**
+ * The engine that is already loaded, or `null` when none is.
+ *
+ * Unlike `getEngine`, this can never create, swap, or download a model — it
+ * only ever hands back the existing singleton. Low-priority features (live
+ * suggestions) use it so they can never be the reason weights start loading,
+ * and can never tear down the running model by asking for a different id.
+ */
+export function peekEngine(): Promise<MLCEngineInterface> | null {
+    return enginePromise
+}
+
 export type ModelInfo = {
     id: string
     vramMB?: number

--- a/app/src/llm/extractJson.test.ts
+++ b/app/src/llm/extractJson.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { extractJsonArray, extractJsonObject } from './extractJson'
+import { LLMError } from './types'
+
+describe('extractJsonObject', () => {
+    it('returns the object as-is when not wrapped', () => {
+        const out = extractJsonObject('{"intent":"top_artists","params":{}}')
+        expect(JSON.parse(out)).toEqual({ intent: 'top_artists', params: {} })
+    })
+
+    it('strips ```json fences', () => {
+        const out = extractJsonObject(
+            '```json\n{"intent":"top_artists","params":{}}\n```'
+        )
+        expect(JSON.parse(out).intent).toBe('top_artists')
+    })
+
+    it('strips bare ``` fences', () => {
+        const out = extractJsonObject(
+            '```\n{"intent":"top_artists","params":{}}\n```'
+        )
+        expect(JSON.parse(out).intent).toBe('top_artists')
+    })
+
+    it('extracts a balanced object out of surrounding prose', () => {
+        const out = extractJsonObject(
+            'Here is the JSON: {"a": "{nested}", "b": 1} thanks!'
+        )
+        expect(JSON.parse(out)).toEqual({ a: '{nested}', b: 1 })
+    })
+
+    it('throws LLMError(parse) when no object is present', () => {
+        expect(() => extractJsonObject('no json here')).toThrow(LLMError)
+    })
+
+    it('throws LLMError(parse) on unbalanced braces', () => {
+        expect(() => extractJsonObject('{"a": 1')).toThrow(LLMError)
+    })
+})
+
+describe('extractJsonArray', () => {
+    it('returns the array as-is when not wrapped', () => {
+        const out = extractJsonArray('[{"label":"A","question":"Q?"}]')
+        expect(JSON.parse(out)).toEqual([{ label: 'A', question: 'Q?' }])
+    })
+
+    it('strips ```json fences and trailing prose', () => {
+        const out = extractJsonArray(
+            'Sure!\n```json\n[{"label":"A"}]\n```\nHope that helps.'
+        )
+        expect(JSON.parse(out)).toEqual([{ label: 'A' }])
+    })
+
+    it('ignores brackets inside string values', () => {
+        const out = extractJsonArray('["a [bracketed] label", "b"] done')
+        expect(JSON.parse(out)).toEqual(['a [bracketed] label', 'b'])
+    })
+
+    it('throws LLMError(parse) when no array is present', () => {
+        expect(() => extractJsonArray('{"not":"an array"}')).toThrow(LLMError)
+    })
+
+    it('throws LLMError(parse) on unbalanced brackets', () => {
+        expect(() => extractJsonArray('[{"a": 1}')).toThrow(LLMError)
+    })
+})

--- a/app/src/llm/extractJson.ts
+++ b/app/src/llm/extractJson.ts
@@ -1,0 +1,61 @@
+import { LLMError } from './types'
+
+type Delimiters = { open: '{' | '['; close: '}' | ']'; name: string }
+
+const OBJECT: Delimiters = { open: '{', close: '}', name: 'object' }
+const ARRAY: Delimiters = { open: '[', close: ']', name: 'array' }
+
+/**
+ * Extract the first balanced JSON value from raw model output, tolerating
+ * markdown fences and trailing commentary.
+ *
+ * Models routinely wrap their JSON in ```json fences or bracket it with prose,
+ * so the payload has to be located by bracket counting rather than trusting the
+ * whole string. Quoted brackets and escapes are skipped so a `{` inside a
+ * string value can't unbalance the scan.
+ */
+function extract(raw: string, { open, close, name }: Delimiters): string {
+    // Strip markdown code fences if the model added them
+    const fenceMatch = raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)
+    const candidate = fenceMatch ? fenceMatch[1] : raw
+
+    const start = candidate.indexOf(open)
+    if (start === -1) {
+        throw new LLMError(`No JSON ${name} found in model output.`, 'parse')
+    }
+    let depth = 0
+    let inString = false
+    let escape = false
+    for (let i = start; i < candidate.length; i++) {
+        const c = candidate[i]
+        if (escape) {
+            escape = false
+            continue
+        }
+        if (c === '\\') {
+            escape = true
+            continue
+        }
+        if (c === '"') {
+            inString = !inString
+            continue
+        }
+        if (inString) continue
+        if (c === open) depth++
+        else if (c === close) {
+            depth--
+            if (depth === 0) return candidate.slice(start, i + 1)
+        }
+    }
+    throw new LLMError(`Unbalanced JSON brackets in model output.`, 'parse')
+}
+
+/** The first balanced `{...}` in raw model output. */
+export function extractJsonObject(raw: string): string {
+    return extract(raw, OBJECT)
+}
+
+/** The first balanced `[...]` in raw model output. */
+export function extractJsonArray(raw: string): string {
+    return extract(raw, ARRAY)
+}

--- a/app/src/llm/prompt.ts
+++ b/app/src/llm/prompt.ts
@@ -10,7 +10,7 @@ import {
 const CURRENT_YEAR = new Date().getFullYear()
 export const CURRENT_DATE = new Date().toISOString().split('T')[0]
 
-const SCHEMA_DESCRIPTION = `\
+export const SCHEMA_DESCRIPTION = `\
 DuckDB schema (the user's music streaming history, fully local):
 
 Table ${TABLE} (one row per playback):

--- a/app/src/llm/shortcuts.ts
+++ b/app/src/llm/shortcuts.ts
@@ -1,0 +1,48 @@
+import type { Suggestion } from './types'
+
+/** A built-in shortcut chip: a suggestion plus the emoji shown on the pill. */
+export type Shortcut = Suggestion & { emoji: string }
+
+/**
+ * The fixed starter chips.
+ *
+ * Shown whenever there is nothing generated to display — an empty input, or a
+ * failed/empty suggestion run — so the chip row is never blank. Also passed to
+ * `askSuggestions` as style examples, which is why they live here rather than
+ * inside the component.
+ */
+export const SHORTCUTS: Shortcut[] = [
+    {
+        emoji: '🎵',
+        label: 'Top artists',
+        question: 'Who are my top 5 most listened to artists?',
+    },
+    {
+        emoji: '🌙',
+        label: 'Late night',
+        question: 'What do I listen to after midnight?',
+    },
+    {
+        emoji: '☀️',
+        label: 'Season trends',
+        question: 'How does my listening change by season?',
+    },
+    {
+        emoji: '🔁',
+        label: 'Most replayed',
+        question: 'What is my most replayed track?',
+    },
+    {
+        emoji: '📅',
+        label: 'Peak day',
+        question: 'Which day of the week do I listen most?',
+    },
+    {
+        emoji: '🆕',
+        label: 'Discovery',
+        question: 'Which artists did I discover this year?',
+    },
+]
+
+/** Emoji used for every model-generated chip, so they read as machine-made. */
+export const SUGGESTION_EMOJI = '✨'

--- a/app/src/llm/suggestionContext.ts
+++ b/app/src/llm/suggestionContext.ts
@@ -1,0 +1,54 @@
+import { queryDBCached } from '../db/queries/queryDBCached'
+import { TABLE } from '../db/queries/constants'
+
+const TOP_ARTISTS_SQL = `
+SELECT artist_name, COUNT(*) AS plays
+FROM ${TABLE}
+WHERE artist_name IS NOT NULL
+GROUP BY artist_name
+ORDER BY plays DESC
+LIMIT 10`
+
+const YEAR_RANGE_SQL = `
+SELECT MIN(EXTRACT(year FROM ts)) AS first_year,
+       MAX(EXTRACT(year FROM ts)) AS last_year
+FROM ${TABLE}`
+
+type ArtistRow = { artist_name: string }
+type YearRow = { first_year: number | null; last_year: number | null }
+
+/**
+ * A few real values from the user's own library, so generated suggestions can
+ * name actual artists and real years instead of inventing plausible ones.
+ *
+ * Both queries go through `queryDBCached`, which resolves from memory after the
+ * first call and self-invalidates when new data is loaded — so this is cheap to
+ * call on every keystroke pause. Returns `undefined` if the data isn't
+ * queryable, in which case suggestions are simply more generic.
+ */
+export async function getSuggestionContext(): Promise<string | undefined> {
+    try {
+        const [artists, years] = await Promise.all([
+            queryDBCached<ArtistRow>(TOP_ARTISTS_SQL, 'suggestionContext'),
+            queryDBCached<YearRow>(YEAR_RANGE_SQL, 'suggestionContext'),
+        ])
+
+        const names = artists
+            .map((r) => r.artist_name)
+            .filter((n): n is string => typeof n === 'string' && n.length > 0)
+
+        const parts: string[] = []
+        if (names.length > 0) {
+            parts.push(`The user's most played artists: ${names.join(', ')}.`)
+        }
+        const { first_year, last_year } = years[0] ?? {}
+        if (first_year && last_year) {
+            parts.push(
+                `Their history covers ${first_year} to ${last_year}. Do not suggest years outside that range.`
+            )
+        }
+        return parts.length > 0 ? parts.join('\n') : undefined
+    } catch {
+        return undefined
+    }
+}

--- a/app/src/llm/types.ts
+++ b/app/src/llm/types.ts
@@ -13,6 +13,16 @@ export type ChatAnswer = {
     sql: string
 }
 
+/**
+ * One shortcut chip. `label` is the short text shown on the pill, `question` is
+ * the full question submitted when it is clicked. Produced either by the static
+ * built-in list or, while the user types, by `askSuggestions`.
+ */
+export type Suggestion = {
+    label: string
+    question: string
+}
+
 export type AssistantPayload =
     | { kind: 'ok'; answer: ChatAnswer; narrative?: string }
     | { kind: 'unsafe-sql'; answer: ChatAnswer; reason: string }


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [x] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The shortcut chips above the chat input are six fixed suggestions. They are a useful cold start, but they go stale the moment someone starts typing — the row keeps offering "Top artists" to a user half-way through a question about their late night listening. Once you are typing, the chips are dead weight.

## 🎹 Proposal

The chips now rewrite themselves to match the draft question, using the local assistant that is already loaded.

After a pause in typing, and only once the draft is long enough to carry intent, the assistant proposes complete questions the user might have meant. The proposals are grounded in the real DuckDB schema, the built-in shortcuts as style examples, and a few real values from the user's own library, so they can name actual artists and stay inside the years there is data for.

Real answers always take priority. An in-flight suggestion is aborted the instant a question is asked, and none starts while an answer is loading — typing assistance can never slow down the thing the user actually wants.

The fixed chips remain the floor rather than being replaced. They show for an empty input and whenever a run fails or returns nothing, and the previous chips stay on screen while a new set generates, so the row never blinks empty and shifts the layout under the cursor. With everything switched off, the behaviour is exactly what it is today.

This is gated behind a new `suggest` axis on the assistant config, alongside the existing chart and narrative modes. It is on for the Rich and Balanced presets and off for Lite and Minimal, so the weakest devices keep the fixed chips, and it can be toggled in Advanced settings. Configs stored before this axis existed load as off, so upgrading never silently opts an existing user into extra inference.

## 🎶 Comments

**Only ever one model.** Suggestions run on the engine that is already warm — never a second instance, never a different model id. That is enforced structurally rather than by convention: a new `peekEngine` returns the loaded engine or nothing at all, and has no code path that can create, swap, or download a model. `getEngine` tears the current engine down when the requested id differs, which mid-typing would be catastrophic, so the suggestion path never calls it. Three tests lock this in, including one asserting `getEngine` is never reached.

**Suggestions are free-form.** They are not constrained to the intent catalogue, which means a generated chip can occasionally lead to a question the SQL agent fails on. This is a deliberate trade-off for variety over a guarantee — the prompt grounds hard on the real schema and real data instead of hard-gating. Worth watching in real use; if it bites, routing candidates through the router and dropping the misses is a cheap follow-up.

**One bug found on the way.** An already-aborted signal still started inference, because racing the completion against the abort resolved whichever settled first. It now returns early without touching the engine. The same latent pattern exists in `askLLM`; left alone as out of scope, but worth a follow-up.

`ChatRole` was removed on `main` while this branch was in flight; the rebase kept that removal.

## 🎤 Test

Automated: `moon run app:test` — 1036 passing, plus `moon run app:typecheck`, `app:lint` and `app:format-check` all clean. Eight failures remain in `ListeningBingo`, `ListeningStreaks`, `CalendarHeatmap`, `GenericChartRenderer` and `formatMonthYear`; these are the known locale-dependent tests and fail identically on a clean checkout of this branch's base.

New coverage: suggestion parsing and sanitisation (fences, malformed JSON, missing fields, de-duplication, the four-chip cap, abort before and during flight), the debounce and priority rules, chip rendering and fallback, draft reporting from the input, the config axis and its legacy default, and the engine-reuse guarantee.

Manual, via `moon run app:dev` with real streaming data on the Chat tab:

1. With an empty input, the six fixed chips are shown — unchanged from today.
2. Type a phrase such as `what do I listen to late` and pause. The chips are replaced with suggestions that follow the subject, naming artists from the library.
3. Keep typing. The chips do not thrash per keystroke and never blink empty between sets.
4. Click a chip mid-draft. It sends immediately and the draft is cleared.
5. Ask a question while a set is generating. The answer is not delayed behind it.
6. Clear the input. The fixed chips return.
7. Switch to the Lite preset in Settings, or set Shortcuts to "Fixed shortcuts". The chips stop adapting.
8. Throughout, the dev toolbar shows inference against a single loaded model — no second load, no model switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dC345KcsibPfsHBs58pTc
