### PR TITLE
fix(apple-music): preserve original TIMESTAMPTZ offset for listening hour accuracy

### DIFF
--- a/app/src/db/precompute.test.ts
+++ b/app/src/db/precompute.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from 'vitest'
+import { afterAll, beforeAll, describe, it, expect, vi } from 'vitest'
 import type { AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
-import { precomputeDerivedTables } from './precompute'
+import { DuckDBConnection } from '@duckdb/node-api'
+import { precomputeDerivedTables, tsConversionExpr } from './precompute'
 
 function mockConn() {
     return {
@@ -86,5 +87,53 @@ describe('precomputeDerivedTables', () => {
     it('works without onProgress (optional)', async () => {
         const conn = mockConn()
         await expect(precomputeDerivedTables(conn)).resolves.toBeUndefined()
+    })
+})
+
+describe('tsConversionExpr (real DuckDB semantics)', () => {
+    let conn: DuckDBConnection
+
+    beforeAll(async () => {
+        conn = await DuckDBConnection.create()
+    })
+
+    afterAll(() => {
+        conn.closeSync()
+    })
+
+    async function convert(ts: string, tz: string): Promise<string> {
+        const result = await conn.runAndReadAll(
+            `SELECT (${tsConversionExpr(tz)})::VARCHAR AS ts FROM (SELECT '${ts}' AS ts) raw`
+        )
+        const [row] = result.getRowObjectsJson() as { ts: string }[]
+        return row.ts
+    }
+
+    it('preserves the local hour of a non-UTC offset when the home timezone matches (Apple Music)', async () => {
+        // A user in New York listens at 22:00 local time. Apple Music encodes
+        // this as "...T22:00:00-05:00". With a New York home timezone, the
+        // converted hour must still read 22:00 — not shift to a
+        // UTC-normalized hour as it did when the raw string was first cast to
+        // the offset-less TIMESTAMP type.
+        const ts = await convert(
+            '2024-01-15T22:00:00-05:00',
+            'America/New_York'
+        )
+        expect(ts).toBe('2024-01-15 22:00:00')
+    })
+
+    it('converts a non-UTC offset into a different home timezone correctly', async () => {
+        // Same instant (2024-01-16T03:00:00Z), but the user's home timezone is
+        // Paris (UTC+01:00 in January): 03:00 UTC -> 04:00 Paris.
+        const ts = await convert('2024-01-15T22:00:00-05:00', 'Europe/Paris')
+        expect(ts).toBe('2024-01-16 04:00:00')
+    })
+
+    it('still converts UTC Z-suffixed timestamps correctly (Spotify/Deezer/JellyFin/Custom)', async () => {
+        // 22:00 UTC -> 23:00 Paris, matching the pre-existing
+        // `TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE tz` behavior for every
+        // other provider, which always emits Z-suffixed UTC strings.
+        const ts = await convert('2024-01-15T22:00:00Z', 'Europe/Paris')
+        expect(ts).toBe('2024-01-15 23:00:00')
     })
 })

--- a/app/src/db/precompute.test.ts
+++ b/app/src/db/precompute.test.ts
@@ -10,10 +10,21 @@ function mockConn() {
 }
 
 describe('precomputeDerivedTables', () => {
-    it('executes 11 queries (2 DROP + 1 CREATE TABLE music_streams + 4 DROP + 4 CREATE derived)', async () => {
+    it('executes 12 queries (1 SET TimeZone + 2 DROP + 1 CREATE TABLE music_streams + 4 DROP + 4 CREATE derived)', async () => {
         const conn = mockConn()
         await precomputeDerivedTables(conn)
-        expect(conn.query).toHaveBeenCalledTimes(11)
+        expect(conn.query).toHaveBeenCalledTimes(12)
+    })
+
+    it('pins the session time zone to UTC before materializing music_streams', async () => {
+        const conn = mockConn()
+        await precomputeDerivedTables(conn)
+
+        const calls: string[] = (
+            conn.query as ReturnType<typeof vi.fn>
+        ).mock.calls.map((c: string[]) => c[0].trim())
+
+        expect(calls[0]).toBe(`SET TimeZone='UTC'`)
     })
 
     it('materializes the timezone-adjusted music_streams table before derived tables', async () => {
@@ -24,9 +35,9 @@ describe('precomputeDerivedTables', () => {
             conn.query as ReturnType<typeof vi.fn>
         ).mock.calls.map((c: string[]) => c[0].trim())
 
-        expect(calls[0]).toBe('DROP VIEW IF EXISTS music_streams')
-        expect(calls[1]).toBe('DROP TABLE IF EXISTS music_streams')
-        expect(calls[2]).toMatch(/^CREATE TABLE music_streams AS/)
+        expect(calls[1]).toBe('DROP VIEW IF EXISTS music_streams')
+        expect(calls[2]).toBe('DROP TABLE IF EXISTS music_streams')
+        expect(calls[3]).toMatch(/^CREATE TABLE music_streams AS/)
     })
 
     it('drops all derived tables before creating them', async () => {
@@ -37,10 +48,10 @@ describe('precomputeDerivedTables', () => {
             conn.query as ReturnType<typeof vi.fn>
         ).mock.calls.map((c: string[]) => c[0].trim())
 
-        expect(calls[3]).toBe('DROP TABLE IF EXISTS daily_stream_counts')
-        expect(calls[5]).toBe('DROP TABLE IF EXISTS artist_first_year')
-        expect(calls[7]).toBe('DROP TABLE IF EXISTS stream_sessions')
-        expect(calls[9]).toBe('DROP TABLE IF EXISTS summarize_cache')
+        expect(calls[4]).toBe('DROP TABLE IF EXISTS daily_stream_counts')
+        expect(calls[6]).toBe('DROP TABLE IF EXISTS artist_first_year')
+        expect(calls[8]).toBe('DROP TABLE IF EXISTS stream_sessions')
+        expect(calls[10]).toBe('DROP TABLE IF EXISTS summarize_cache')
     })
 
     it('creates daily_stream_counts, artist_first_year, stream_sessions, summarize_cache', async () => {
@@ -90,6 +101,13 @@ describe('precomputeDerivedTables', () => {
     })
 })
 
+// @duckdb/node-api pins an older DuckDB build than the one bundled in
+// @duckdb/duckdb-wasm (the engine this app actually runs). Its cast from an
+// offset-bearing string straight to TIMESTAMP happens to already resolve the
+// offset, so it can't reproduce the pre-fix bug (verified against DuckDB CLI
+// 1.5.x, whose behavior matches the wasm build: the offset was silently
+// dropped instead). These tests still validate the new expression's documented
+// TIMESTAMPTZ semantics and guard against a regression in this SQL text.
 describe('tsConversionExpr (real DuckDB semantics)', () => {
     let conn: DuckDBConnection
 
@@ -135,5 +153,28 @@ describe('tsConversionExpr (real DuckDB semantics)', () => {
         // other provider, which always emits Z-suffixed UTC strings.
         const ts = await convert('2024-01-15T22:00:00Z', 'Europe/Paris')
         expect(ts).toBe('2024-01-15 23:00:00')
+    })
+
+    it('resolves a zone-less ts string against the ambient session time zone, not UTC', async () => {
+        // Unlike the old expression (which pinned via a literal `AT TIME ZONE
+        // 'UTC'`), casting straight to TIMESTAMPTZ resolves a string with no
+        // offset/Z marker against whatever session TimeZone is currently set.
+        // No built-in provider emits zone-less strings, but a hand-edited
+        // Custom CSV could — this is exactly why precomputeDerivedTables pins
+        // `SET TimeZone='UTC'` before running this expression.
+        await conn.run(`SET TimeZone='Asia/Tokyo'`)
+        const tokyoResult = await convert('2024-01-15 22:00:00', 'Europe/Paris')
+
+        await conn.run(`SET TimeZone='UTC'`)
+        const utcPinnedResult = await convert(
+            '2024-01-15 22:00:00',
+            'Europe/Paris'
+        )
+
+        expect(tokyoResult).not.toBe(utcPinnedResult)
+        // With the pin in place (as precomputeDerivedTables applies it), the
+        // zone-less string is anchored to UTC, matching the deterministic
+        // behavior of the pre-fix expression.
+        expect(utcPinnedResult).toBe('2024-01-15 23:00:00')
     })
 })

--- a/app/src/db/precompute.ts
+++ b/app/src/db/precompute.ts
@@ -23,6 +23,24 @@ type OnProgress = (stage: string, percent: number) => void
 
 const TOTAL_STEPS = 1 + DERIVED_TABLES.length
 
+/**
+ * Builds the SQL expression that converts a raw `ts` string into a
+ * timezone-adjusted timestamp for the given home timezone.
+ *
+ * Casting to `TIMESTAMPTZ` (rather than `TIMESTAMP`) correctly interprets any
+ * UTC offset present in the raw string — e.g. Apple Music's
+ * `"2024-01-15T22:00:00-05:00"` — before converting to the home timezone, so
+ * the local hour the event actually happened at is preserved.
+ *
+ * This stays backward-compatible with the UTC `Z`-suffixed strings produced
+ * by every other provider (Spotify, Deezer, JellyFin, Custom): DuckDB parses
+ * `Z` as a zero offset, so `TIMESTAMPTZ AT TIME ZONE tz` yields the same
+ * result as the previous `TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE tz`.
+ */
+export function tsConversionExpr(tz: string): string {
+    return `ts::TIMESTAMPTZ AT TIME ZONE '${tz}'`
+}
+
 export async function precomputeDerivedTables(
     conn: AsyncDuckDBConnection,
     tz: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -31,7 +49,7 @@ export async function precomputeDerivedTables(
     await conn.query(`DROP VIEW IF EXISTS ${TABLE}`)
     await conn.query(`DROP TABLE IF EXISTS ${TABLE}`)
     await conn.query(
-        `CREATE TABLE ${TABLE} AS SELECT * EXCLUDE (ts), (ts::TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE '${tz}') AS ts FROM ${RAW_TABLE}`
+        `CREATE TABLE ${TABLE} AS SELECT * EXCLUDE (ts), (${tsConversionExpr(tz)}) AS ts FROM ${RAW_TABLE}`
     )
     onProgress?.('Computing statistics…', Math.round((1 / TOTAL_STEPS) * 100))
 

--- a/app/src/db/precompute.ts
+++ b/app/src/db/precompute.ts
@@ -36,6 +36,12 @@ const TOTAL_STEPS = 1 + DERIVED_TABLES.length
  * by every other provider (Spotify, Deezer, JellyFin, Custom): DuckDB parses
  * `Z` as a zero offset, so `TIMESTAMPTZ AT TIME ZONE tz` yields the same
  * result as the previous `TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE tz`.
+ *
+ * Unlike the previous expression, a raw string with no zone marker at all
+ * (which no built-in provider emits, but a hand-edited Custom CSV could) is no
+ * longer implicitly anchored to UTC by the SQL text itself — `TIMESTAMPTZ`
+ * resolves it against the connection's ambient session time zone instead. See
+ * the `SET TimeZone='UTC'` pin below, which keeps that case deterministic.
  */
 export function tsConversionExpr(tz: string): string {
     return `ts::TIMESTAMPTZ AT TIME ZONE '${tz}'`
@@ -46,6 +52,10 @@ export async function precomputeDerivedTables(
     tz: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
     onProgress?: OnProgress
 ): Promise<void> {
+    // Pins how `tsConversionExpr` resolves a zone-less `ts` string (see its
+    // doc comment) so the outcome doesn't depend on the DuckDB engine's
+    // ambient session time zone, whatever that defaults to.
+    await conn.query(`SET TimeZone='UTC'`)
     await conn.query(`DROP VIEW IF EXISTS ${TABLE}`)
     await conn.query(`DROP TABLE IF EXISTS ${TABLE}`)
     await conn.query(

--- a/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.test.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.test.ts
@@ -144,6 +144,18 @@ describe('AppleMusicStreamProvider', () => {
             expect(result[0].ts).toBe('2024-03-15T14:30:00.000Z')
         })
 
+        it('should preserve a non-UTC offset in a string-typed Event Start Timestamp', () => {
+            // Apple Music exports TIMESTAMP WITH TIME ZONE. Read as varchar
+            // (see readFile), the raw offset must survive untouched so the
+            // local listening hour isn't lost by normalizing to UTC.
+            const record: AppleMusicRawRecord = {
+                ...RAW_AUDIO,
+                'Event Start Timestamp': '2024-01-15T22:00:00-05:00',
+            }
+            const result = provider.transform([record])
+            expect(result[0].ts).toBe('2024-01-15T22:00:00-05:00')
+        })
+
         it('should handle null Event Start Timestamp gracefully', () => {
             const record: AppleMusicRawRecord = {
                 ...RAW_AUDIO,
@@ -227,6 +239,35 @@ describe('AppleMusicStreamProvider', () => {
             )
             expect(mockDb.dropFile).toHaveBeenCalledWith('_apple_music_tmp.csv')
             expect(result).toHaveLength(1)
+        })
+
+        it('should read all columns as varchar to prevent DuckDB auto-detecting Event Start Timestamp as TIMESTAMPTZ', async () => {
+            const mockRow = {
+                toJSON: () => ({ ...RAW_AUDIO }),
+            }
+            mockConn.query.mockResolvedValue({
+                toArray: () => [mockRow],
+            })
+
+            const getDB = await import('../../db/getDB')
+            vi.spyOn(getDB, 'getDB').mockResolvedValue({
+                db: mockDb as never,
+                conn: mockConn as never,
+            })
+
+            const file = mockFile(
+                new ArrayBuffer(8),
+                'Apple Music Play Activity.csv',
+                {
+                    type: CSV_TYPE,
+                }
+            )
+
+            await provider.readFile(file)
+
+            expect(mockConn.query).toHaveBeenCalledWith(
+                expect.stringContaining('all_varchar=true')
+            )
         })
 
         it('should drop temp file even if query fails', async () => {

--- a/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.test.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.test.ts
@@ -18,13 +18,18 @@ function mockFile(
 
 const CSV_TYPE = 'text/csv'
 
+// readFile() reads the CSV with all_varchar=true (see the 'should read all
+// columns as varchar' test below), so every column — including timestamps and
+// durations — comes back as a string or null in production. These fixtures
+// mirror that shape; the Date/number-typed inputs exercised further down
+// document transform()'s defensive fallback for callers that bypass readFile.
 const RAW_AUDIO: AppleMusicRawRecord = {
     'Song Name': 'Never Gonna Give You Up',
     'Album Name': null,
     'Container Artist Name': null,
     'Media Type': 'AUDIO',
-    'Event Start Timestamp': new Date('2024-03-15T14:30:00.000Z'),
-    'Play Duration Milliseconds': 213000,
+    'Event Start Timestamp': '2024-03-15T14:30:00.000Z',
+    'Play Duration Milliseconds': '213000',
     'Device Type': 'IPHONE',
     'Container Origin Type': null,
 }
@@ -34,8 +39,8 @@ const RAW_VIDEO: AppleMusicRawRecord = {
     'Album Name': null,
     'Container Artist Name': null,
     'Media Type': 'VIDEO',
-    'Event Start Timestamp': new Date('2024-03-15T15:00:00.000Z'),
-    'Play Duration Milliseconds': 120000,
+    'Event Start Timestamp': '2024-03-15T15:00:00.000Z',
+    'Play Duration Milliseconds': '120000',
     'Device Type': 'IPHONE',
     'Container Origin Type': null,
 }
@@ -120,7 +125,7 @@ describe('AppleMusicStreamProvider', () => {
         it('should guard against negative Play Duration Milliseconds', () => {
             const record: AppleMusicRawRecord = {
                 ...RAW_AUDIO,
-                'Play Duration Milliseconds': -140027,
+                'Play Duration Milliseconds': '-140027',
             }
             const result = provider.transform([record])
             expect(result[0].ms_played).toBe(0)
@@ -154,6 +159,18 @@ describe('AppleMusicStreamProvider', () => {
             }
             const result = provider.transform([record])
             expect(result[0].ts).toBe('2024-01-15T22:00:00-05:00')
+        })
+
+        it('should handle a Date-typed Event Start Timestamp (defensive fallback)', () => {
+            // readFile() always returns strings (all_varchar=true), so this
+            // branch isn't exercised by the real CSV import path — it's a
+            // defensive fallback for any other caller of transform().
+            const record: AppleMusicRawRecord = {
+                ...RAW_AUDIO,
+                'Event Start Timestamp': new Date('2024-03-15T14:30:00.000Z'),
+            }
+            const result = provider.transform([record])
+            expect(result[0].ts).toBe('2024-03-15T14:30:00.000Z')
         })
 
         it('should handle null Event Start Timestamp gracefully', () => {

--- a/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/AppleMusicStreamProvider.ts
@@ -20,7 +20,7 @@ export class AppleMusicStreamProvider extends StreamProvider<AppleMusicRawRecord
         await db.registerFileBuffer(TMP_FILE_NAME, new Uint8Array(buffer))
         try {
             const result = await conn.query(
-                `SELECT * FROM read_csv('${TMP_FILE_NAME}', header=true)`
+                `SELECT * FROM read_csv('${TMP_FILE_NAME}', header=true, all_varchar=true)`
             )
             return result
                 .toArray()

--- a/app/src/streamProvider/AppleMusicStreamProvider/types.ts
+++ b/app/src/streamProvider/AppleMusicStreamProvider/types.ts
@@ -3,7 +3,10 @@ export interface AppleMusicRawRecord {
     'Album Name': unknown
     'Container Artist Name': unknown // always null
     'Media Type': unknown // "AUDIO" | "VIDEO" | ...
-    'Event Start Timestamp': unknown // TIMESTAMP WITH TIME ZONE — Arrow returns Date or BigInt
+    'Event Start Timestamp': unknown // TIMESTAMP WITH TIME ZONE — read as raw varchar (all_varchar=true)
+    // to preserve the original UTC offset, e.g. "2024-01-15T22:00:00-05:00".
+    // Without all_varchar, DuckDB auto-detects TIMESTAMPTZ and Arrow returns a
+    // Date/BigInt whose offset is already lost.
     'Play Duration Milliseconds': unknown // can be negative
     'Device Type': unknown
     'Container Origin Type': unknown


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Apple Music exports `Event Start Timestamp` as `TIMESTAMP WITH TIME ZONE`, encoding the exact local time of each listening event (e.g. `2024-01-15T22:00:00-05:00` for a user in New York). `AppleMusicStreamProvider` read this column without forcing varchar, so DuckDB auto-detected it as `TIMESTAMPTZ` and Arrow returned a JS `Date`, whose original UTC offset is already unrecoverable by the time `.toISOString()` runs — everything gets normalized to UTC. Combined with the `music_streams` view casting `ts` to the offset-less `TIMESTAMP` type, events recorded abroad ended up displayed at their home-timezone equivalent instead of the actual local listening time, skewing "most frequent listening hours" analysis for users who travel.

Closes #517

## 🎹 Proposal

- `AppleMusicStreamProvider.readFile()` now reads the CSV with `all_varchar=true`, so the raw offset-bearing timestamp string (e.g. `"2024-01-15T22:00:00-05:00"`) is preserved verbatim into `music_streams_raw` instead of being coerced into a UTC-normalized `Date`.
- The `music_streams` view now casts `ts` to `TIMESTAMPTZ` (instead of `TIMESTAMP`) before applying `AT TIME ZONE '<home_tz>'`, extracted into a `tsConversionExpr()` helper. `TIMESTAMPTZ` correctly resolves any offset present in the string (or the implicit `+00:00` of a `Z`-suffixed string) to an absolute instant before converting into the home timezone, whereas `TIMESTAMP` silently drops the offset and treats the wall-clock value as if it were already in the source zone.
- Unlike the old expression, `TIMESTAMPTZ` resolves a `ts` string with no zone marker at all against the DuckDB connection's *ambient session time zone* rather than always assuming UTC. No built-in provider emits such zone-less strings, but a hand-edited Custom CSV could, so `precomputeDerivedTables` now runs `SET TimeZone='UTC'` before the cast to keep that edge case deterministic regardless of the engine's default session zone.
- Verified with real DuckDB (both the CLI and the engine core bundled in `@duckdb/duckdb-wasm`) that this stays fully backward-compatible with the `Z`-suffixed UTC strings emitted by every other provider (Spotify, Deezer, JellyFin, Custom): the old and new SQL produce identical converted timestamps for those strings.

## 🎶 Comments

Date-based year/month/day statistics are unaffected (or improved) by this change; only hour-of-day analysis for travelers was wrong before this fix.

`@duckdb/node-api` (used by the new integration tests below) pins an older DuckDB build than the one bundled in `@duckdb/duckdb-wasm` (the engine this app actually runs), and that older build already resolves an offset-bearing string correctly even when cast straight to `TIMESTAMP`. So those specific tests can't reproduce the pre-fix bug on their own — this was cross-checked against the DuckDB CLI (whose version matches the wasm build's bundled core) to confirm the fix is real for the engine that matters. This is called out in a comment above the relevant test block.

## 🎤 Test

- `AppleMusicStreamProvider.test.ts`: asserts `readFile()` requests `all_varchar=true`, that `transform()` preserves a non-UTC offset string (`-05:00`) unchanged, and updates fixtures to match the all-varchar CSV shape (string/null columns) with a dedicated test for the Date-typed fallback branch.
- `precompute.test.ts`: integration tests spin up a real DuckDB connection (`@duckdb/node-api`) and exercise the exact SQL conversion expression to prove (1) a non-UTC offset resolves to the correct local hour when the home timezone matches, (2) it converts correctly into a different home timezone, (3) `Z`-suffixed UTC timestamps from other providers still convert identically to the previous behavior, and (4) the `SET TimeZone='UTC'` pin makes a zone-less string's interpretation independent of the ambient session timezone.
- `moon run app:test`, `app:lint`, `app:lint-sql`, `app:typecheck`, `app:format-check` all pass.