### PR TITLE
fix(charts): align album identity in Top 10 Billboard Race

### DIFF
--- a/app/src/components/Charts/LabCharts/Top10BillboardRace/Top10BillboardRaceAlbums.sql
+++ b/app/src/components/Charts/LabCharts/Top10BillboardRace/Top10BillboardRaceAlbums.sql
@@ -1,9 +1,9 @@
 select
-    album_name as entity_name,
     count(*)::int as period_plays,
+    album_name || ' — ' || artist_name as entity_name,
     epoch(date_trunc('week', ts::datetime)::date) * 1000 as period_ts
 from ${table}
-where album_name is not null
+where album_name is not null and artist_name is not null
 ${yearFilter}
 group by period_ts, entity_name
 order by period_ts asc

--- a/app/src/components/Charts/LabCharts/Top10BillboardRace/albumRankingParity.test.ts
+++ b/app/src/components/Charts/LabCharts/Top10BillboardRace/albumRankingParity.test.ts
@@ -1,0 +1,101 @@
+import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
+import type { DuckDBValue } from '@duckdb/node-api'
+import { queryTop10BillboardRace } from './query'
+import { queryTopAlbums } from '../../SimpleCharts/TopAlbums/query'
+import {
+    createTestConnection,
+    closeTestConnection,
+    createTestTable,
+    testQuery,
+    type TestStreamEntry,
+} from '../../SimpleCharts/__tests__/test-utils'
+import type { DuckDBConnection } from '@duckdb/node-api'
+
+// Regression test for #592: "Top Albums" (simple view) and "Top 10
+// Billboard Race" (lab view, albums mode) must agree on album identity and
+// ranking. Album identity is (album_name, artist_name) — two albums that
+// share a name but belong to different artists are distinct entities in
+// both charts.
+
+let conn: DuckDBConnection
+
+const testYear = 2025
+const testDate = `${testYear}-01-01`
+
+const createStream = (overrides: Partial<TestStreamEntry> = {}) => ({
+    ts: testDate,
+    track_name: 'track1',
+    artist_name: 'artist1',
+    album_name: 'album1',
+    ms_played: 1,
+    ...overrides,
+})
+
+const testData: TestStreamEntry[] = [
+    ...Array.from({ length: 12 }, () => createStream({ album_name: 'album1' })),
+    ...Array.from({ length: 10 }, () => createStream({ album_name: 'album2' })),
+    ...Array.from({ length: 8 }, () =>
+        createStream({ album_name: 'album3', artist_name: 'artist3' })
+    ),
+    ...Array.from({ length: 6 }, () => createStream({ album_name: 'album4' })),
+    // Same album name as above, but a different artist: must stay a
+    // distinct entity in both charts instead of being merged.
+    ...Array.from({ length: 5 }, () => createStream({ album_name: 'album5' })),
+    ...Array.from({ length: 4 }, () =>
+        createStream({ album_name: 'album5', artist_name: 'artist5' })
+    ),
+]
+
+describe('Top Albums vs Top 10 Billboard Race (albums) ranking parity', () => {
+    beforeAll(async () => {
+        conn = await createTestConnection()
+    })
+
+    afterAll(() => {
+        closeTestConnection(conn)
+    })
+
+    beforeEach(async () => {
+        await createTestTable(conn, testData)
+    })
+
+    it('produce the same top-5 album ranking across the period', async () => {
+        const simpleViewRows = await testQuery<{
+            album_name: string
+            artist_name: string
+            count_streams: number
+        }>(conn, queryTopAlbums(testYear))
+
+        const simpleViewRanking = simpleViewRows.map(
+            (row) => `${row.album_name} — ${row.artist_name}`
+        )
+
+        const raceRows = await conn.runAndReadAll(
+            queryTop10BillboardRace(testYear, 'albums')
+        )
+
+        const totals = new Map<string, number>()
+        for (const row of raceRows.getRowObjects() as Record<
+            string,
+            DuckDBValue
+        >[]) {
+            const entityName = row.entity_name as string
+            const periodPlays = row.period_plays as number
+            totals.set(entityName, (totals.get(entityName) ?? 0) + periodPlays)
+        }
+
+        const raceRanking = Array.from(totals.entries())
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 5)
+            .map(([entityName]) => entityName)
+
+        expect(raceRanking).toEqual(simpleViewRanking)
+        // Sanity check: the duplicate album name across artists must not
+        // have collapsed into a single race entity.
+        expect(raceRanking).toContain('album5 — artist1')
+        expect(totals.has('album5 — artist5')).toBe(true)
+        expect(totals.get('album5 — artist1')).not.toBe(
+            totals.get('album5 — artist5')
+        )
+    })
+})

--- a/app/src/components/Charts/LabCharts/Top10BillboardRace/query.test.ts
+++ b/app/src/components/Charts/LabCharts/Top10BillboardRace/query.test.ts
@@ -137,10 +137,35 @@ describe('Top10BillboardRace Query', () => {
         const week1Ts = 1577664000000
         const week2Ts = 1609113600000
 
+        // Album A is shared by Artist A and Artist B in the fixture: they
+        // must remain distinct entities (name+artist identity), matching
+        // the "Top Albums" simple view grouping. See issue #592.
         expect(rows).toEqual([
-            { period_ts: week1Ts, entity_name: 'Album A', period_plays: 5 },
-            { period_ts: week1Ts, entity_name: 'Album B', period_plays: 1 },
-            { period_ts: week2Ts, entity_name: 'Album A', period_plays: 3 },
+            {
+                period_ts: week1Ts,
+                entity_name: 'Album A — Artist A',
+                period_plays: 3,
+            },
+            {
+                period_ts: week1Ts,
+                entity_name: 'Album A — Artist B',
+                period_plays: 2,
+            },
+            {
+                period_ts: week1Ts,
+                entity_name: 'Album B — Artist C',
+                period_plays: 1,
+            },
+            {
+                period_ts: week2Ts,
+                entity_name: 'Album A — Artist A',
+                period_plays: 1,
+            },
+            {
+                period_ts: week2Ts,
+                entity_name: 'Album A — Artist B',
+                period_plays: 2,
+            },
         ])
     })
 })


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Follow-up to #588. The "Top 10 Billboard Race" chart (albums mode) also merges plays from two different artists that happen to share an album name into a single entity, disagreeing with the "Top Albums" simple view (and with its own sibling, the tracks race, which already groups correctly).

Closes #592

## 🎹 Proposal

Same bug class as #588, same fix shape: `Top10BillboardRaceAlbums.sql` now groups weekly plays by `album_name` and `artist_name` together and builds its display key as `album — artist`, matching the pairing already used by `Top10BillboardRaceTracks.sql` (`track — artist`) and the Top10Race album fix from #588. Rows with a null `artist_name` are filtered out, consistent with the simple view.

## 🎶 Comments

Stacked on #590 — merge after that one. This PR only contains the billboard-race-albums fix; the base branch `fix/588-top-albums-race-mismatch` carries the #588 fix this one builds on.

## 🎤 Test

Updated the existing weekly album query test expectations (previously encoding the buggy merged-by-name behavior) and added a regression test (`albumRankingParity.test.ts`) seeding a dataset with two albums sharing a name across different artists, asserting the billboard race and simple view agree on the top-5 ranking.

`moon run app:test`, `app:lint`, `app:lint-sql`, `app:typecheck`, and `app:format-check` all pass.
