### PR TITLE
fix(charts): align album identity between Top Albums and Top 10 Race

### DIFF
--- a/app/src/components/Charts/LabCharts/Top10Race/Top10Albums.sql
+++ b/app/src/components/Charts/LabCharts/Top10Race/Top10Albums.sql
@@ -1,10 +1,10 @@
 with daily_streams as (
     select
         date_trunc('day', ts::datetime)::date as stream_date,
-        album_name as entity_name,
-        count(*)::int as daily_plays
+        count(*)::int as daily_plays,
+        album_name || ' — ' || artist_name as entity_name
     from ${table}
-    where album_name is not null
+    where album_name is not null and artist_name is not null
     ${yearFilter}
     GROUP BY stream_date, entity_name
 )

--- a/app/src/components/Charts/LabCharts/Top10Race/albumRankingParity.test.ts
+++ b/app/src/components/Charts/LabCharts/Top10Race/albumRankingParity.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
+import type { DuckDBValue } from '@duckdb/node-api'
+import { queryTop10Race } from './query'
+import { queryTopAlbums } from '../../SimpleCharts/TopAlbums/query'
+import {
+    createTestConnection,
+    closeTestConnection,
+    createTestTable,
+    testQuery,
+    type TestStreamEntry,
+} from '../../SimpleCharts/__tests__/test-utils'
+import type { DuckDBConnection } from '@duckdb/node-api'
+
+// Regression test for #588: "Top Albums" (simple view) and "Top 10 Race"
+// (lab view, albums mode) must agree on album identity and ranking. Album
+// identity is (album_name, artist_name) — two albums that share a name but
+// belong to different artists are distinct entities in both charts.
+
+let conn: DuckDBConnection
+
+const testYear = 2025
+const testDate = `${testYear}-01-01`
+
+const createStream = (overrides: Partial<TestStreamEntry> = {}) => ({
+    ts: testDate,
+    track_name: 'track1',
+    artist_name: 'artist1',
+    album_name: 'album1',
+    ms_played: 1,
+    ...overrides,
+})
+
+const testData: TestStreamEntry[] = [
+    ...Array.from({ length: 12 }, () => createStream({ album_name: 'album1' })),
+    ...Array.from({ length: 10 }, () => createStream({ album_name: 'album2' })),
+    ...Array.from({ length: 8 }, () =>
+        createStream({ album_name: 'album3', artist_name: 'artist3' })
+    ),
+    ...Array.from({ length: 6 }, () => createStream({ album_name: 'album4' })),
+    // Same album name as above, but a different artist: must stay a
+    // distinct entity in both charts instead of being merged.
+    ...Array.from({ length: 5 }, () => createStream({ album_name: 'album5' })),
+    ...Array.from({ length: 4 }, () =>
+        createStream({ album_name: 'album5', artist_name: 'artist5' })
+    ),
+]
+
+describe('Top Albums vs Top 10 Race (albums) ranking parity', () => {
+    beforeAll(async () => {
+        conn = await createTestConnection()
+    })
+
+    afterAll(() => {
+        closeTestConnection(conn)
+    })
+
+    beforeEach(async () => {
+        await createTestTable(conn, testData)
+    })
+
+    it('produce the same top-5 album ranking at the end of the period', async () => {
+        const simpleViewRows = await testQuery<{
+            album_name: string
+            artist_name: string
+            count_streams: number
+        }>(conn, queryTopAlbums(testYear))
+
+        const simpleViewRanking = simpleViewRows.map(
+            (row) => `${row.album_name} — ${row.artist_name}`
+        )
+
+        const raceRows = await conn.runAndReadAll(
+            queryTop10Race(testYear, 'albums')
+        )
+
+        const finalTotals = new Map<string, number>()
+        for (const row of raceRows.getRowObjects() as Record<
+            string,
+            DuckDBValue
+        >[]) {
+            const entityName = row.entity_name as string
+            const playCount = row.play_count as number
+            finalTotals.set(
+                entityName,
+                Math.max(finalTotals.get(entityName) ?? 0, playCount)
+            )
+        }
+
+        const raceRanking = Array.from(finalTotals.entries())
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 5)
+            .map(([entityName]) => entityName)
+
+        expect(raceRanking).toEqual(simpleViewRanking)
+        // Sanity check: the duplicate album name across artists must not
+        // have collapsed into a single race entity.
+        expect(raceRanking).toContain('album5 — artist1')
+        expect(finalTotals.has('album5 — artist5')).toBe(true)
+        expect(finalTotals.get('album5 — artist1')).not.toBe(
+            finalTotals.get('album5 — artist5')
+        )
+    })
+})

