### PR TITLE
fix(db): drop music_streams table before the view on re-ingestion

### DIFF
--- a/app/src/db/precompute.test.ts
+++ b/app/src/db/precompute.test.ts
@@ -23,9 +23,33 @@ describe('precomputeDerivedTables', () => {
             conn.query as ReturnType<typeof vi.fn>
         ).mock.calls.map((c: string[]) => c[0].trim())
 
-        expect(calls[0]).toBe('DROP VIEW IF EXISTS music_streams')
-        expect(calls[1]).toBe('DROP TABLE IF EXISTS music_streams')
+        expect(calls[0]).toBe('DROP TABLE IF EXISTS music_streams')
+        expect(calls[1]).toBe('DROP VIEW IF EXISTS music_streams')
         expect(calls[2]).toMatch(/^CREATE TABLE music_streams AS/)
+    })
+
+    // Regression test for https://github.com/Gudsfile/tracksy/issues/577:
+    // music_streams is a materialized TABLE after the first import, and
+    // DuckDB's `IF EXISTS` only suppresses "not found" errors — running
+    // `DROP VIEW IF EXISTS music_streams` against an existing table raises a
+    // Catalog Error instead of no-op'ing, which broke every import after the
+    // first. The table drop must run first so nothing is left for the view
+    // drop to collide with.
+    it('drops the table before attempting the view drop, so a second import does not hit a type-mismatch Catalog Error', async () => {
+        const conn = mockConn()
+        await precomputeDerivedTables(conn)
+        await precomputeDerivedTables(conn)
+
+        const calls: string[] = (
+            conn.query as ReturnType<typeof vi.fn>
+        ).mock.calls.map((c: string[]) => c[0].trim())
+
+        const dropTableIndex = calls.indexOf(
+            'DROP TABLE IF EXISTS music_streams'
+        )
+        const dropViewIndex = calls.indexOf('DROP VIEW IF EXISTS music_streams')
+        expect(dropTableIndex).toBeGreaterThanOrEqual(0)
+        expect(dropViewIndex).toBeGreaterThan(dropTableIndex)
     })
 
     it('drops all derived tables before creating them', async () => {

--- a/app/src/db/precompute.ts
+++ b/app/src/db/precompute.ts
@@ -28,8 +28,14 @@ export async function precomputeDerivedTables(
     tz: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
     onProgress?: OnProgress
 ): Promise<void> {
-    await conn.query(`DROP VIEW IF EXISTS ${TABLE}`)
+    // Table first: after the first import ${TABLE} is a materialized table, and
+    // DuckDB's IF EXISTS only suppresses "not found" errors, not type mismatches
+    // — `DROP VIEW IF EXISTS` on an existing table raises a Catalog Error rather
+    // than being a no-op. Dropping the table first leaves nothing behind for the
+    // view drop to trip over; the view drop stays to clean up the plain view
+    // that ${TABLE} used to be before it was materialized as a table.
     await conn.query(`DROP TABLE IF EXISTS ${TABLE}`)
+    await conn.query(`DROP VIEW IF EXISTS ${TABLE}`)
     await conn.query(
         `CREATE TABLE ${TABLE} AS SELECT * EXCLUDE (ts), (ts::TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE '${tz}') AS ts FROM ${RAW_TABLE}`
     )

--- a/e2e/tests/second-ingestion.spec.ts
+++ b/e2e/tests/second-ingestion.spec.ts
@@ -6,6 +6,9 @@ import * as path from 'path'
 // ("Existing object music_streams is of type Table, trying to drop type View")
 // because precompute.ts tried to DROP VIEW an object that was already a TABLE.
 test('can ingest a second dataset after a first successful import', async ({ page }) => {
+    // General hygiene, not the regression detector: the original bug is a
+    // caught DuckDB error rendered through the `role="alert"` banner (see
+    // TracksyWrapper.tsx), so it never surfaces here as an uncaught pageerror.
     const pageErrors: Error[] = []
     page.on('pageerror', (error) => pageErrors.push(error))
 
@@ -25,6 +28,8 @@ test('can ingest a second dataset after a first successful import', async ({ pag
         )
 
         await expect(simpleViewTab).toBeVisible()
+        // This is the assertion that actually catches the regression: the
+        // DuckDB Catalog Error from #577 surfaces as an `UploadError` alert.
         await expect(page.getByRole('alert')).toHaveCount(0)
         await expect(page.getByRole('heading', { name: /Top Tracks/ })).toBeVisible()
     })

--- a/e2e/tests/second-ingestion.spec.ts
+++ b/e2e/tests/second-ingestion.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test'
+import * as path from 'path'
+
+// Regression test for https://github.com/Gudsfile/tracksy/issues/577: importing
+// a second dataset in the same session used to throw a DuckDB Catalog Error
+// ("Existing object music_streams is of type Table, trying to drop type View")
+// because precompute.ts tried to DROP VIEW an object that was already a TABLE.
+test('can ingest a second dataset after a first successful import', async ({ page }) => {
+    const pageErrors: Error[] = []
+    page.on('pageerror', (error) => pageErrors.push(error))
+
+    await page.goto(process.env.TEST_PATH || '/tracksy')
+
+    const fileInput = page.locator('input[type="file"]')
+    const simpleViewTab = page.getByRole('tab', { name: /✨ Simple/ })
+
+    await test.step('first import succeeds', async () => {
+        await fileInput.setInputFiles(path.join(__dirname, '../datasets/spotify/streamings_1000.zip'))
+        await expect(simpleViewTab).toBeVisible()
+    })
+
+    await test.step('second import succeeds without an upload error', async () => {
+        await fileInput.setInputFiles(
+            path.join(__dirname, '../datasets/spotify/Streaming_History_Audio_2006_1000.json')
+        )
+
+        await expect(simpleViewTab).toBeVisible()
+        await expect(page.getByRole('alert')).toHaveCount(0)
+        await expect(page.getByRole('heading', { name: /Top Tracks/ })).toBeVisible()
+    })
+
+    expect(pageErrors).toEqual([])
+})


### PR DESCRIPTION
## 1️⃣ First
- [x] I have read the [CONTRIBUTION.md](https://github.com/Gudsfile/tracksy/blob/main/CONTRIBUTING.md).
- [ ] **OPTIONAL** I agree to be added as a contributor in the README.md by the all-contributors bot.

## 🔇 Problem

Importing a second dataset in the same session always failed, showing "Upload failed. Check the file and try again." with no way to recover short of reloading the page.

Root cause: `precomputeDerivedTables` (app/src/db/precompute.ts) ran `DROP VIEW IF EXISTS music_streams` before `DROP TABLE IF EXISTS music_streams`. A prior change (materializing `music_streams` as a table instead of a view for performance) made `music_streams` a real `TABLE` after the first import. DuckDB's `IF EXISTS` only suppresses "object not found" errors — it does not suppress a type mismatch. So on the second import, `DROP VIEW IF EXISTS music_streams` hit an existing `TABLE` and DuckDB raised:

```
Catalog Error: Existing object music_streams is of type Table, trying to drop type View
```

That exception propagated out of `insertFilesInDatabase`/`insertUrlInDatabase`, so every ingestion after the first one failed.

## 🎹 Proposal

Swap the order: drop the table first, then the (now nonexistent) view. This handles the normal case (table exists → gets dropped → the view drop becomes a harmless no-op) while still cleaning up a plain view if one somehow exists.

## 🎶 Comments

The first import was always fine because `music_streams` didn't exist yet, so both drops were no-ops — the bug only surfaces starting with the second ingestion, which matches the issue title exactly.

## 🎤 Test

- Reproduced against the real DuckDB engine with a new Playwright e2e test (`e2e/tests/second-ingestion.spec.ts`) that uploads two datasets back-to-back; it failed with the Catalog Error above on `main` and passes with this fix, across chromium/firefox/webkit.
- Added a unit test in `app/src/db/precompute.test.ts` asserting the table drop happens before the view drop, to guard against reintroducing the wrong order.
- `moon run app:test`, `app:lint`, `app:lint-sql`, `app:typecheck`, `app:format-check` all pass.

Closes #577