--- a/app/src/components/Charts/LabCharts/Top10Race/query.test.ts
+++ b/app/src/components/Charts/LabCharts/Top10Race/query.test.ts
@@ -150,41 +150,44 @@ describe('Top10Race Query', () => {
                     )
             )
 
+        // Album A is shared by Artist A and Artist B in the fixture: they
+        // must remain distinct entities (name+artist identity), matching
+        // the "Top Albums" simple view grouping. See issue #588.
         expect(rows).toEqual([
             {
                 stream_date_ts: new Date('2020-01-01').getTime(),
-                entity_name: 'Album A',
+                entity_name: 'Album A — Artist A',
                 play_count: 1,
             },
             {
                 stream_date_ts: new Date('2020-01-01').getTime(),
-                entity_name: 'Album B',
+                entity_name: 'Album B — Artist C',
                 play_count: 1,
             },
             {
                 stream_date_ts: new Date('2020-01-02').getTime(),
-                entity_name: 'Album A',
+                entity_name: 'Album A — Artist A',
                 play_count: 3,
             },
             {
                 stream_date_ts: new Date('2020-01-03').getTime(),
-                entity_name: 'Album A',
-                play_count: 5,
+                entity_name: 'Album A — Artist B',
+                play_count: 2,
             },
             {
                 stream_date_ts: new Date('2021-01-01').getTime(),
-                entity_name: 'Album A',
-                play_count: 6,
+                entity_name: 'Album A — Artist B',
+                play_count: 3,
             },
             {
                 stream_date_ts: new Date('2021-01-02').getTime(),
-                entity_name: 'Album A',
-                play_count: 7,
+                entity_name: 'Album A — Artist B',
+                play_count: 4,
             },
             {
                 stream_date_ts: new Date('2021-01-03').getTime(),
-                entity_name: 'Album A',
-                play_count: 8,
+                entity_name: 'Album A — Artist A',
+                play_count: 4,
             },
         ])
     })


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

The "Top Albums" chart (simple view) and the "Top 10 Race" chart in albums mode (lab view) show different rankings for the same underlying data. Only albums are affected — tracks and artists agree between the two views.

Closes #588

## 🎹 Proposal

The two charts disagreed on what counts as one "album". The simple view groups plays by `album_name` and `artist_name` together, while the race chart grouped by `album_name` alone. Whenever two different artists happen to share an album name (or a compilation/reissue title), the race chart merged their play counts into a single entity while the simple view kept them separate, so the two charts could rank albums differently even off the same dataset.

The race query for albums now groups by `album_name` and `artist_name` and builds its display key as `album — artist`, the same pairing already used by the tracks race query (`track — artist`). Both charts now treat "album" identically, so their rankings agree.

## 🎶 Comments

No changes were needed for the tracks or artists modes of the race chart — they already grouped correctly.

## 🎤 Test

Repro: load the demo dataset, open "Top Albums" (simple view) and note the top rankings. Open "Top 10 Race" (lab view), select albums, and advance to the end of the period (the race is dynamic and starts at the period's beginning, so the two need to be compared at the same point in time). The rankings now match.

Added a regression test (`albumRankingParity.test.ts`) that seeds a dataset with two albums sharing a name across different artists and asserts both queries agree on the top-5 ranking at the end of the period. Updated the existing `Top10Race` album query test fixture expectations, which previously encoded the buggy merged-by-name behavior.